### PR TITLE
Added Server.from_endpoint/1 which obtains url (including :path) directly from Endpoint

### DIFF
--- a/lib/open_api_spex/open_api.ex
+++ b/lib/open_api_spex/open_api.ex
@@ -46,7 +46,7 @@ defmodule   OpenApiSpex.OpenApi do
         %OpenApi{
           servers: [
             # Populate the Server info from a phoenix endpoint
-            Server.from_endpoint(MyAppWeb.Endpoint, otp_app: :my_app)
+            Server.from_endpoint(MyAppWeb.Endpoint)
           ],
           info: %Info{
             title: "My App",

--- a/lib/open_api_spex/server.ex
+++ b/lib/open_api_spex/server.ex
@@ -25,16 +25,11 @@ defmodule OpenApiSpex.Server do
   @doc """
   Builds a Server from a phoenix Endpoint module
   """
-  @spec from_endpoint(module, [otp_app: atom]) :: t
-  def from_endpoint(endpoint, opts) do
-    app = opts[:otp_app]
-    url_config = Application.get_env(app, endpoint, []) |> Keyword.get(:url, [])
-    scheme = Keyword.get(url_config, :scheme, "http")
-    host = Keyword.get(url_config, :host, "localhost")
-    port = Keyword.get(url_config, :port, "80")
-    path = Keyword.get(url_config, :path, "/")
+  @spec from_endpoint(module) :: t
+  def from_endpoint(endpoint) do
+    uri = apply(endpoint, :struct_url, [])
     %Server{
-      url: "#{scheme}://#{host}:#{port}#{path}"
+      url: URI.to_string(uri)
     }
   end
 end

--- a/lib/open_api_spex/server.ex
+++ b/lib/open_api_spex/server.ex
@@ -25,6 +25,15 @@ defmodule OpenApiSpex.Server do
   @doc """
   Builds a Server from a phoenix Endpoint module
   """
+  @deprecated "Use from_endpoint/1 instead"
+  @spec from_endpoint(module, ignored :: any()) :: t
+  def from_endpoint(endpoint, _opts) do
+    from_endpoint(endpoint)
+  end
+
+  @doc """
+  Builds a Server from a phoenix Endpoint module
+  """
   @spec from_endpoint(module) :: t
   def from_endpoint(endpoint) do
     uri = apply(endpoint, :struct_url, [])

--- a/test/server_test.exs
+++ b/test/server_test.exs
@@ -3,17 +3,11 @@ defmodule OpenApiSpex.ServerTest do
   alias OpenApiSpex.{Server}
   alias OpenApiSpexTest.Endpoint
 
+  @otp_app :open_api_spex_test
+
   describe "Server" do
-    test "from_endpoint" do
-      Application.put_env(:open_api_spex_test, Endpoint, [
-        url: [
-          scheme: "https",
-          host: "example.com",
-          port: 1234,
-          path: "/api/v1/"
-        ]
-      ])
-      Endpoint.start_link()
+    test "from_endpoint/1" do
+      setup_endpoint()
 
       server = Server.from_endpoint(Endpoint)
 
@@ -21,7 +15,27 @@ defmodule OpenApiSpex.ServerTest do
         url: "https://example.com:1234/api/v1/"
       } = server
     end
+
+    test "from_endpoint/2" do
+      setup_endpoint()
+
+      expected = Server.from_endpoint(Endpoint)
+      actual = Server.from_endpoint(Endpoint, [opt_app: @otp_app])
+
+      assert ^expected = actual
+    end
   end
 
+  defp setup_endpoint do
+    Application.put_env(@otp_app, Endpoint, [
+      url: [
+        scheme: "https",
+        host: "example.com",
+        port: 1234,
+        path: "/api/v1/"
+      ]
+    ])
+    Endpoint.start_link()
+  end
 end
 

--- a/test/server_test.exs
+++ b/test/server_test.exs
@@ -1,15 +1,21 @@
 defmodule OpenApiSpex.ServerTest do
   use ExUnit.Case
   alias OpenApiSpex.{Server}
-  alias OpenApiSpexText.Endpoint
+  alias OpenApiSpexTest.Endpoint
 
   describe "Server" do
     test "from_endpoint" do
-      Application.put_env(:phoenix_swagger, Endpoint, [
-        url: [host: "example.com", port: 1234, path: "/api/v1/", scheme: :https],
+      Application.put_env(:open_api_spex_test, Endpoint, [
+        url: [
+          scheme: "https",
+          host: "example.com",
+          port: 1234,
+          path: "/api/v1/"
+        ]
       ])
+      Endpoint.start_link()
 
-      server = Server.from_endpoint(Endpoint, otp_app: :phoenix_swagger)
+      server = Server.from_endpoint(Endpoint)
 
       assert %{
         url: "https://example.com:1234/api/v1/"
@@ -18,3 +24,4 @@ defmodule OpenApiSpex.ServerTest do
   end
 
 end
+

--- a/test/support/endpoint.ex
+++ b/test/support/endpoint.ex
@@ -1,0 +1,4 @@
+defmodule OpenApiSpexTest.Endpoint do
+  use Phoenix.Endpoint, otp_app: :open_api_spex_test
+end
+


### PR DESCRIPTION
Addresses #110

* Removed `Server.from_endpoint/2` as opts for opt_app no required.
* `Endpoint.url/0` does not append :path, therefore `Endpoint.struct_url/0` used.

Does the Server URL need to have the path appended?  If not `Endpoint.url/0` can be used directly.

This patch will enable better support for Endpoints which perform runtime configuration within the `Endpoint.init/2` callback, where host, port, path etc may not be present within mix config that was relied upon by `Server.from_endpoint/2`.