### PR TITLE
Convert string to atom when casting enum schema

### DIFF
--- a/lib/open_api_spex/cast.ex
+++ b/lib/open_api_spex/cast.ex
@@ -122,11 +122,7 @@ defmodule OpenApiSpex.Cast do
   # Enum
   def cast(%__MODULE__{schema: %{enum: enum}} = ctx) when is_list(enum) do
     with {:ok, value} <- cast(%{ctx | schema: %{ctx.schema | enum: nil}}) do
-      if value in enum do
-        {:ok, value}
-      else
-        error(ctx, {:invalid_enum})
-      end
+      OpenApiSpex.Cast.Enum.cast(%{ctx | value: value})
     end
   end
 

--- a/lib/open_api_spex/cast/enum.ex
+++ b/lib/open_api_spex/cast/enum.ex
@@ -10,6 +10,7 @@ defmodule OpenApiSpex.Cast.Enum do
     {:ok, value}
   end
 
+  # Special case: convert binary to atom enum
   def cast(ctx = %Cast{schema: schema = %{enum: [atom_value | tail]}, value: value})
       when is_binary(value) and is_atom(atom_value) do
     if value == to_string(atom_value) do
@@ -19,7 +20,29 @@ defmodule OpenApiSpex.Cast.Enum do
     end
   end
 
+  # Special case: convert string-keyed map to atom-keyed map enum
+  def cast(ctx = %Cast{schema: schema = %{enum: [enum_map = %{} | tail]}, value: value = %{}}) do
+    if maps_equivalent?(value, enum_map) do
+      {:ok, enum_map}
+    else
+      cast(%{ctx | schema: %{schema | enum: tail}})
+    end
+  end
+
   def cast(ctx = %Cast{schema: schema = %{enum: [_ | tail]}}) do
     cast(%{ctx | schema: %{schema | enum: tail}})
   end
+
+  defp maps_equivalent?(x, x), do: true
+
+  # an explicit schema should be used to cast to enum of structs
+  defp maps_equivalent?(_left, %_struct{}), do: false
+
+  defp maps_equivalent?(left = %{}, right = %{}) when map_size(left) == map_size(right) do
+    Enum.all?(right, fn {k, v} ->
+      maps_equivalent?(Map.get(left, to_string(k)), v)
+    end)
+  end
+
+  defp maps_equivalent?(_left, _right), do: false
 end

--- a/lib/open_api_spex/cast/enum.ex
+++ b/lib/open_api_spex/cast/enum.ex
@@ -1,0 +1,25 @@
+defmodule OpenApiSpex.Cast.Enum do
+  @moduledoc false
+  alias OpenApiSpex.Cast
+
+  def cast(%Cast{schema: %{enum: []}} = ctx) do
+    Cast.error(ctx, {:invalid_enum})
+  end
+
+  def cast(%Cast{schema: %{enum: [value | _]}, value: value}) do
+    {:ok, value}
+  end
+
+  def cast(ctx = %Cast{schema: schema = %{enum: [atom_value | tail]}, value: value})
+      when is_binary(value) and is_atom(atom_value) do
+    if value == to_string(atom_value) do
+      {:ok, atom_value}
+    else
+      cast(%{ctx | schema: %{schema | enum: tail}})
+    end
+  end
+
+  def cast(ctx = %Cast{schema: schema = %{enum: [_ | tail]}}) do
+    cast(%{ctx | schema: %{schema | enum: tail}})
+  end
+end

