### PR TITLE
Revert breaking changes in Schema.cast/3

### DIFF
--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -319,9 +319,6 @@ defmodule OpenApiSpex.Schema do
   def cast(%Schema{type: :array}, value, _schemas) when not is_list(value) do
     {:error, "Invalid array: #{inspect(value)}"}
   end
-  def cast(%Schema{type: :object}, value, _schemas) when not is_map(value) do
-    {:error, "Invalid object: #{inspect(value)}"}
-  end
   def cast(schema = %Schema{type: :object, discriminator: discriminator = %{}}, value = %{}, schemas) do
     discriminator_property = String.to_existing_atom(discriminator.propertyName)
     already_cast? =

--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -273,8 +273,6 @@ defmodule OpenApiSpex.Schema do
 
     - Cast the value using each schema listed in `anyOf`, stopping as soon as a succesful cast is made.
   """
-  @spec cast(Schema.t | Reference.t, term, %{String.t => Schema.t | Reference.t}) :: {:ok, term} | {:error, String.t}
-  def cast(%Schema{nullable: true}, nil, _schemas), do: {:ok, nil}
   def cast(%Schema{type: :boolean}, value, _schemas) when is_boolean(value), do: {:ok, value}
   def cast(%Schema{type: :boolean}, value, _schemas) when is_binary(value) do
     case value do
@@ -283,31 +281,19 @@ defmodule OpenApiSpex.Schema do
       _ -> {:error, "Invalid boolean: #{inspect(value)}"}
     end
   end
-  def cast(%Schema{type: :boolean}, value, _schemas) do
-    {:error, "Invalid boolean: #{inspect(value)}"}
-  end
   def cast(%Schema{type: :integer}, value, _schemas) when is_integer(value), do: {:ok, value}
   def cast(%Schema{type: :integer}, value, _schemas) when is_binary(value) do
     case Integer.parse(value) do
       {i, ""} -> {:ok, i}
-      _ -> {:error, "Invalid integer: #{inspect(value)}"}
+      _ -> {:error, :bad_integer}
     end
-  end
-  def cast(%Schema{type: :integer}, value, _schemas) do
-    {:error, "Invalid integer: #{inspect(value)}"}
-  end
-  def cast(%Schema{type: :number, format: fmt}, value, _schema) when is_integer(value) and fmt in [:float, :double] do
-    {:ok, value * 1.0}
   end
   def cast(%Schema{type: :number}, value, _schemas) when is_number(value), do: {:ok, value}
   def cast(%Schema{type: :number}, value, _schemas) when is_binary(value) do
     case Float.parse(value) do
       {x, ""} -> {:ok, x}
-      _ -> {:error, "Invalid number: #{inspect(value)}"}
+      _ -> {:error, :bad_float}
     end
-  end
-  def cast(%Schema{type: :number}, value, _schemas) do
-    {:error, "Invalid number: #{inspect(value)}"}
   end
   def cast(%Schema{type: :string, format: :"date-time"}, value, _schemas) when is_binary(value) do
     case DateTime.from_iso8601(value) do
@@ -322,9 +308,6 @@ defmodule OpenApiSpex.Schema do
     end
   end
   def cast(%Schema{type: :string}, value, _schemas) when is_binary(value), do: {:ok, value}
-  def cast(%Schema{type: :string}, value, _schemas) do
-    {:error, "Invalid string: #{inspect(value)}"}
-  end
   def cast(%Schema{type: :array, items: nil}, value, _schemas) when is_list(value), do: {:ok, value}
   def cast(%Schema{type: :array}, [], _schemas), do: {:ok, []}
   def cast(schema = %Schema{type: :array, items: items_schema}, [x | rest], schemas) do

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -22,127 +22,7 @@ defmodule OpenApiSpex.SchemaTest do
     end
   end
 
-  describe "Cast nil" do
-    test "to nullable type" do
-      assert {:ok, nil} = Schema.cast(%Schema{nullable: true}, nil, %{})
-      assert {:ok, nil} = Schema.cast(%Schema{type: :integer, nullable: true}, nil, %{})
-      assert {:ok, nil} = Schema.cast(%Schema{type: :string, nullable: true}, nil, %{})
-    end
-
-    test "to non-nullable type" do
-      assert {:error, _} = Schema.cast(%Schema {type: :string}, nil, %{})
-      assert {:error, _} = Schema.cast(%Schema {type: :integer}, nil, %{})
-      assert {:error, _} = Schema.cast(%Schema {type: :object}, nil, %{})
-    end
-  end
-
-  describe "Cast boolean" do
-    test "from boolean" do
-      assert {:ok, true} = Schema.cast(%Schema{type: :boolean}, true, %{})
-      assert {:ok, false} = Schema.cast(%Schema{type: :boolean}, false, %{})
-    end
-
-    test "from string" do
-      assert {:ok, true} = Schema.cast(%Schema{type: :boolean}, "true", %{})
-      assert {:ok, false} = Schema.cast(%Schema{type: :boolean}, "false", %{})
-    end
-
-    test "from invalid data type" do
-      assert {:error, _} = Schema.cast(%Schema{type: :boolean}, "not a bool", %{})
-      assert {:error, _} = Schema.cast(%Schema{type: :boolean}, 1, %{})
-      assert {:error, _} = Schema.cast(%Schema{type: :boolean}, nil, %{})
-      assert {:error, _} = Schema.cast(%Schema{type: :boolean}, [true], %{})
-    end
-  end
-
-  describe "Cast integer" do
-    test "from integer" do
-      assert {:ok, -1} = Schema.cast(%Schema{type: :integer}, -1, %{})
-      assert {:ok, 0} = Schema.cast(%Schema{type: :integer}, 0, %{})
-      assert {:ok, 1} = Schema.cast(%Schema{type: :integer}, 1, %{})
-      assert {:ok, 12345} = Schema.cast(%Schema{type: :integer}, 12345, %{})
-    end
-
-    test "from string" do
-      assert {:ok, -1} = Schema.cast(%Schema{type: :integer}, "-1", %{})
-      assert {:ok, 0} = Schema.cast(%Schema{type: :integer}, "0", %{})
-      assert {:ok, 1} = Schema.cast(%Schema{type: :integer}, "1", %{})
-      assert {:ok, 12345} = Schema.cast(%Schema{type: :integer}, "12345", %{})
-      assert {:error, _} = Schema.cast(%Schema{type: :integer}, "not an int", %{})
-      assert {:error, _} = Schema.cast(%Schema{type: :integer}, "3.14159", %{})
-      assert {:error, _} = Schema.cast(%Schema{type: :integer}, "", %{})
-    end
-
-    test "from invalid data type" do
-      assert {:error, _} = Schema.cast(%Schema{type: :integer}, true, %{})
-      assert {:error, _} = Schema.cast(%Schema{type: :integer}, 3.14159, %{})
-      assert {:error, _} = Schema.cast(%Schema{type: :integer}, nil, %{})
-      assert {:error, _} = Schema.cast(%Schema{type: :integer}, [1, 2], %{})
-    end
-  end
-
-  describe "Cast number" do
-    test "from number" do
-      assert {:ok, -1.0} = Schema.cast(%Schema{type: :number, format: :float}, -1, %{})
-      assert {:ok, -1.0} = Schema.cast(%Schema{type: :number, format: :double}, -1, %{})
-      assert {:ok, -1} = Schema.cast(%Schema{type: :number}, -1, %{})
-      assert {:ok, 0.0} = Schema.cast(%Schema{type: :number}, 0.0, %{})
-      assert {:ok, 1.0} = Schema.cast(%Schema{type: :number}, 1.0, %{})
-      assert {:ok, 123.45} = Schema.cast(%Schema{type: :number}, 123.45, %{})
-    end
-    test "from string" do
-      assert {:ok, -1.0} = Schema.cast(%Schema{type: :number}, "-1", %{})
-      assert {:ok, 0.0} = Schema.cast(%Schema{type: :number}, "0.0", %{})
-      assert {:ok, 1.0} = Schema.cast(%Schema{type: :number}, "1.0", %{})
-      assert {:ok, 123.45} = Schema.cast(%Schema{type: :number}, "123.45", %{})
-    end
-    test "from invalid data type" do
-      assert {:error, _} = Schema.cast(%Schema{type: :number}, nil, %{})
-      assert {:error, _} = Schema.cast(%Schema{type: :number}, false, %{})
-      assert {:error, _} = Schema.cast(%Schema{type: :number}, "", %{})
-      assert {:error, _} = Schema.cast(%Schema{type: :number}, "not a number", %{})
-      assert {:error, _} = Schema.cast(%Schema{type: :number}, [], %{})
-      assert {:error, _} = Schema.cast(%Schema{type: :number}, [1.0, 2.0], %{})
-    end
-  end
-
-  describe "cast string" do
-    test "from string" do
-      assert {:ok, ""} = Schema.cast(%Schema{type: :string}, "", %{})
-      assert {:ok, "  "} = Schema.cast(%Schema{type: :string}, "  ", %{})
-      assert {:ok, "hello"} = Schema.cast(%Schema{type: :string}, "hello", %{})
-    end
-    test "from invalid data type" do
-      assert {:error, _} = Schema.cast(%Schema{type: :string}, nil, %{})
-      assert {:error, _} = Schema.cast(%Schema{type: :string}, [], %{})
-      assert {:error, _} = Schema.cast(%Schema{type: :string}, :an_atom, %{})
-      assert {:error, _} = Schema.cast(%Schema{type: :string}, 0, %{})
-    end
-  end
-
-  describe "cast array" do
-    test "from list" do
-      assert {:ok, []} = Schema.cast(%Schema{type: :array}, [], %{})
-      assert {:ok, [1, 2, 3]} = Schema.cast(%Schema{type: :array}, [1,2,3], %{})
-      assert {:ok, [1, "a", true]} = Schema.cast(%Schema{type: :array}, [1, "a", true], %{})
-
-      int_array = %Schema{type: :array, items: %Schema{type: :integer}}
-      assert {:ok, [1, 2, 3]} = Schema.cast(int_array, [1, 2, 3], %{})
-      assert {:ok, [1, 2, 3]} = Schema.cast(int_array, ["1", "2", "3"], %{})
-    end
-    test "from invalid data type" do
-      assert {:error, _} = Schema.cast(%Schema{type: :array}, nil, %{})
-      assert {:error, _} = Schema.cast(%Schema{type: :array}, 0, %{})
-      assert {:error, _} = Schema.cast(%Schema{type: :array}, "", %{})
-      assert {:error, _} = Schema.cast(%Schema{type: :array}, "1,2,3", %{})
-    end
-    test "from list with invalid item type" do
-      string_array = %Schema{type: :array, items: %Schema{type: :string}}
-      assert {:error, _} = Schema.cast(string_array, [1, 2, 3], %{})
-    end
-  end
-
-  describe "Cast object" do
+  describe "cast/3" do
     test "cast request schema" do
       api_spec = ApiSpec.spec()
       schemas = api_spec.components.schemas
@@ -220,9 +100,7 @@ defmodule OpenApiSpex.SchemaTest do
 
       assert {:error, _} = Schema.cast(user_request_schema, input, schemas)
     end
-  end
 
-  describe "Polymorphic cast" do
     test "Cast Cat from Pet schema" do
       api_spec = ApiSpec.spec()
       schemas = api_spec.components.schemas
@@ -277,7 +155,7 @@ defmodule OpenApiSpex.SchemaTest do
 
     test "Cast string to anyOf number or datetime" do
       schema = %Schema{
-        anyOf: [
+        oneOf: [
           %Schema{type: :number},
           %Schema{type: :string, format: :"date-time"}
         ]

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -49,40 +49,6 @@ defmodule OpenApiSpex.SchemaTest do
              }
     end
 
-    test "cast/3 with unexpected type for object" do
-      api_spec = ApiSpec.spec()
-      schemas = api_spec.components.schemas
-      user_request_schema = schemas["UserRequest"]
-
-      input = []
-
-      {:error, _output} = Schema.cast(user_request_schema, input, schemas)
-    end
-
-    test "cast/3 with unexpected type for nested object" do
-      api_spec = ApiSpec.spec()
-      schemas = api_spec.components.schemas
-      user_request_schema = schemas["UserRequest"]
-
-      input = %{
-        "user" => []
-      }
-
-      {:error, _output} = Schema.cast(user_request_schema, input, schemas)
-    end
-
-    test "cast/3 with unexpected type for nested array" do
-      api_spec = ApiSpec.spec()
-      schemas = api_spec.components.schemas
-      user_response_schema = schemas["UsersResponse"]
-
-      input = %{
-        "data" => %{}
-      }
-
-      {:error, _output} = Schema.cast(user_response_schema, input, schemas)
-    end
-
     test "cast request schema with unexpected fields returns error" do
       api_spec = ApiSpec.spec()
       schemas = api_spec.components.schemas


### PR DESCRIPTION
Reverts recent changes in `Schema.cast/3` that introduce breaking changes.

@mbuhot: I assume you don't want to do another major release so soon after v3. Let's come up with a plan on how to introduce the changes we want without breaking backwards compatibility. Let's talk over the Elixir Slack workspace.