### PR TITLE
Allow OpenApiSpex.schema() to take struct

### DIFF
--- a/lib/open_api_spex.ex
+++ b/lib/open_api_spex.ex
@@ -149,7 +149,10 @@ defmodule OpenApiSpex do
     quote do
       @compile {:report_warnings, false}
       @behaviour OpenApiSpex.Schema
-      @schema struct(OpenApiSpex.Schema, Map.put(unquote(body), :"x-struct", __MODULE__))
+      @schema struct(
+                OpenApiSpex.Schema,
+                Map.put(Map.delete(unquote(body), :__struct__), :"x-struct", __MODULE__)
+              )
       def schema, do: @schema
 
       @derive Enum.filter([Poison.Encoder, Jason.Encoder], &Code.ensure_loaded?/1)

--- a/test/schema_construction_test.exs
+++ b/test/schema_construction_test.exs
@@ -1,0 +1,15 @@
+defmodule OpenApiSpex.SchemaConstructionTest do
+  use ExUnit.Case
+
+  defmodule SchemaCreate do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%OpenApiSpex.Schema{type: :string})
+  end
+
+  test "calling schema() macro works with a struct" do
+    assert %OpenApiSpex.Schema{"x-struct": module, type: schema_type} = SchemaCreate.schema()
+    assert schema_type == :string
+    assert module == SchemaCreate
+  end
+end


### PR DESCRIPTION
Functions that dynamically construct a Schema can have their result passed
as-is to OpenApiSpex.schema without doing Map.from_struct. The change is to
Map.delete the __struct__ atom - which will do nothing on map and convert a
struct to map otherwise.