### PR TITLE
Cast and validate guide

### DIFF
--- a/lib/open_api_spex/cast.ex
+++ b/lib/open_api_spex/cast.ex
@@ -40,10 +40,10 @@ defmodule OpenApiSpex.Cast do
   Recognizes all the types defined in Open API (itself a superset of JSON Schema).
 
   JSON Schema types:
-  https://json-schema.org/latest/json-schema-core.html#rfc.section.4.2.1
+  [https://json-schema.org/latest/json-schema-core.html#rfc.section.4.2.1](https://json-schema.org/latest/json-schema-core.html#rfc.section.4.2.1)
 
   Open API primitive types:
-  https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#data-types
+  [https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#data-types](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#data-types)
 
   For an `:object` schema type, the cast operation returns a map with atom keys.
 

--- a/lib/open_api_spex/cast.ex
+++ b/lib/open_api_spex/cast.ex
@@ -34,8 +34,61 @@ defmodule OpenApiSpex.Cast do
             index: 0,
             errors: []
 
+  @doc ~S"""
+  Cast and validate a value against the given schema.
+
+  Recognizes all the types defined in Open API (itself a superset of JSON Schema).
+
+  JSON Schema types:
+  https://json-schema.org/latest/json-schema-core.html#rfc.section.4.2.1
+
+  Open API primitive types:
+  https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#data-types
+
+  For an `:object` schema type, the cast operation returns a map with atom keys.
+
+  ## Examples
+
+      iex> alias OpenApiSpex.{Cast, Schema}
+      iex> schema = %Schema{type: :string}
+      iex> Cast.cast(schema, "a string")
+      {:ok, "a string"}
+      iex> Cast.cast(schema, :not_a_string)
+      {
+        :error,
+        [
+          %OpenApiSpex.Cast.Error{
+            reason: :invalid_type,
+            type: :string,
+            value: :not_a_string
+          }
+        ]
+      }
+      iex> schema = %Schema{
+      ...>    type: :object,
+      ...>    properties: %{
+      ...>      name: nil
+      ...>    }
+      ...> }
+      iex> Cast.cast(schema, %{"name" => "spex"})
+      {:ok, %{name: "spex"}}
+      iex> Cast.cast(schema, %{"bad" => "spex"})
+      {
+        :error,
+        [
+          %OpenApiSpex.Cast.Error{
+            name: "bad",
+            path: ["bad"],
+            reason: :unexpected_field,
+            value: %{"bad" => "spex"}
+          }
+        ]
+      }
+
+  """
+
   @spec cast(schema_or_reference | nil, term(), map()) :: {:ok, term()} | {:error, [Error.t()]}
-  def cast(schema, value, schemas) do
+  def cast(schema, value, schemas \\ %{}) do
     ctx = %__MODULE__{schema: schema, value: value, schemas: schemas}
     cast(ctx)
   end

--- a/lib/open_api_spex/open_api.ex
+++ b/lib/open_api_spex/open_api.ex
@@ -35,6 +35,10 @@ defmodule OpenApiSpex.OpenApi do
     externalDocs: ExternalDocumentation.t | nil
   }
 
+  @json_encoder Enum.find([Jason, Poison], &Code.ensure_loaded?/1)
+
+  def json_encoder, do: @json_encoder
+
   for encoder <- [Poison.Encoder, Jason.Encoder] do
     if Code.ensure_loaded?(encoder) do
       defimpl encoder do

--- a/lib/open_api_spex/operation2.ex
+++ b/lib/open_api_spex/operation2.ex
@@ -1,6 +1,6 @@
 defmodule OpenApiSpex.Operation2 do
   @moduledoc """
-  Defines the `OpenApiSpex.Operation.t` type.
+  Casts and validates a request from a Plug conn.
   """
   alias OpenApiSpex.{
     Cast,

--- a/lib/open_api_spex/plug/cast_and_validate.ex
+++ b/lib/open_api_spex/plug/cast_and_validate.ex
@@ -46,7 +46,7 @@ defmodule OpenApiSpex.Plug.CastAndValidate do
   def init(opts) do
     opts
     |> Map.new()
-    |> Map.put_new(:render_error, OpenApiSpex.Plug.DefaultRenderError)
+    |> Map.put_new(:render_error, OpenApiSpex.Plug.JsonRenderError)
   end
 
   @impl Plug

--- a/lib/open_api_spex/plug/json_render_error.ex
+++ b/lib/open_api_spex/plug/json_render_error.ex
@@ -1,0 +1,26 @@
+defmodule OpenApiSpex.Plug.JsonRenderError do
+  @behaviour Plug
+
+  alias Plug.Conn
+  alias OpenApiSpex.OpenApi
+
+  @impl Plug
+  def init(opts), do: opts
+
+  @impl Plug
+  def call(conn, reasons) when is_list(reasons) do
+    response = %{
+      errors: Enum.map(reasons, &to_string/1)
+    }
+
+    json = OpenApi.json_encoder().encode!(response)
+
+    conn
+    |> Conn.put_resp_content_type("application/json")
+    |> Conn.send_resp(422, json)
+  end
+
+  def call(conn, reason) do
+    call(conn, [reason])
+  end
+end

--- a/test/cast_test.exs
+++ b/test/cast_test.exs
@@ -2,6 +2,7 @@ defmodule OpenApiSpec.CastTest do
   use ExUnit.Case
   alias OpenApiSpex.{Cast, Schema, Reference}
   alias OpenApiSpex.Cast.Error
+  doctest OpenApiSpex.Cast
 
   def cast(ctx), do: Cast.cast(ctx)
 


### PR DESCRIPTION
- Makes CastAndValidate the canonical usage pattern
- Fixes runtime error for default error handler
- By default, uses application/json for error response
- Add guide for casting/validating outside of request/response cycle