### PR TITLE
Clean up schema_test.exs

### DIFF
--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -6,6 +6,22 @@ defmodule OpenApiSpex.SchemaTest do
 
   doctest Schema
 
+  describe "schema/1" do
+    test "EntityWithDict Schema example matches schema" do
+      api_spec = ApiSpec.spec()
+      assert_schema(Schemas.EntityWithDict.schema().example, "EntityWithDict", api_spec)
+    end
+
+    test "User Schema example matches schema" do
+      spec = ApiSpec.spec()
+
+      assert_schema(Schemas.User.schema().example, "User", spec)
+      assert_schema(Schemas.UserRequest.schema().example, "UserRequest", spec)
+      assert_schema(Schemas.UserResponse.schema().example, "UserResponse", spec)
+      assert_schema(Schemas.UsersResponse.schema().example, "UsersResponse", spec)
+    end
+  end
+
   describe "cast/3" do
     test "cast request schema" do
       api_spec = ApiSpec.spec()
@@ -49,20 +65,6 @@ defmodule OpenApiSpex.SchemaTest do
       }
 
       assert {:error, _} = Schema.cast(user_request_schema, input, schemas)
-    end
-
-    test "EntityWithDict Schema example matches schema" do
-      api_spec = ApiSpec.spec()
-      assert_schema(Schemas.EntityWithDict.schema().example, "EntityWithDict", api_spec)
-    end
-
-    test "User Schema example matches schema" do
-      spec = ApiSpec.spec()
-
-      assert_schema(Schemas.User.schema().example, "User", spec)
-      assert_schema(Schemas.UserRequest.schema().example, "UserRequest", spec)
-      assert_schema(Schemas.UserResponse.schema().example, "UserResponse", spec)
-      assert_schema(Schemas.UsersResponse.schema().example, "UsersResponse", spec)
     end
 
     test "Cast Cat from Pet schema" do

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -6,123 +6,127 @@ defmodule OpenApiSpex.SchemaTest do
 
   doctest Schema
 
-  test "cast request schema" do
-    api_spec = ApiSpec.spec()
-    schemas = api_spec.components.schemas
-    user_request_schema = schemas["UserRequest"]
+  describe "cast/3" do
+    test "cast request schema" do
+      api_spec = ApiSpec.spec()
+      schemas = api_spec.components.schemas
+      user_request_schema = schemas["UserRequest"]
 
