### PR TITLE
Fix maximum and minimum error handling

### DIFF
--- a/lib/open_api_spex/cast/error.ex
+++ b/lib/open_api_spex/cast/error.ex
@@ -270,9 +270,14 @@ defmodule OpenApiSpex.Cast.Error do
     "#{size} is larger than maximum #{max}"
   end
 
-  def message(%{reason: min, length: min, value: size})
-      when min in [:exclusive_min, :minimum] do
-    "#{size} is smaller than (exclusive) minimum #{min}"
+  def message(%{reason: :exclusive_min, length: min, value: value})
+      when value <= min do
+    "#{value} is smaller than exclusive minimum #{min}"
+  end
+
+  def message(%{reason: :minimum, length: min, value: value})
+      when value < min do
+    "#{value} is smaller than inclusive minimum #{min}"
   end
 
   def message(%{reason: :invalid_type, type: type, value: value}) do

--- a/lib/open_api_spex/cast/error.ex
+++ b/lib/open_api_spex/cast/error.ex
@@ -265,9 +265,14 @@ defmodule OpenApiSpex.Cast.Error do
     "#{count} is not a multiple of #{multiple}"
   end
 
-  def message(%{reason: max, length: max, value: size})
-      when max in [:exclusive_max, :maximum] do
-    "#{size} is larger than maximum #{max}"
+  def message(%{reason: :exclusive_max, length: max, value: value})
+      when value >= max do
+    "#{value} is larger than exclusive maximum #{max}"
+  end
+
+  def message(%{reason: :maximum, length: max, value: value})
+      when value > max do
+    "#{value} is larger than inclusive maximum #{max}"
   end
 
   def message(%{reason: :exclusive_min, length: min, value: value})

--- a/lib/open_api_spex/cast/integer.ex
+++ b/lib/open_api_spex/cast/integer.ex
@@ -28,19 +28,19 @@ defmodule OpenApiSpex.Cast.Integer do
 
   defp cast_integer(%{value: value, schema: %{minimum: minimum, exclusiveMinimum: true}} = ctx)
        when is_integer(value) and is_integer(minimum) do
-    if value < minimum do
-      Cast.error(ctx, {:exclusive_min, minimum, value})
-    else
+    if value > minimum do
       Cast.success(ctx, [:minimum, :exclusiveMinimum])
+    else
+      Cast.error(ctx, {:exclusive_min, minimum, value})
     end
   end
 
   defp cast_integer(%{value: value, schema: %{minimum: minimum}} = ctx)
        when is_integer(value) and is_integer(minimum) do
-    if value <= minimum do
-      Cast.error(ctx, {:minimum, minimum, value})
-    else
+    if value >= minimum do
       Cast.success(ctx, :minimum)
+    else
+      Cast.error(ctx, {:minimum, minimum, value})
     end
   end
 

--- a/lib/open_api_spex/cast/integer.ex
+++ b/lib/open_api_spex/cast/integer.ex
@@ -46,19 +46,19 @@ defmodule OpenApiSpex.Cast.Integer do
 
   defp cast_integer(%{value: value, schema: %{maximum: maximum, exclusiveMaximum: true}} = ctx)
        when is_integer(value) and is_integer(maximum) do
-    if value > maximum do
-      Cast.error(ctx, {:exclusive_max, maximum, value})
-    else
+    if value < maximum do
       Cast.success(ctx, [:maximum, :exclusiveMaximum])
+    else
+      Cast.error(ctx, {:exclusive_max, maximum, value})
     end
   end
 
   defp cast_integer(%{value: value, schema: %{maximum: maximum}} = ctx)
        when is_integer(value) and is_integer(maximum) do
-    if value >= maximum do
-      Cast.error(ctx, {:maximum, maximum, value})
-    else
+    if value <= maximum do
       Cast.success(ctx, :maximum)
+    else
+      Cast.error(ctx, {:maximum, maximum, value})
     end
   end
 

--- a/test/cast/integer_test.exs
+++ b/test/cast/integer_test.exs
@@ -42,11 +42,13 @@ defmodule OpenApiSpex.CastIntegerTest do
     test "with maximum" do
       schema = %Schema{type: :integer, maximum: 2}
       assert cast(value: 1, schema: schema) == {:ok, 1}
-      assert {:error, [error]} = cast(value: 2, schema: schema)
+      assert cast(value: 2, schema: schema) == {:ok, 2}
+      assert {:error, [error]} = cast(value: 3, schema: schema)
       assert error.reason == :maximum
-      assert error.value == 2
+      assert error.value == 3
       # error.length is the maximum
       assert error.length == 2
+      assert Error.message(error) =~ "larger than inclusive maximum"
     end
 
     test "with minimum w/ exclusiveMinimum" do
@@ -62,12 +64,13 @@ defmodule OpenApiSpex.CastIntegerTest do
 
     test "with maximum w/ exclusiveMaximum" do
       schema = %Schema{type: :integer, maximum: 2, exclusiveMaximum: true}
-      assert cast(value: 2, schema: schema) == {:ok, 2}
-      assert {:error, [error]} = cast(value: 3, schema: schema)
+      assert cast(value: 1, schema: schema) == {:ok, 1}
+      assert {:error, [error]} = cast(value: 2, schema: schema)
       assert error.reason == :exclusive_max
-      assert error.value == 3
+      assert error.value == 2
       # error.length is the maximum
       assert error.length == 2
+      assert Error.message(error) =~ "larger than exclusive maximum"
     end
   end
 end

--- a/test/cast/integer_test.exs
+++ b/test/cast/integer_test.exs
@@ -30,11 +30,13 @@ defmodule OpenApiSpex.CastIntegerTest do
     test "with minimum" do
       schema = %Schema{type: :integer, minimum: 2}
       assert cast(value: 3, schema: schema) == {:ok, 3}
-      assert {:error, [error]} = cast(value: 2, schema: schema)
+      assert cast(value: 2, schema: schema) == {:ok, 2}
+      assert {:error, [error]} = cast(value: 1, schema: schema)
       assert error.reason == :minimum
-      assert error.value == 2
+      assert error.value == 1
       # error.length is the minimum
       assert error.length == 2
+      assert Error.message(error) =~ "smaller than inclusive minimum"
     end
 
     test "with maximum" do
@@ -49,12 +51,13 @@ defmodule OpenApiSpex.CastIntegerTest do
 
     test "with minimum w/ exclusiveMinimum" do
       schema = %Schema{type: :integer, minimum: 2, exclusiveMinimum: true}
-      assert cast(value: 2, schema: schema) == {:ok, 2}
-      assert {:error, [error]} = cast(value: 1, schema: schema)
+      assert cast(value: 3, schema: schema) == {:ok, 3}
+      assert {:error, [error]} = cast(value: 2, schema: schema)
       assert error.reason == :exclusive_min
-      assert error.value == 1
+      assert error.value == 2
       # error.length is the minimum
       assert error.length == 2
+      assert Error.message(error) =~ "smaller than exclusive minimum"
     end
 
     test "with maximum w/ exclusiveMaximum" do


### PR DESCRIPTION
According to [Json Specs](https://json-schema.org/understanding-json-schema/reference/numeric.html#range) maximum and minimum (with and without comparison) are incorrect.

This PR fixes the comparison, tests and also verifies error message.