### PR TITLE
Fix number casting

### DIFF
--- a/lib/open_api_spex/cast/primitive.ex
+++ b/lib/open_api_spex/cast/primitive.ex
@@ -16,7 +16,7 @@ defmodule OpenApiSpex.Cast.Primitive do
   end
 
   ## number
-  def cast_number(%{value: value}) when is_number(value) do
+  def cast_number(%{value: value}) when is_float(value) do
     {:ok, value}
   end
 

--- a/test/cast/primitive_test.exs
+++ b/test/cast/primitive_test.exs
@@ -16,10 +16,10 @@ defmodule OpenApiSpex.PrimitiveTest do
     end
 
     test "number" do
-      assert cast_number(%Cast{value: 1}) == {:ok, 1.0}
-      assert cast_number(%Cast{value: 1.5}) == {:ok, 1.5}
-      assert cast_number(%Cast{value: "1"}) == {:ok, 1.0}
-      assert cast_number(%Cast{value: "1.5"}) == {:ok, 1.5}
+      assert cast_number(%Cast{value: 1}) === {:ok, 1.0}
+      assert cast_number(%Cast{value: 1.5}) === {:ok, 1.5}
+      assert cast_number(%Cast{value: "1"}) === {:ok, 1.0}
+      assert cast_number(%Cast{value: "1.5"}) === {:ok, 1.5}
       assert {:error, [error]} = cast_number(%Cast{value: "other"})
       assert %Error{reason: :invalid_type} = error
       assert error.value == "other"


### PR DESCRIPTION
The == comparison was converting the result and giving a false positive
on the tests.