### PR TITLE
Deprecate Plug.Cast2, in favor of Plug.CastAndValidate

### DIFF
--- a/lib/open_api_spex/plug/cast2.ex
+++ b/lib/open_api_spex/plug/cast2.ex
@@ -2,14 +2,10 @@ defmodule OpenApiSpex.Plug.Cast2 do
   @behaviour Plug
 
   @impl Plug
-  def init(opts) do
-    IO.warn("OpenApiSpex.Plug.Cast2 is deprecated. Please use OpenApiSpex.Plug.CastAndValidate.")
-    OpenApiSpex.Plug.CastAndValidate.init(opts)
-  end
+  @deprecated "Use OpenApiSpex.Plug.CastAndValidate.init/1 instead"
+  defdelegate init(opts), to: OpenApiSpex.Plug.CastAndValidate
 
   @impl Plug
-  def call(conn, opts) do
-    IO.warn("OpenApiSpex.Plug.Cast2 is deprecated. Please use OpenApiSpex.Plug.CastAndValidate.")
-    OpenApiSpex.Plug.CastAndValidate.call(conn, opts)
-  end
+  @deprecated "Use OpenApiSpex.Plug.CastAndValidate.call/2 instead"
+  defdelegate call(conn, opts), to: OpenApiSpex.Plug.CastAndValidate
 end

--- a/lib/open_api_spex/plug/cast2.ex
+++ b/lib/open_api_spex/plug/cast2.ex
@@ -1,107 +1,15 @@
 defmodule OpenApiSpex.Plug.Cast2 do
-  @moduledoc """
-  Module plug that will cast the `Conn.params` and `Conn.body_params` according to the schemas defined for the operation.
-  Note that when using this plug, the body params are no longer merged into `Conn.params` and must be read from `Conn.body_params`
-  separately.
-
-  The operation_id can be given at compile time as an argument to `init`:
-
-      plug OpenApiSpex.Plug.Cast, operation_id: "MyApp.ShowUser"
-
-  For phoenix applications, the operation_id can be obtained at runtime automatically.
-
-      defmodule MyAppWeb.UserController do
-        use Phoenix.Controller
-        plug OpenApiSpex.Plug.Cast
-        ...
-      end
-
-  If you want customize the error response, you can provide the `:render_error` option to register a plug which creates
-  a custom response in the case of a validation error.
-
-  ## Example
-
-      defmodule MyAppWeb.UserController do
-        use Phoenix.Controller
-        plug OpenApiSpex.Plug.Cast,
-        render_error: MyApp.RenderError
-
-        ...
-      end
-
-      defmodule MyApp.RenderError do
-        def init(opts), do: opts
-
-        def call(conn, reason) do
-          msg = %{error: reason} |> Posion.encode!()
-
-          conn
-          |> Conn.put_resp_content_type("application/json")
-          |> Conn.send_resp(400, msg)
-        end
-      end
-  """
-
   @behaviour Plug
-
-  alias Plug.Conn
 
   @impl Plug
   def init(opts) do
-    opts
-    |> Map.new()
-    |> Map.put_new(:render_error, OpenApiSpex.Plug.DefaultRenderError)
+    IO.warn("OpenApiSpex.Plug.Cast2 is deprecated. Please use OpenApiSpex.Plug.CastAndValidate.")
+    OpenApiSpex.Plug.CastAndValidate.init(opts)
   end
 
   @impl Plug
-  def call(conn = %{private: %{open_api_spex: private_data}}, %{
-        operation_id: operation_id,
-        render_error: render_error
-      }) do
-    spec = private_data.spec
-    operation = private_data.operation_lookup[operation_id]
-
-    content_type =
-      Conn.get_req_header(conn, "content-type")
-      |> Enum.at(0, "")
-      |> String.split(";")
-      |> Enum.at(0)
-
-    private_data = Map.put(private_data, :operation_id, operation_id)
-    conn = Conn.put_private(conn, :open_api_spex, private_data)
-
-    with {:ok, conn} <- OpenApiSpex.cast_and_validate(spec, operation, conn, content_type) do
-      conn
-    else
-      {:error, reason} ->
-        opts = render_error.init(reason)
-
-        conn
-        |> render_error.call(opts)
-        |> Plug.Conn.halt()
-    end
-  end
-
-  def call(
-        conn = %{
-          private: %{phoenix_controller: controller, phoenix_action: action, open_api_spex: _pd}
-        },
-        opts
-      ) do
-    operation_id = controller.open_api_operation(action).operationId
-
-    if operation_id do
-      call(conn, Map.put(opts, :operation_id, operation_id))
-    else
-      raise "operationId was not found in action API spec"
-    end
-  end
-
-  def call(_conn = %{private: %{open_api_spex: _pd}}, _opts) do
-    raise ":operation_id was neither provided nor inferred from conn. Consider putting plug OpenApiSpex.Plug.Cast rather into your phoenix controller."
-  end
-
-  def call(_conn, _opts) do
-    raise ":open_api_spex was not found under :private. Maybe OpenApiSpex.Plug.PutApiSpec was not called before?"
+  def call(conn, opts) do
+    IO.warn("OpenApiSpex.Plug.Cast2 is deprecated. Please use OpenApiSpex.Plug.CastAndValidate.")
+    OpenApiSpex.Plug.CastAndValidate.call(conn, opts)
   end
 end

