### PR TITLE
Add operation lookup by phoenix {controller, action}

### DIFF
--- a/lib/open_api_spex/plug/cache.ex
+++ b/lib/open_api_spex/plug/cache.ex
@@ -1,0 +1,50 @@
+defmodule OpenApiSpex.Plug.Cache do
+  @moduledoc false
+
+  @callback get(module) :: {OpenApiSpex.OpenApi.t(), map} | nil
+  @callback put(module, {OpenApiSpex.OpenApi.t(), map}) :: :ok
+
+  @spec adapter() :: OpenApiSpex.Plug.AppEnvCache | OpenApiSpex.Plug.PersistentTermCache
+  def adapter do
+    if function_exported?(:persistent_term, :info, 0) do
+      OpenApiSpex.Plug.PersistentTermCache
+    else
+      OpenApiSpex.Plug.AppEnvCache
+    end
+  end
+end
+
+defmodule OpenApiSpex.Plug.AppEnvCache do
+  @moduledoc false
+  @behaviour OpenApiSpex.Plug.Cache
+
+  @impl OpenApiSpex.Plug.Cache
+  def get(spec_module) do
+    Application.get_env(:open_api_spex, spec_module)
+  end
+
+  @impl OpenApiSpex.Plug.Cache
+  def put(spec_module, spec) do
+    :ok = Application.put_env(:open_api_spex, spec_module, spec)
+  end
+end
+
+if function_exported?(:persistent_term, :info, 0) do
+  defmodule OpenApiSpex.Plug.PersistentTermCache do
+    @moduledoc false
+    @behaviour OpenApiSpex.Plug.Cache
+
+    @impl OpenApiSpex.Plug.Cache
+    def get(spec_module) do
+      :persistent_term.get(spec_module)
+    rescue
+      ArgumentError ->
+        nil
+    end
+
+    @impl OpenApiSpex.Plug.Cache
+    def put(spec_module, spec) do
+      :ok = :persistent_term.put(spec_module, spec)
+    end
+  end
+end


### PR DESCRIPTION
This optimization avoids having to call `controller.open_api_operation(action)`
in each call to `CastAndValidate` for phoenix controllers.

The caching behaviour is moved into a separate module `OpenApiSpex.Plug.Cache`, and
updated from` CastAndValidate` the first time a phoenix controller/action
is used to resolve an Operation.

With this optimization in place, it becomes reasonable to use the `@doc` based `Operation` definitions accessed with `Code.fetch_docs/1` at runtime.