### PR TITLE
fix minimum error message

### DIFF
--- a/lib/open_api_spex/cast/error.ex
+++ b/lib/open_api_spex/cast/error.ex
@@ -270,9 +270,9 @@ defmodule OpenApiSpex.Cast.Error do
     "#{size} is larger than maximum #{max}"
   end
 
-  def message(%{reason: min, length: min, value: size})
+  def message(%{reason: min, length: min_value, value: size})
       when min in [:exclusive_min, :minimum] do
-    "#{size} is smaller than (exclusive) minimum #{min}"
+    "#{size} is smaller than (exclusive) minimum #{min_value}"
   end
 
   def message(%{reason: :invalid_type, type: type, value: value}) do


### PR DESCRIPTION
Function clause for min error message has a typo on `min` so in case of validation an exception raises.

Same is for max, if ok will open a new PR.