### PR TITLE
Add extensions field inside of Info object

### DIFF
--- a/lib/open_api_spex/extendable.ex
+++ b/lib/open_api_spex/extendable.ex
@@ -1,0 +1,17 @@
+defprotocol OpenApiSpex.Extendable do
+  @fallback_to_any true
+  def to_map(struct)
+end
+
+defimpl OpenApiSpex.Extendable, for: Any do
+  def to_map(struct), do: Map.from_struct(struct)
+end
+
+defimpl OpenApiSpex.Extendable, for: [OpenApiSpex.Info] do
+  def to_map(struct = %{extensions: e}) do
+    struct
+    |> Map.from_struct()
+    |> Map.delete(:extensions)
+    |> Map.merge(e || %{})
+  end
+end

--- a/lib/open_api_spex/info.ex
+++ b/lib/open_api_spex/info.ex
@@ -10,7 +10,8 @@ defmodule OpenApiSpex.Info do
     :termsOfService,
     :contact,
     :license,
-    :version
+    :version,
+    :extensions
   ]
 
   @typedoc """
@@ -25,6 +26,7 @@ defmodule OpenApiSpex.Info do
     termsOfService: String.t | nil,
     contact: Contact.t | nil,
     license: License.t | nil,
-    version: String.t
+    version: String.t,
+    extensions: %{String.t() => String.t()} | nil,
   }
 end

--- a/lib/open_api_spex/open_api.ex
+++ b/lib/open_api_spex/open_api.ex
@@ -80,10 +80,11 @@ defmodule   OpenApiSpex.OpenApi do
           |> to_json()
         end
         defp to_json(value) when is_map(value) do
+          extensions = to_json(value[:extensions]) || %{}
           value
           |> Stream.map(fn {k,v} -> {to_string(k), to_json(v)} end)
-          |> Stream.filter(fn {_, nil} -> false; _ -> true end)
-          |> Enum.into(%{})
+          |> Stream.filter(fn {_, nil} -> false; {"extensions", _} -> false;_ -> true end)
+          |> Enum.into(extensions)
         end
         defp to_json(value) when is_list(value) do
           Enum.map(value, &to_json/1)

--- a/lib/open_api_spex/open_api.ex
+++ b/lib/open_api_spex/open_api.ex
@@ -4,7 +4,7 @@ defmodule   OpenApiSpex.OpenApi do
   construct an `OpenApiSpex.OpenApi.t` at runtime.
   """
   alias OpenApiSpex.{
-    Info, Server, Paths, Components,
+    Extendable, Info, Server, Paths, Components,
     SecurityRequirement, Tag, ExternalDocumentation,
     OpenApi
   }
@@ -76,15 +76,14 @@ defmodule   OpenApiSpex.OpenApi do
         defp to_json(%Regex{source: source}), do: source
         defp to_json(value = %{__struct__: _}) do
           value
-          |> Map.from_struct()
+          |> Extendable.to_map()
           |> to_json()
         end
         defp to_json(value) when is_map(value) do
-          extensions = to_json(value[:extensions]) || %{}
           value
           |> Stream.map(fn {k,v} -> {to_string(k), to_json(v)} end)
-          |> Stream.filter(fn {_, nil} -> false; {"extensions", _} -> false;_ -> true end)
-          |> Enum.into(extensions)
+          |> Stream.filter(fn {_, nil} -> false; _ -> true end)
+          |> Enum.into(%{})
         end
         defp to_json(value) when is_list(value) do
           Enum.map(value, &to_json/1)

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -1,0 +1,36 @@
+defmodule OpenApiSpex.EncodeTest do
+  use ExUnit.Case
+
+  alias OpenApiSpex.{
+    Info,
+    OpenApi
+  }
+
+  test "Vendor extensions x-logo properly encoded" do
+    spec = %OpenApi{
+      info: %Info{
+        title: "Test",
+        version: "1.0.0",
+        extensions: %{
+          "x-logo" => %{
+            "url" => "https://example.com/logo.png",
+            "backgroundColor" => "#FFFFFF",
+            "altText" => "Example logo"
+          }
+        }
+      },
+      paths: %{}
+    }
+
+    decoded =
+      OpenApiSpex.resolve_schema_modules(spec)
+      |> Jason.encode!()
+      |> Jason.decode!()
+
+    assert decoded["info"]["x-logo"]["url"] == "https://example.com/logo.png"
+    assert decoded["info"]["x-logo"]["backgroundColor"] == "#FFFFFF"
+    assert decoded["info"]["x-logo"]["altText"] == "Example logo"
+
+    assert is_nil(decoded["info"]["extensions"])
+  end
+end


### PR DESCRIPTION
This allows specify [extensions](https://swagger.io/specification/#specificationExtensions).
One of the useful cases could be setting up `x-logo` for [redoc](https://github.com/Rebilly/ReDoc/blob/master/docs/redoc-vendor-extensions.md#x-logo)