### PR TITLE
ExDocs based documentation generation

### DIFF
--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -94,9 +94,9 @@ defmodule OpenApiSpex.Controller do
   end
 
   @doc false
-  @spec __api_operation__(module(), atom()) :: Operation.t()
+  @spec __api_operation__(module(), atom()) :: Operation.t() | nil
   def __api_operation__(mod, name) do
-    with {mod_meta, summary, docs, meta} <- get_docs(mod, name) do
+    with {:ok, {mod_meta, summary, docs, meta}} <- get_docs(mod, name) do
       %Operation{
         description: docs,
         operationId: "#{inspect(mod)}.#{name}",
@@ -106,6 +106,8 @@ defmodule OpenApiSpex.Controller do
         summary: summary,
         tags: Map.get(mod_meta, :tags, []) ++ Map.get(meta, :tags, [])
       }
+    else
+      _ -> nil
     end
   end
 
@@ -119,14 +121,13 @@ defmodule OpenApiSpex.Controller do
       end)
 
     if docs == :none do
-      IO.puts("docs == :none. module=#{inspect(module)}, name=#{inspect(name)}")
-      nil
+      :error
     else
       docs = Map.get(docs, "en", "")
 
       [summary | _] = String.split(docs, ~r/\n\s*\n/, parts: 2)
 
-      {mod_meta, summary, docs, meta}
+      {:ok, {mod_meta, summary, docs, meta}}
     end
   end
 

--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -30,14 +30,13 @@ defmodule OpenApiSpex.Controller do
 
   ### `responses`
 
-  Responses are controlled by `:responses` tag and currently supports only
-  `application/json` responses. Responses must be defined as a map or keyword list
-  in form of:
+  Responses are controlled by `:responses` tag. Responses must be defined as
+  a map or keyword list in form of:
 
   ```
   %{
-    200 => {"Response name", schema},
-    :not_found => {"Response name", schema}
+    200 => {"Response name", "application/json", schema},
+    :not_found => {"Response name", "application/json", schema}
   }
   ```
 
@@ -46,7 +45,7 @@ defmodule OpenApiSpex.Controller do
   ### `requestBody`
 
   Controlled by `:body` parameter and is defined as a tuple in form
-  `{description, schema}`.
+  `{description, mime, schema}`.
 
   ### `tags`
 