--- a/lib/open_api_spex/plug/cast_and_validate.ex
+++ b/lib/open_api_spex/plug/cast_and_validate.ex
@@ -1,0 +1,103 @@
+defmodule OpenApiSpex.Plug.CastAndValidate do
+  @moduledoc """
+  Module plug that will cast and validate the `Conn.params` and `Conn.body_params` according to the schemas defined for the operation.
+
+  The operation_id can be given at compile time as an argument to `init`:
+
+      plug OpenApiSpex.Plug.CastAndValidate, operation_id: "MyApp.ShowUser"
+
+  For phoenix applications, the operation_id can be obtained at runtime automatically.
+
+      defmodule MyAppWeb.UserController do
+        use Phoenix.Controller
+        plug OpenApiSpex.Plug.CastAndValidate
+        ...
+      end
+
+  If you want customize the error response, you can provide the `:render_error` option to register a plug which creates
+  a custom response in the case of a validation error.
+
+  ## Example
+
+      defmodule MyAppWeb.UserController do
+        use Phoenix.Controller
+        plug OpenApiSpex.Plug.CastAndValidate, render_error: MyApp.RenderError
+        ...
+      end
+
+      defmodule MyApp.RenderError do
+        def init(opts), do: opts
+
+        def call(conn, reason) do
+          msg = Jason.encode!(%{error: reason})
+
+          conn
+          |> Conn.put_resp_content_type("application/json")
+          |> Conn.send_resp(400, msg)
+        end
+      end
+  """
+
+  @behaviour Plug
+
+  alias Plug.Conn
+
+  @impl Plug
+  def init(opts) do
+    opts
+    |> Map.new()
+    |> Map.put_new(:render_error, OpenApiSpex.Plug.DefaultRenderError)
+  end
+
+  @impl Plug
+  def call(conn = %{private: %{open_api_spex: private_data}}, %{
+        operation_id: operation_id,
+        render_error: render_error
+      }) do
+    spec = private_data.spec
+    operation = private_data.operation_lookup[operation_id]
+
+    content_type =
+      Conn.get_req_header(conn, "content-type")
+      |> Enum.at(0, "")
+      |> String.split(";")
+      |> Enum.at(0)
+
+    private_data = Map.put(private_data, :operation_id, operation_id)
+    conn = Conn.put_private(conn, :open_api_spex, private_data)
+
+    with {:ok, conn} <- OpenApiSpex.cast_and_validate(spec, operation, conn, content_type) do
+      conn
+    else
+      {:error, reason} ->
+        opts = render_error.init(reason)
+
+        conn
+        |> render_error.call(opts)
+        |> Plug.Conn.halt()
+    end
+  end
+
+  def call(
+        conn = %{
+          private: %{phoenix_controller: controller, phoenix_action: action, open_api_spex: _pd}
+        },
+        opts
+      ) do
+    operation_id = controller.open_api_operation(action).operationId
+
+    if operation_id do
+      call(conn, Map.put(opts, :operation_id, operation_id))
+    else
+      raise "operationId was not found in action API spec"
+    end
+  end
+
+  def call(_conn = %{private: %{open_api_spex: _pd}}, _opts) do
+    raise ":operation_id was neither provided nor inferred from conn. Consider putting plug OpenApiSpex.Plug.Cast rather into your phoenix controller."
+  end
+
+  def call(_conn, _opts) do
+    raise ":open_api_spex was not found under :private. Maybe OpenApiSpex.Plug.PutApiSpec was not called before?"
+  end
+end


### PR DESCRIPTION
- Move implementation of `Plug.Cast2` to `Plug.CastAndValidate`.
- Add module documentation for `Plug.CastAndValidate`.

This is an API change to make way for a new section I'd like to add to the project README. The new README section would guide the user on casting and validating requests using the new "cast and validate" plug (formerly `Cast2`, now `CastAndValidate`).

I didn't want to create public documentation on a module whose name was temporary. With a permanent name, users of the newer plug don't have to adjust their code once the new pattern becomes the preferred pattern.

Also, this work got me thinking about a related problem, #87.