### PR TITLE
Remove String.trim/1 from cast binary validation

### DIFF
--- a/lib/open_api_spex/cast/string.ex
+++ b/lib/open_api_spex/cast/string.ex
@@ -39,12 +39,8 @@ defmodule OpenApiSpex.Cast.String do
   end
 
   defp cast_binary(%{value: value, schema: %{minLength: min_length}} = ctx)
-       when is_integer(min_length) do
-    # Note: This is not part of the JSON Shema spec: trim string before measuring length
-    # It's just too important to miss
-    length = String.trim(value) |> String.length()
-
-    if length < min_length do
+  when is_integer(min_length) do
+    if String.length(value) < min_length do
       Cast.error(ctx, {:min_length, min_length})
     else
       Cast.success(ctx, :minLength)
@@ -52,12 +48,8 @@ defmodule OpenApiSpex.Cast.String do
   end
 
   defp cast_binary(%{value: value, schema: %{maxLength: max_length}} = ctx)
-       when is_integer(max_length) do
-    # Note: This is not part of the JSON Shema spec: trim string before measuring length
-    # It's just too important to miss
-    length = String.trim(value) |> String.length()
-
-    if length > max_length do
+  when is_integer(max_length) do
+    if String.length(value) > max_length do
       Cast.error(ctx, {:max_length, max_length})
     else
       Cast.success(ctx, :maxLength)

--- a/test/cast/string_test.exs
+++ b/test/cast/string_test.exs
@@ -48,7 +48,7 @@ defmodule OpenApiSpex.CastStringTest do
     test "minLength" do
       schema = %Schema{type: :string, minLength: 1}
       assert {:ok, "a"} = cast(value: "a", schema: schema)
-      assert {:error, [error]} = cast(value: "   ", schema: schema)
+      assert {:error, [error]} = cast(value: "", schema: schema)
       assert %Error{} = error
       assert error.reason == :min_length
     end


### PR DESCRIPTION
The reasoning is noted here:
https://github.com/open-api-spex/open_api_spex/issues/78

As noted in the issue this is being removed to conform with the spec. 