### PR TITLE
Add extensions field inside of root object

### DIFF
--- a/lib/open_api_spex/extendable.ex
+++ b/lib/open_api_spex/extendable.ex
@@ -7,7 +7,7 @@ defimpl OpenApiSpex.Extendable, for: Any do
   def to_map(struct), do: Map.from_struct(struct)
 end
 
-defimpl OpenApiSpex.Extendable, for: [OpenApiSpex.Info] do
+defimpl OpenApiSpex.Extendable, for: [OpenApiSpex.Info, OpenApiSpex.OpenApi] do
   def to_map(struct = %{extensions: e}) do
     struct
     |> Map.from_struct()

--- a/lib/open_api_spex/open_api.ex
+++ b/lib/open_api_spex/open_api.ex
@@ -17,7 +17,8 @@ defmodule   OpenApiSpex.OpenApi do
     components: nil,
     security: [],
     tags: [],
-    externalDocs: nil
+    externalDocs: nil,
+    extensions: nil
   ]
 
   @typedoc """
@@ -33,7 +34,8 @@ defmodule   OpenApiSpex.OpenApi do
     components: Components.t | nil,
     security: [SecurityRequirement.t] | nil,
     tags: [Tag.t] | nil,
-    externalDocs: ExternalDocumentation.t | nil
+    externalDocs: ExternalDocumentation.t | nil,
+    extensions: %{String.t() => any()} | nil,
   }
 
   @doc """

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -33,4 +33,36 @@ defmodule OpenApiSpex.EncodeTest do
 
     assert is_nil(decoded["info"]["extensions"])
   end
+
+  test "Vendor extensions x-tagGroups properly encoded" do
+    spec = %OpenApi{
+      info: %Info{
+        title: "Test",
+        version: "1.0.0"
+      },
+      extensions: %{
+        "x-tagGroups" => [
+          %{
+            "name" => "Methods",
+            "tags" => [
+              "Search",
+              "Fetch",
+              "Delete"
+            ]
+          }
+        ]
+      },
+      paths: %{}
+    }
+
+    decoded =
+      OpenApiSpex.resolve_schema_modules(spec)
+      |> Jason.encode!()
+      |> Jason.decode!()
+
+    assert hd(decoded["x-tagGroups"])["name"] == "Methods"
+    assert hd(decoded["x-tagGroups"])["tags"] == ["Search", "Fetch", "Delete"]
+
+    assert is_nil(decoded["extensions"])
+  end
 end


### PR DESCRIPTION
This allows specify [extensions](https://swagger.io/specification/#specificationExtensions).
One of the useful cases could be setting up `x-tagGroups` for [redoc](https://github.com/Redocly/redoc/blob/master/docs/redoc-vendor-extensions.md#x-tagGroups)