-    input = %{
-      "user" => %{
-        "id" => 123,
-        "name" => "asdf",
-        "email" => "foo@bar.com",
-        "updated_at" => "2017-09-12T14:44:55Z"
+      input = %{
+        "user" => %{
+          "id" => 123,
+          "name" => "asdf",
+          "email" => "foo@bar.com",
+          "updated_at" => "2017-09-12T14:44:55Z"
+        }
       }
-    }
 
-    {:ok, output} = Schema.cast(user_request_schema, input, schemas)
+      {:ok, output} = Schema.cast(user_request_schema, input, schemas)
 
-    assert output == %OpenApiSpexTest.Schemas.UserRequest{
-      user: %OpenApiSpexTest.Schemas.User{
-        id: 123,
-        name: "asdf",
-        email: "foo@bar.com",
-        updated_at: DateTime.from_naive!(~N[2017-09-12T14:44:55], "Etc/UTC")
+      assert output == %OpenApiSpexTest.Schemas.UserRequest{
+               user: %OpenApiSpexTest.Schemas.User{
+                 id: 123,
+                 name: "asdf",
+                 email: "foo@bar.com",
+                 updated_at: DateTime.from_naive!(~N[2017-09-12T14:44:55], "Etc/UTC")
+               }
+             }
+    end
+
+    test "cast request schema with unexpected fields returns error" do
+      api_spec = ApiSpec.spec()
+      schemas = api_spec.components.schemas
+      user_request_schema = schemas["UserRequest"]
+
+      input = %{
+        "user" => %{
+          "id" => 123,
+          "name" => "asdf",
+          "email" => "foo@bar.com",
+          "updated_at" => "2017-09-12T14:44:55Z",
+          "unexpected_field" => "unexpected value"
+        }
       }
-    }
-  end
 
-  test "cast request schema with unexpected fields returns error" do
-    api_spec = ApiSpec.spec()
-    schemas = api_spec.components.schemas
-    user_request_schema = schemas["UserRequest"]
+      assert {:error, _} = Schema.cast(user_request_schema, input, schemas)
+    end
 
-    input = %{
-      "user" => %{
-        "id" => 123,
-        "name" => "asdf",
-        "email" => "foo@bar.com",
-        "updated_at" => "2017-09-12T14:44:55Z",
-        "unexpected_field" => "unexpected value"
+    test "EntityWithDict Schema example matches schema" do
+      api_spec = ApiSpec.spec()
+      assert_schema(Schemas.EntityWithDict.schema().example, "EntityWithDict", api_spec)
+    end
+
+    test "User Schema example matches schema" do
+      spec = ApiSpec.spec()
+
+      assert_schema(Schemas.User.schema().example, "User", spec)
+      assert_schema(Schemas.UserRequest.schema().example, "UserRequest", spec)
+      assert_schema(Schemas.UserResponse.schema().example, "UserResponse", spec)
+      assert_schema(Schemas.UsersResponse.schema().example, "UsersResponse", spec)
+    end
+
+    test "Cast Cat from Pet schema" do
+      api_spec = ApiSpec.spec()
+      schemas = api_spec.components.schemas
+      pet_schema = schemas["Pet"]
+
+      input = %{
+        "pet_type" => "Cat",
+        "meow" => "meow"
       }
-    }
 
-    assert {:error, _} = Schema.cast(user_request_schema, input, schemas)
-  end
+      assert {:ok, %Schemas.Cat{meow: "meow", pet_type: "Cat"}} =
+               Schema.cast(pet_schema, input, schemas)
+    end
 
-  test "EntityWithDict Schema example matches schema" do
-    api_spec = ApiSpec.spec()
-    assert_schema(Schemas.EntityWithDict.schema().example, "EntityWithDict", api_spec)
-  end
+    test "Cast Dog from oneOf [cat, dog] schema" do
+      api_spec = ApiSpec.spec()
+      schemas = api_spec.components.schemas
+      cat_or_dog = Map.fetch!(schemas, "CatOrDog")
 
-  test "User Schema example matches schema" do
-    spec = ApiSpec.spec()
+      input = %{
+        "pet_type" => "Cat",
+        "meow" => "meow"
+      }
 
-    assert_schema(Schemas.User.schema().example, "User", spec)
-    assert_schema(Schemas.UserRequest.schema().example, "UserRequest", spec)
-    assert_schema(Schemas.UserResponse.schema().example, "UserResponse", spec)
-    assert_schema(Schemas.UsersResponse.schema().example, "UsersResponse", spec)
-  end
+      assert {:ok, %Schemas.Cat{meow: "meow", pet_type: "Cat"}} =
+               Schema.cast(cat_or_dog, input, schemas)
+    end
 
-  test "Cast Cat from Pet schema" do
-    api_spec = ApiSpec.spec()
-    schemas = api_spec.components.schemas
-    pet_schema = schemas["Pet"]
+    test "Cast number to string or number" do
+      schema = %Schema{
+        oneOf: [
+          %Schema{type: :number},
+          %Schema{type: :string}
+        ]
+      }
 
-    input = %{
-      "pet_type" => "Cat",
-      "meow" => "meow"
-    }
+      result = Schema.cast(schema, "123", %{})
 
-    assert {:ok, %Schemas.Cat{meow: "meow", pet_type: "Cat"}} = Schema.cast(pet_schema, input, schemas)
-  end
+      assert {:ok, 123.0} = result
+    end
 
-  test "Cast Dog from oneOf [cat, dog] schema" do
-    api_spec = ApiSpec.spec()
-    schemas = api_spec.components.schemas
-    cat_or_dog = Map.fetch!(schemas, "CatOrDog")
+    test "Cast string to oneOf number or datetime" do
+      schema = %Schema{
+        oneOf: [
+          %Schema{type: :number},
+          %Schema{type: :string, format: :"date-time"}
+        ]
+      }
 
-    input = %{
-      "pet_type" => "Cat",
-      "meow" => "meow"
-    }
+      assert {:ok, %DateTime{}} = Schema.cast(schema, "2018-04-01T12:34:56Z", %{})
+    end
 
-    assert {:ok, %Schemas.Cat{meow: "meow", pet_type: "Cat"}} = Schema.cast(cat_or_dog, input, schemas)
-  end
+    test "Cast string to anyOf number or datetime" do
+      schema = %Schema{
+        oneOf: [
+          %Schema{type: :number},
+          %Schema{type: :string, format: :"date-time"}
+        ]
+      }
 
-  test "Cast number to string or number" do
-    schema = %Schema{
-      oneOf: [
-        %Schema{type: :number},
-        %Schema{type: :string}
-      ]
-    }
-
-    result = Schema.cast(schema, "123", %{})
-
-    assert {:ok, 123.0} = result
-  end
-
-  test "Cast string to oneOf number or datetime" do
-    schema = %Schema{
-      oneOf: [
-        %Schema{type: :number},
-        %Schema{type: :string, format: :"date-time"}
-      ]
-    }
-
-    assert {:ok, %DateTime{}} = Schema.cast(schema, "2018-04-01T12:34:56Z", %{})
-  end
-
-  test "Cast string to anyOf number or datetime" do
-    schema = %Schema{
-      oneOf: [
-        %Schema{type: :number},
-        %Schema{type: :string, format: :"date-time"}
-      ]
-    }
-
-    assert {:ok, %DateTime{}} = Schema.cast(schema, "2018-04-01T12:34:56Z", %{})
+      assert {:ok, %DateTime{}} = Schema.cast(schema, "2018-04-01T12:34:56Z", %{})
+    end
   end
 
   describe "Integer validation" do
@@ -150,6 +154,7 @@ defmodule OpenApiSpex.SchemaTest do
       schema = %Schema{
         type: :string
       }
+
       assert {:error, _} = Schema.validate(schema, %{}, %{})
     end
 
@@ -157,6 +162,7 @@ defmodule OpenApiSpex.SchemaTest do
       schema = %Schema{
         type: :string
       }
+
       assert {:error, _} = Schema.validate(schema, DateTime.utc_now(), %{})
     end
 


### PR DESCRIPTION
Clean up test before adding more tests for `cast/3`:
- Wrap `schema/1` tests in a dedicated `"describe"` block.
- Wrap `cast/3` tests in a dedicated `"describe"` block.