### PR TITLE
Add support for phoenix 1.4.7 route.plug_opts

### DIFF
--- a/lib/open_api_spex/operation.ex
+++ b/lib/open_api_spex/operation.ex
@@ -55,8 +55,20 @@ defmodule OpenApiSpex.Operation do
   Constructs an Operation struct from the plug and opts specified in the given route
   """
   @spec from_route(PathItem.route) :: t
-  def from_route(route) do
-    from_plug(route.plug, route.opts)
+  def from_route(route)
+
+  def from_route(route = %_{}) do
+    route
+    |> Map.from_struct()
+    |> from_route()
+  end
+
+  def from_route(%{plug: plug, plug_opts: opts}) do
+    from_plug(plug, opts)
+  end
+
+  def from_route(%{plug: plug, opts: opts}) do
+    from_plug(plug, opts)
   end
 
   @doc """

--- a/lib/open_api_spex/path_item.ex
+++ b/lib/open_api_spex/path_item.ex
@@ -48,7 +48,9 @@ defmodule OpenApiSpex.PathItem do
   Represents a route from in a Plug/Phoenix application.
   Eg from the generated `__routes__` function in a Phoenix.Router module.
   """
-  @type route :: %{verb: atom, plug: atom, opts: any}
+  @type route ::
+    %{verb: atom, plug: atom, opts: any} |
+    %{verb: atom, plug: atom, plug_opts: any}
 
   @doc """
   Builds a PathItem struct from a list of routes that share a path.

--- a/test/operation_test.exs
+++ b/test/operation_test.exs
@@ -4,8 +4,28 @@ defmodule OpenApiSpex.OperationTest do
   alias OpenApiSpexTest.UserController
 
   describe "Operation" do
-    test "from_route" do
-      route = %{plug: UserController, opts: :show}
+    test "from_route %Phoenix.Router.Route{}" do
+      plug = UserController
+      plug_opts = :show
+
+      route = Phoenix.Router.Route.build(
+        _line = nil,
+        _kind = :match,
+        _verb = :atom,
+        _path = nil,
+        _host = nil,
+        plug,
+        plug_opts,
+        _helper = nil,
+        _pipe_through = [],
+        _private = %{},
+        _assigns = %{}
+      )
+      assert Operation.from_route(route) == UserController.show_operation()
+    end
+
+    test "from_route ~ phoenix v1.4.7+" do
+      route = %{plug: UserController, plug_opts: :show}
       assert Operation.from_route(route) == UserController.show_operation()
     end
 


### PR DESCRIPTION
Phoenix 1.4.7 changed `Phoenix.Router.Route` key `opts` to `plug_opts`.
https://github.com/phoenixframework/phoenix/commit/73949e7a47dad8ed427fc49ab0f1a431f70d6351

This patch addresses the issue caused when open_api_spex constructs an Operation struct from the route, specifically the plug and opts specified in the given route.  I have added tests to cover the new functionality.

I would suggest however that some thought be put into generic, early extraction of the keys from the route struct.  I think have a pop at this I think.

The Phoenix 1.4.7 release will raise this issue with users of this library due to the internal API dependency, so I pushed this patch quickly.