### PR TITLE
Send Plug CSRF token as x-csrf-token header

### DIFF
--- a/lib/open_api_spex/plug/swagger_ui.ex
+++ b/lib/open_api_spex/plug/swagger_ui.ex
@@ -112,7 +112,11 @@ defmodule OpenApiSpex.Plug.SwaggerUI do
         plugins: [
           SwaggerUIBundle.plugins.DownloadUrl
         ],
-        layout: "StandaloneLayout"
+        layout: "StandaloneLayout",
+        requestInterceptor: function(request){
+          request.headers["x-csrf-token"] = "<%= Plug.CSRFProtection.get_csrf_token() %>";
+          return request;
+        }
       })
       window.ui = ui
     }

--- a/lib/open_api_spex/plug/swagger_ui.ex
+++ b/lib/open_api_spex/plug/swagger_ui.ex
@@ -114,7 +114,7 @@ defmodule OpenApiSpex.Plug.SwaggerUI do
         ],
         layout: "StandaloneLayout",
         requestInterceptor: function(request){
-          request.headers["x-csrf-token"] = "<%= Plug.CSRFProtection.get_csrf_token() %>";
+          request.headers["x-csrf-token"] = "<%= csrf_token %>";
           return request;
         }
       })
@@ -127,12 +127,18 @@ defmodule OpenApiSpex.Plug.SwaggerUI do
   """
 
   @impl Plug
-  def init(path: path), do: [html:  EEx.eval_string(@html, path: path)]
+  def init(path: path), do: %{path: path}
 
   @impl Plug
-  def call(conn, html: html) do
+  def call(conn, %{path: path}) do
+    csrf_token = Plug.CSRFProtection.get_csrf_token()
+    html = render(path, csrf_token)
+
     conn
     |> Plug.Conn.put_resp_content_type("text/html")
     |> Plug.Conn.send_resp(200, html)
   end
+
+  require EEx
+  EEx.function_from_string(:defp, :render, @html, [:path, :csrf_token])
 end

--- a/test/plug/swagger_ui_test.exs
+++ b/test/plug/swagger_ui_test.exs
@@ -1,0 +1,16 @@
+defmodule OpenApiSpec.Plug.SwaggerUITest do
+  use ExUnit.Case
+
+  alias OpenApiSpex.Plug.SwaggerUI
+
+  @opts SwaggerUI.init(path: "/ui")
+
+  test "renders csrf token" do
+    token = Plug.CSRFProtection.get_csrf_token()
+
+    conn = Plug.Test.conn(:get, "/ui")
+    conn = SwaggerUI.call(conn, @opts)
+    assert conn.resp_body =~ ~r[pathname.+?/ui]
+    assert String.contains?(conn.resp_body, token)
+  end
+end


### PR DESCRIPTION
This small change allows using Swagger UI for CSRF-protected APIs