### PR TITLE
Resolve schema references within in-line response schemas

### DIFF
--- a/lib/open_api_spex/schema_resolver.ex
+++ b/lib/open_api_spex/schema_resolver.ex
@@ -73,10 +73,10 @@ defmodule OpenApiSpex.SchemaResolver do
     {Enum.reverse(parameters), schemas}
   end
 
-  defp resolve_schema_modules_from_parameter(parameter = %Parameter{schema: schema, content: nil}, schemas) when is_atom(schema) do
-    {ref, new_schemas} = resolve_schema_modules_from_schema(schema, schemas)
-    new_parameter = %{parameter | schema: ref}
-    {new_parameter, new_schemas}
+  defp resolve_schema_modules_from_parameter(parameter = %Parameter{schema: schema, content: nil}, schemas) do
+    {schema, schemas} = resolve_schema_modules_from_schema(schema, schemas)
+    new_parameter = %{parameter | schema: schema}
+    {new_parameter, schemas}
   end
   defp resolve_schema_modules_from_parameter(parameter = %Parameter{schema: nil, content: content = %{}}, schemas) do
     {new_content, schemas} = resolve_schema_modules_from_content(content, schemas)
@@ -97,10 +97,10 @@ defmodule OpenApiSpex.SchemaResolver do
     end)
   end
 
-  defp resolve_schema_modules_from_media_type(media = %MediaType{schema: schema}, schemas) when is_atom(schema) do
-    {ref, new_schemas} = resolve_schema_modules_from_schema(schema, schemas)
-    new_media = %{media | schema: ref}
-    {new_media, new_schemas}
+  defp resolve_schema_modules_from_media_type(media = %MediaType{schema: schema}, schemas) do
+    {schema, schemas} = resolve_schema_modules_from_schema(schema, schemas)
+    new_media = %{media | schema: schema}
+    {new_media, schemas}
   end
   defp resolve_schema_modules_from_media_type(media = %MediaType{}, schemas) do
     {media, schemas}

--- a/test/schema_resolver_test.exs
+++ b/test/schema_resolver_test.exs
@@ -68,6 +68,30 @@ defmodule OpenApiSpex.SchemaResolverTest do
               }
             }
           }
+        },
+        "/api/users/{id}/friends" => %PathItem{
+          get: %Operation{
+            parameters: [
+              %OpenApiSpex.Parameter{
+                name: :id,
+                in: :path,
+                schema: %Schema{type: :integer}
+              }
+            ],
+            responses: %{
+              200 => %Response{
+                description: "Success",
+                content: %{
+                  "application/json" => %MediaType{
+                    schema: %Schema{
+                      type: :array,
+                      items: OpenApiSpexTest.Schemas.User
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -91,5 +115,9 @@ defmodule OpenApiSpex.SchemaResolverTest do
              "CreditCardPaymentDetails" => %Schema{},
              "DirectDebitPaymentDetails" => %Schema{}
            } = resolved.components.schemas
+
+    get_friends = resolved.paths["/api/users/{id}/friends"].get
+    assert %Reference{"$ref": "#/components/schemas/User"} =
+             get_friends.responses[200].content["application/json"].schema.items
   end
 end


### PR DESCRIPTION
Existing code was only resolving schemas when the response itself
was a schema reference, not an inline schema.

Now in-line schemas in responses will be treated the same as
schemas defined in the components.schemas section of the API spec.

Resolves #77 