### PR TITLE
Handle missing or invalid content-type header

### DIFF
--- a/lib/open_api_spex/cast/error.ex
+++ b/lib/open_api_spex/cast/error.ex
@@ -17,6 +17,8 @@ defmodule OpenApiSpex.Cast.Error do
   @type min_length_error :: {:min_length, non_neg_integer()}
   @type minimum_error :: {:minimum, integer(), integer()}
   @type missing_field_error :: {:missing_field, String.t() | atom()}
+  @type missing_header_error :: {:missing_header, String.t() | atom()}
+  @type invalid_header_error :: {:invalid_header, String.t() | atom()}
   @type multiple_of_error :: {:multiple_of, non_neg_integer(), non_neg_integer()}
   @type no_value_for_discriminator_error :: {:no_value_for_discriminator, String.t() | atom()}
   @type invalid_discriminator_value_error :: {:invalid_discriminator_value, String.t() | atom()}
@@ -43,6 +45,8 @@ defmodule OpenApiSpex.Cast.Error do
           | :min_length
           | :minimum
           | :missing_field
+          | :missing_header
+          | :invalid_header
           | :multiple_of
           | :no_value_for_discriminator
           | :null_value
@@ -68,6 +72,8 @@ defmodule OpenApiSpex.Cast.Error do
           | min_length_error()
           | minimum_error()
           | missing_field_error()
+          | missing_header_error()
+          | invalid_header_error()
           | multiple_of_error()
           | no_value_for_discriminator_error()
           | null_value_error()
@@ -198,6 +204,16 @@ defmodule OpenApiSpex.Cast.Error do
     |> add_context_fields(ctx)
   end
 
+  def new(ctx, {:missing_header, name}) do
+    %__MODULE__{reason: :missing_header, name: name}
+    |> add_context_fields(ctx)
+  end
+
+  def new(ctx, {:invalid_header, name}) do
+    %__MODULE__{reason: :invalid_header, name: name}
+    |> add_context_fields(ctx)
+  end
+
   def new(ctx, {:no_value_for_discriminator, field}) do
     %__MODULE__{reason: :no_value_for_discriminator, name: field}
     |> add_context_fields(ctx)
@@ -319,6 +335,14 @@ defmodule OpenApiSpex.Cast.Error do
 
   def message(%{reason: :missing_field, name: name}) do
     "Missing field: #{name}"
+  end
+
+  def message(%{reason: :missing_header, name: name}) do
+    "Missing header: #{name}"
+  end
+
+  def message(%{reason: :invalid_header, name: name, value: value}) do
+    "Invalid value for header: #{name}. Got: #{inspect(value)}"
   end
 
   def message(%{reason: :max_properties, meta: meta}) do

--- a/test/operation2_test.exs
+++ b/test/operation2_test.exs
@@ -151,6 +151,31 @@ defmodule OpenApiSpex.Operation2Test do
       assert error.name == :name
     end
 
+    test "validate missing content-type header for required requestBody" do
+      conn = :post |> Plug.Test.conn("/api/users/") |> Plug.Conn.fetch_query_params()
+      operation = OperationFixtures.create_user()
+      assert {:error, [%Error{reason: :missing_header, name: "content-type"}]} = Operation2.cast(
+        operation,
+        conn,
+        nil,
+        SchemaFixtures.schemas()
+      )
+    end
+
+    test "validate invalid content-type header for required requestBody" do
+      conn =
+        create_conn(%{})
+        |> Plug.Conn.put_req_header("content-type", "text/html")
+
+      operation = OperationFixtures.create_user()
+      assert {:error, [%Error{reason: :invalid_header, name: "content-type"}]} = Operation2.cast(
+        operation,
+        conn,
+        "text/html",
+        SchemaFixtures.schemas()
+      )
+    end
+
     test "validate invalid value for integer range" do
       parameter =
         Operation.parameter(


### PR DESCRIPTION
Fixes #109 

On missing content-type for required requestBody, errors with `missing_header`.
On content-type for which there is no schema defined, errors with `invalid_header`.