--- a/test/cast/enum_test.exs
+++ b/test/cast/enum_test.exs
@@ -1,0 +1,90 @@
+defmodule OpenApiSpex.Cast.EnumTest do
+  use ExUnit.Case
+  alias OpenApiSpex.{Cast, Schema}
+  alias OpenApiSpex.Cast.Error
+
+  defp cast(ctx), do: Cast.cast(ctx)
+
+  defmodule User do
+    require OpenApiSpex
+    alias __MODULE__
+
+    defstruct [:age]
+
+    def schema() do
+      %OpenApiSpex.Schema{
+        type: :object,
+        required: [:age],
+        properties: %{
+          age: %Schema{type: :integer},
+        },
+        enum: [%User{age: 32}, %User{age: 45}],
+        "x-struct": __MODULE__
+      }
+    end
+  end
+
+  describe "Enum of strings" do
+    setup do
+      {:ok, %{schema: %Schema{type: :string, enum: ["one"]}}}
+    end
+
+    test "error on invalid string", %{schema: schema} do
+      assert {:error, [error]} = cast(schema: schema, value: "two")
+      assert %Error{} = error
+      assert error.reason == :invalid_enum
+    end
+
+    test "OK on valid string", %{schema: schema} do
+      assert {:ok, "one"} = cast(schema: schema, value: "one")
+    end
+  end
+
+  describe "Enum of atoms" do
+    setup do
+      {:ok, %{schema: %Schema{type: :string, enum: [:one, :two, :three]}}}
+    end
+
+    test "string will be converted to atom", %{schema: schema} do
+      assert {:ok, :three} = cast(schema: schema, value: "three")
+    end
+
+    test "error on invalid string", %{schema: schema} do
+      assert {:error, [error]} = cast(schema: schema, value: "four")
+      assert %Error{} = error
+      assert error.reason == :invalid_enum
+    end
+  end
+
+  describe "Enum with explicit schema" do
+    test "converts string keyed map to struct" do
+      assert {:ok, %User{age: 32}} = cast(schema: User.schema(), value: %{"age" => 32})
+    end
+
+    test "Must be a valid enum value" do
+      assert {:error, [error]} = cast(schema: User.schema(), value: %{"age" => 33})
+      assert %Error{} = error
+      assert error.reason == :invalid_enum
+    end
+  end
+
+  describe "Enum without explicit schema" do
+    setup do
+      schema = %Schema{
+        type: :object,
+        enum: [%{age: 55}, %{age: 66}, %{age: 77}]
+      }
+      {:ok, %{schema: schema}}
+    end
+
+    test "casts from string keyed map", %{schema: schema} do
+      assert {:ok, %{age: 55}} = cast(value: %{"age" => 55}, schema: schema)
+    end
+
+    test "value must be a valid enum value", %{schema: schema} do
+      assert {:error, [error]} = cast(value: %{"age" => 56}, schema: schema)
+      assert %Error{} = error
+      assert error.reason == :invalid_enum
+    end
+  end
+end

--- a/test/cast_test.exs
+++ b/test/cast_test.exs
@@ -209,6 +209,16 @@ defmodule OpenApiSpec.CastTest do
       schema = %Schema{type: :string, enum: [:one, :two, :three]}
       assert {:ok, :three} = cast(value: "three", schema: schema)
     end
+
+    test "enum - atom keyed map" do
+      schema = %Schema{
+        type: :object,
+        properties: %{age: %Schema{type: :integer}},
+        enum: [%{age: 10}, %{age: 12}, %{age: 18}]
+      }
+
+      assert {:ok, %{age: 12}} = cast(value: %{"age" => 12}, schema: schema)
+    end
   end
 
   describe "ok/1" do

--- a/test/cast_test.exs
+++ b/test/cast_test.exs
@@ -191,34 +191,6 @@ defmodule OpenApiSpec.CastTest do
 
       assert Error.message_with_path(error2) == "#/3: Invalid integer. Got: string"
     end
-
-    test "enum - invalid" do
-      schema = %Schema{type: :string, enum: ["one"]}
-      assert {:error, [error]} = cast(value: "two", schema: schema)
-
-      assert %Error{} = error
-      assert error.reason == :invalid_enum
-    end
-
-    test "enum - valid" do
-      schema = %Schema{type: :string, enum: ["one"]}
-      assert {:ok, "one"} = cast(value: "one", schema: schema)
-    end
-
-    test "enum - atoms" do
-      schema = %Schema{type: :string, enum: [:one, :two, :three]}
-      assert {:ok, :three} = cast(value: "three", schema: schema)
-    end
-
-    test "enum - atom keyed map" do
-      schema = %Schema{
-        type: :object,
-        properties: %{age: %Schema{type: :integer}},
-        enum: [%{age: 10}, %{age: 12}, %{age: 18}]
-      }
-
-      assert {:ok, %{age: 12}} = cast(value: %{"age" => 12}, schema: schema)
-    end
   end
 
   describe "ok/1" do

--- a/test/cast_test.exs
+++ b/test/cast_test.exs
@@ -204,6 +204,11 @@ defmodule OpenApiSpec.CastTest do
       schema = %Schema{type: :string, enum: ["one"]}
       assert {:ok, "one"} = cast(value: "one", schema: schema)
     end
+
+    test "enum - atoms" do
+      schema = %Schema{type: :string, enum: [:one, :two, :three]}
+      assert {:ok, :three} = cast(value: "three", schema: schema)
+    end
   end
 
   describe "ok/1" do


### PR DESCRIPTION
Resolves #60 

Main changes in this PR are:

 - Supports casting a simple string to an atom in enum list
 - Supports casting a string-keyed map to atom keyed map in enum list
 - Add tests for casting string keyed map to schema struct in enum list (was already supported by existing code)

Casting from a string keyed map to a struct enum without an explicit object schema is disallowed - if a struct is required, then a schema should be defined.