### PR TITLE
Resolve raised exception; return error tuple instead

### DIFF
--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -319,6 +319,9 @@ defmodule OpenApiSpex.Schema do
   def cast(%Schema{type: :array}, value, _schemas) when not is_list(value) do
     {:error, "Invalid array: #{inspect(value)}"}
   end
+  def cast(%Schema{type: :object}, value, _schemas) when not is_map(value) do
+    {:error, "Invalid object: #{inspect(value)}"}
+  end
   def cast(schema = %Schema{type: :object, discriminator: discriminator = %{}}, value = %{}, schemas) do
     discriminator_property = String.to_existing_atom(discriminator.propertyName)
     already_cast? =

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -59,7 +59,19 @@ defmodule OpenApiSpex.SchemaTest do
       {:error, _output} = Schema.cast(user_request_schema, input, schemas)
     end
 
-    test "cast/3 with unexpected type for array" do
+    test "cast/3 with unexpected type for nested object" do
+      api_spec = ApiSpec.spec()
+      schemas = api_spec.components.schemas
+      user_request_schema = schemas["UserRequest"]
+
+      input = %{
+        "user" => []
+      }
+
+      {:error, _output} = Schema.cast(user_request_schema, input, schemas)
+    end
+
+    test "cast/3 with unexpected type for nested array" do
       api_spec = ApiSpec.spec()
       schemas = api_spec.components.schemas
       user_response_schema = schemas["UsersResponse"]

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -49,6 +49,28 @@ defmodule OpenApiSpex.SchemaTest do
              }
     end
 
+    test "cast/3 with unexpected type for object" do
+      api_spec = ApiSpec.spec()
+      schemas = api_spec.components.schemas
+      user_request_schema = schemas["UserRequest"]
+
+      input = []
+
+      {:error, _output} = Schema.cast(user_request_schema, input, schemas)
+    end
+
+    test "cast/3 with unexpected type for array" do
+      api_spec = ApiSpec.spec()
+      schemas = api_spec.components.schemas
+      user_response_schema = schemas["UsersResponse"]
+
+      input = %{
+        "data" => %{}
+      }
+
+      {:error, _output} = Schema.cast(user_response_schema, input, schemas)
+    end
+
     test "cast request schema with unexpected fields returns error" do
       api_spec = ApiSpec.spec()
       schemas = api_spec.components.schemas


### PR DESCRIPTION
Fixes raised exception, `** (MatchError) no match of right hand side value: {:ok, []}` in `cast/3`, when wrong type is encountered for an object type. Also adds testing around handling unexpected type for array.

Question: When `nil` is the given value for an object type, should `cast/3` return an error, or should it return an ok? If ok, should it cast the `nil` to a `%{}`? This PR changes the behavior for that case from returning ok to returning an error.