@@ -66,11 +65,13 @@ defmodule OpenApiSpex.Controller do
 
     More docs
     """
-    @doc parameters: [
-      id: [in: :path, type: :string, required: true]
-    ]
-    @doc responses: [
-      ok: {"Foo document", FooSchema}
+    @doc [
+      parameters: [
+        id: [in: :path, type: :string, required: true]
+      ],
+      responses: [
+        ok: {"Foo document", "application/json", FooSchema}
+      ]
     ]
     def show(conn, %{id: id}) do
       # …
@@ -138,16 +139,16 @@ defmodule OpenApiSpex.Controller do
   defp build_parameters(_), do: []
 
   defp build_responses(%{responses: responses}) do
-    for {status, {description, schema}} <- responses, into: %{} do
+    for {status, {description, mime, schema}} <- responses, into: %{} do
       {Plug.Conn.Status.code(status),
-       Operation.response(description, "application/json", schema)}
+       Operation.response(description, mime, schema)}
     end
   end
 
   defp build_responses(_), do: []
 
-  defp build_request_body(%{body: {name, schema}}),
-    do: Operation.request_body(name, "application/json", schema)
+  defp build_request_body(%{body: {name, mime, schema}}),
+    do: Operation.request_body(name, mime, schema)
 
   defp build_request_body(_), do: nil
 end

--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -1,0 +1,153 @@
+defmodule OpenApiSpex.Controller do
+  @moduledoc ~S'''
+  Generation of OpenAPI documentation via ExDoc documentation and tags.
+
+  ## Supported OpenAPI fields
+
+  Attribute `operationId` is automatically provided by the implementation
+  and cannot be changed in any way. It is constructed as `Module.Name.function_name`
+  in the same way as function references in backtraces.
+
+  ### `description` and `summary`
+
+  Description of endpoint will be filled with documentation string in the same
+  manner as ExDocs, so first line will be used as a `summary` and whole
+  documentation will be used as `description` field.
+
+  ### `parameters`
+
+  Parameters of the endpoint are defined by `:parameters` tag which should be
+  map or keyword list that is formed as:
+
+  ```
+  [
+    param_name: definition
+  ]
+  ```
+
+  Where `definition` is `OpenApiSpex.Parameter.t()` structure or map or keyword
+  list that accepts the same arguments.
+
+  ### `responses`
+
+  Responses are controlled by `:responses` tag and currently supports only
+  `application/json` responses. Responses must be defined as a map or keyword list
+  in form of:
+
+  ```
+  %{
+    200 => {"Response name", schema},
+    :not_found => {"Response name", schema}
+  }
+  ```
+
+  Where atoms are the same as `Plug.Conn.Status.code/1` values.
+
+  ### `requestBody`
+
+  Controlled by `:body` parameter and is defined as a tuple in form
+  `{description, schema}`.
+
+  ### `tags`
+
+  Tags are controlled by `:tags` attribute. In contrast to other attributes, this
+  one will also inherit all tags defined as a module documentation attributes.
+
+  ## Example
+
+  ```
+  defmodule FooController do
+    use #{inspect(__MODULE__)}
+
+    @moduledoc tags: ["Foos"]
+
+    @doc """
+    Endpoint summary
+
+    More docs
+    """
+    @doc parameters: [
+      id: [in: :path, type: :string, required: true]
+    ]
+    @doc responses: [
+      ok: {"Foo document", FooSchema}
+    ]
+    def show(conn, %{id: id}) do
+      # …
+    end
+  end
+  ```
+  '''
+
+  alias OpenApiSpex.Operation
+
+  defmacro __using__(_opts) do
+    quote do
+      @doc false
+      @spec open_api_operation(atom()) :: OpenApiSpex.Operation.t()
+      def open_api_operation(name),
+        do: unquote(__MODULE__).__api_operation__(__MODULE__, name)
+
+      defoverridable open_api_operation: 1
+    end
+  end
+
+  @doc false
+  @spec __api_operation__(module(), atom()) :: Operation.t()
+  def __api_operation__(mod, name) do
+    {mod_meta, summary, docs, meta} = get_docs(mod, name)
+
+    %Operation{
+      description: docs,
+      operationId: "#{inspect(mod)}.#{name}",
+      parameters: build_parameters(meta),
+      requestBody: build_request_body(meta),
+      responses: build_responses(meta),
+      summary: summary,
+      tags: Map.get(mod_meta, :tags, []) ++ Map.get(meta, :tags, [])
+    }
+  end
+
+  defp get_docs(module, name) do
+    {:docs_v1, _anno, _lang, _format, _module_doc, mod_meta, mod_docs} =
+      Code.fetch_docs(module)
+
+    {_, _, _, docs, meta} =
+      Enum.find(mod_docs, fn
+        {{:function, ^name, _}, _, _, _, _} -> true
+        _ -> false
+      end)
+
+    docs = Map.get(docs, "en", "")
+
+    [summary | _] = String.split(docs, ~r/\n\s*\n/, parts: 2)
+
+    {mod_meta, summary, docs, meta}
+  end
+
+  defp build_parameters(%{parameters: params}) do
+    for {name, options} <- params do
+      {location, options} = Keyword.pop(options, :in, :query)
+      {type, options} = Keyword.pop(options, :type, :string)
+      {description, options} = Keyword.pop(options, :description, :string)
+
+      Operation.parameter(name, location, type, description, options)
+    end
+  end
+
+  defp build_parameters(_), do: []
+
+  defp build_responses(%{responses: responses}) do
+    for {status, {description, schema}} <- responses, into: %{} do
+      {Plug.Conn.Status.code(status),
+       Operation.response(description, "application/json", schema)}
+    end
+  end
+
+  defp build_responses(_), do: []
+
+  defp build_request_body(%{body: {name, schema}}),
+    do: Operation.request_body(name, "application/json", schema)
+
+  defp build_request_body(_), do: nil
+end

--- a/lib/open_api_spex/path_item.ex
+++ b/lib/open_api_spex/path_item.ex
@@ -4,6 +4,7 @@ defmodule OpenApiSpex.PathItem do
   """
 
   alias OpenApiSpex.{Operation, Server, Parameter, PathItem, Reference}
