### PR TITLE
Dynamically generate spec

### DIFF
--- a/lib/open_api_spex/plug/put_api_spec.ex
+++ b/lib/open_api_spex/plug/put_api_spec.ex
@@ -11,35 +11,24 @@ defmodule OpenApiSpex.Plug.PutApiSpec do
   @behaviour Plug
 
   @impl Plug
-  def init(opts = [module: _mod]), do: opts
+  def init(opts) do
+    module = Keyword.fetch!(opts, :module)
+
+    build_spec(module)
+  end
 
   @impl Plug
-  def call(conn, module: mod) do
-    {spec, operation_lookup} =
-      case Application.get_env(:open_api_spex, mod) do
-        nil -> build_spec(mod)
-        cached -> cached
-      end
-
-    private_data =
-      conn
-      |> Map.get(:private)
-      |> Map.get(:open_api_spex, %{})
-      |> Map.put(:spec, spec)
-      |> Map.put(:operation_lookup, operation_lookup)
-
+  def call(conn, private_data) do
     Plug.Conn.put_private(conn, :open_api_spex, private_data)
   end
 
-  @spec build_spec(module) :: {OpenApiSpex.OpenApi.t, %{String.t => OpenApiSpex.Operation.t}}
   defp build_spec(mod) do
     spec = mod.spec()
     operation_lookup = build_operation_lookup(spec)
-    Application.put_env(:open_api_spex, mod, {spec, operation_lookup})
-    {spec, operation_lookup}
+
+    %{spec: spec, operation_lookup: operation_lookup}
   end
 
-  @spec build_operation_lookup(OpenApiSpex.OpenApi.t) :: %{String.t => OpenApiSpex.Operation.t}
   defp build_operation_lookup(spec = %OpenApiSpex.OpenApi{}) do
     spec
     |> Map.get(:paths)


### PR DESCRIPTION
In Phoenix applications this should not have any impact on performance when used with [`:plug_init_mode` set to `:compile` (default)](https://hexdocs.pm/plug/1.7.1/Plug.Builder.html) while provide recompilation of schema in development. Additionally this will allow using hot-reloads.

Close #72