+
   defstruct [
     :"$ref",
     :summary,
@@ -29,28 +30,28 @@ defmodule OpenApiSpex.PathItem do
   but they will not know which operations and parameters are available.
   """
   @type t :: %__MODULE__{
-    "$ref": String.t | nil,
-    summary: String.t | nil,
-    description: String.t | nil,
-    get: Operation.t | nil,
-    put: Operation.t | nil,
-    post: Operation.t | nil,
-    delete: Operation.t | nil,
-    options: Operation.t | nil,
-    head: Operation.t | nil,
-    patch: Operation.t | nil,
-    trace: Operation.t | nil,
-    servers: [Server.t] | nil,
-    parameters: [Parameter.t | Reference.t] | nil
-  }
+          "$ref": String.t() | nil,
+          summary: String.t() | nil,
+          description: String.t() | nil,
+          get: Operation.t() | nil,
+          put: Operation.t() | nil,
+          post: Operation.t() | nil,
+          delete: Operation.t() | nil,
+          options: Operation.t() | nil,
+          head: Operation.t() | nil,
+          patch: Operation.t() | nil,
+          trace: Operation.t() | nil,
+          servers: [Server.t()] | nil,
+          parameters: [Parameter.t() | Reference.t()] | nil
+        }
 
   @typedoc """
   Represents a route from in a Plug/Phoenix application.
   Eg from the generated `__routes__` function in a Phoenix.Router module.
   """
   @type route ::
-    %{verb: atom, plug: atom, opts: any} |
-    %{verb: atom, plug: atom, plug_opts: any}
+          %{verb: atom, plug: atom, opts: any}
+          | %{verb: atom, plug: atom, plug_opts: any}
 
   @doc """
   Builds a PathItem struct from a list of routes that share a path.
@@ -68,7 +69,18 @@ defmodule OpenApiSpex.PathItem do
 
   @spec from_valid_routes([route]) :: nil | t
   defp from_valid_routes([]), do: nil
+
   defp from_valid_routes(routes) do
-    struct(PathItem, Enum.map(routes, &{&1.verb, Operation.from_route(&1)}))
+    attrs =
+      routes
+      |> Enum.map(fn route ->
+        case Operation.from_route(route) do
+          nil -> nil
+          op -> {route.verb, op}
+        end
+      end)
+      |> Enum.filter(& &1)
+
+    struct(PathItem, attrs)
   end
 end

--- a/lib/open_api_spex/schema_resolver.ex
+++ b/lib/open_api_spex/schema_resolver.ex
@@ -29,13 +29,13 @@ defmodule OpenApiSpex.SchemaResolver do
 
   See `OpenApiSpex.schema` macro for a convenient syntax for defining schema modules.
   """
-  @spec resolve_schema_modules(OpenApi.t) :: OpenApi.t
+  @spec resolve_schema_modules(OpenApi.t()) :: OpenApi.t()
   def resolve_schema_modules(spec = %OpenApi{}) do
     components = spec.components || %Components{}
     schemas = components.schemas || %{}
     {paths, schemas} = resolve_schema_modules_from_paths(spec.paths, schemas)
     schemas = resolve_schema_modules_from_schemas(schemas)
-    %{spec | paths: paths, components: %{components| schemas: schemas}}
+    %{spec | paths: paths, components: %{components | schemas: schemas}}
   end
 
   defp resolve_schema_modules_from_paths(paths = %{}, schemas = %{}) do
@@ -57,39 +57,61 @@ defmodule OpenApiSpex.SchemaResolver do
 
   defp resolve_schema_modules_from_operation(operation = %Operation{}, schemas) do
     {parameters, schemas} = resolve_schema_modules_from_parameters(operation.parameters, schemas)
-    {request_body, schemas} = resolve_schema_modules_from_request_body(operation.requestBody, schemas)
+
+    {request_body, schemas} =
+      resolve_schema_modules_from_request_body(operation.requestBody, schemas)
+
     {responses, schemas} = resolve_schema_modules_from_responses(operation.responses, schemas)
-    new_operation = %{operation | parameters: parameters, requestBody: request_body, responses: responses}
+
+    new_operation = %{
+      operation
+      | parameters: parameters,
+        requestBody: request_body,
+        responses: responses
+    }
+
     {new_operation, schemas}
   end
 
   defp resolve_schema_modules_from_parameters(nil, schemas), do: {nil, schemas}
+
   defp resolve_schema_modules_from_parameters(parameters, schemas) do
     {parameters, schemas} =
       Enum.reduce(parameters, {[], schemas}, fn parameter, {parameters, schemas} ->
         {new_parameter, schemas} = resolve_schema_modules_from_parameter(parameter, schemas)
         {[new_parameter | parameters], schemas}
       end)
+
     {Enum.reverse(parameters), schemas}
   end
 
-  defp resolve_schema_modules_from_parameter(parameter = %Parameter{schema: schema, content: nil}, schemas) do
+  defp resolve_schema_modules_from_parameter(
+         parameter = %Parameter{schema: schema, content: nil},
+         schemas
+       ) do
     {schema, schemas} = resolve_schema_modules_from_schema(schema, schemas)
     new_parameter = %{parameter | schema: schema}
     {new_parameter, schemas}
   end
-  defp resolve_schema_modules_from_parameter(parameter = %Parameter{schema: nil, content: content = %{}}, schemas) do
+
+  defp resolve_schema_modules_from_parameter(
+         parameter = %Parameter{schema: nil, content: content = %{}},
+         schemas
+       ) do
     {new_content, schemas} = resolve_schema_modules_from_content(content, schemas)
     {%{parameter | content: new_content}, schemas}
   end
+
   defp resolve_schema_modules_from_parameter(parameter = %Parameter{}, schemas) do
     {parameter, schemas}
   end
+
   defp resolve_schema_modules_from_parameter(parameter = %Reference{}, schemas) do
     {parameter, schemas}
   end
 
   defp resolve_schema_modules_from_content(nil, schemas), do: {nil, schemas}
+
   defp resolve_schema_modules_from_content(content, schemas) do
     Enum.reduce(content, {content, schemas}, fn {mime, media}, {content, schemas} ->
       {new_media, schemas} = resolve_schema_modules_from_media_type(media, schemas)
@@ -102,18 +124,25 @@ defmodule OpenApiSpex.SchemaResolver do
     new_media = %{media | schema: schema}
     {new_media, schemas}
   end
+
   defp resolve_schema_modules_from_media_type(media = %MediaType{}, schemas) do
     {media, schemas}
   end
 
   defp resolve_schema_modules_from_request_body(nil, schemas), do: {nil, schemas}
+
   defp resolve_schema_modules_from_request_body(request_body = %RequestBody{}, schemas) do
     {content, schemas} = resolve_schema_modules_from_content(request_body.content, schemas)
     new_request_body = %{request_body | content: content}
     {new_request_body, schemas}
   end
+
   defp resolve_schema_modules_from_request_body(request_body = %Reference{}, schemas) do
     {request_body, schemas}
+  end
+
+  defp resolve_schema_modules_from_responses(responses, schemas = %{}) when is_list(responses) do
+    resolve_schema_modules_from_responses(Map.new(responses), schemas)
   end
 
   defp resolve_schema_modules_from_responses(responses = %{}, schemas = %{}) do
@@ -139,11 +168,14 @@ defmodule OpenApiSpex.SchemaResolver do
   defp resolve_schema_modules_from_schema(false, schemas), do: {false, schemas}
   defp resolve_schema_modules_from_schema(true, schemas), do: {true, schemas}
   defp resolve_schema_modules_from_schema(nil, schemas), do: {nil, schemas}
+
   defp resolve_schema_modules_from_schema(schema_list, schemas) when is_list(schema_list) do
     Enum.map_reduce(schema_list, schemas, &resolve_schema_modules_from_schema/2)
   end
+
   defp resolve_schema_modules_from_schema(schema, schemas) when is_atom(schema) do
     title = schema.schema().title
+
     new_schemas =
       if Map.has_key?(schemas, title) do
         schemas
@@ -151,31 +183,41 @@ defmodule OpenApiSpex.SchemaResolver do
         {new_schema, schemas} = resolve_schema_modules_from_schema(schema.schema(), schemas)
         Map.put(schemas, title, new_schema)
       end
+
     {%Reference{"$ref": "#/components/schemas/#{title}"}, new_schemas}
   end
+
   defp resolve_schema_modules_from_schema(schema = %Schema{}, schemas) do
     {all_of, schemas} = resolve_schema_modules_from_schema(schema.allOf, schemas)
     {one_of, schemas} = resolve_schema_modules_from_schema(schema.oneOf, schemas)
     {any_of, schemas} = resolve_schema_modules_from_schema(schema.anyOf, schemas)
     {not_schema, schemas} = resolve_schema_modules_from_schema(schema.not, schemas)
     {items, schemas} = resolve_schema_modules_from_schema(schema.items, schemas)
-    {additional, schemas} = resolve_schema_modules_from_schema(schema.additionalProperties, schemas)
-    {properties, schemas} = resolve_schema_modules_from_schema_properties(schema.properties, schemas)
-    schema =
-      %{schema |
-        allOf: all_of,
+
+    {additional, schemas} =
+      resolve_schema_modules_from_schema(schema.additionalProperties, schemas)
+
+    {properties, schemas} =
+      resolve_schema_modules_from_schema_properties(schema.properties, schemas)
+
+    schema = %{
+      schema
+      | allOf: all_of,
         oneOf: one_of,
         anyOf: any_of,
         not: not_schema,
         items: items,
         additionalProperties: additional,
         properties: properties
-      }
+    }
+
     {schema, schemas}
   end
+
   defp resolve_schema_modules_from_schema(ref = %Reference{}, schemas), do: {ref, schemas}
 
   defp resolve_schema_modules_from_schema_properties(nil, schemas), do: {nil, schemas}
+
   defp resolve_schema_modules_from_schema_properties(properties, schemas) do
     Enum.reduce(properties, {properties, schemas}, fn {name, property}, {properties, schemas} ->
       {new_property, schemas} = resolve_schema_modules_from_schema(property, schemas)

--- a/test/controller_test.exs
+++ b/test/controller_test.exs
@@ -1,0 +1,33 @@
+defmodule OpenApiSpex.ControllerTest do
+  use ExUnit.Case, async: true
+
+  alias OpenApiSpex.Controller, as: Subject
+
+  doctest Subject
+
+  @controller OpenApiSpexTest.UserControllerAnnotated
+
+  describe "Example module" do
+    test "exports open_api_operation/1" do
+      assert function_exported?(@controller, :open_api_operation, 1)
+    end
+
+    test "has defined OpenApiSpex.Operation for show action" do
+      assert %OpenApiSpex.Operation{} = @controller.open_api_operation(:show)
+    end
+
+    test "summary matches 'Endpoint summary'" do
+      assert %{summary: "Endpoint summary"} = @controller.open_api_operation(:show)
+    end
+
+    test "has response for HTTP 200" do
+      assert %{responses: %{200 => _}} = @controller.open_api_operation(:show)
+    end
+
+    test "has parameter `:id`" do
+      assert %{parameters: [param]} = @controller.open_api_operation(:show)
+      assert param.name == :id
+      assert param.required
+    end
+  end
+end

--- a/test/support/user_controller_annotated.ex
+++ b/test/support/user_controller_annotated.ex
@@ -1,0 +1,19 @@
+defmodule OpenApiSpexTest.UserControllerAnnotated do
+  use OpenApiSpex.Controller
+
+  @moduledoc tags: ["Foo"]
+
+  @doc """
+  Endpoint summary
+
+  More docs
+  """
+  @doc parameters: [
+    id: [in: :path, type: :string, required: true]
+  ]
+  @doc responses: [
+    ok: {"Foo document", FooSchema}
+  ]
+  def show, do: :ok
+end
+

--- a/test/support/user_controller_annotated.ex
+++ b/test/support/user_controller_annotated.ex
@@ -12,7 +12,7 @@ defmodule OpenApiSpexTest.UserControllerAnnotated do
     id: [in: :path, type: :string, required: true]
   ]
   @doc responses: [
-    ok: {"Foo document", FooSchema}
+    ok: {"Foo document", "application/json", FooSchema}
   ]
   def show, do: :ok
 end


### PR DESCRIPTION
This is basic support for documenting endpoints via ExDocs tags and documentation
strings. This introduces support for:

- `summary`
- `description`
- `requestBody`
- `parameters`
- `responses`
- `tags`

Close #76