### PR TITLE
Use default from schema when build Elixir structure

### DIFF
--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -841,7 +841,8 @@ defmodule OpenApiSpex.Schema do
   included in the `allOf` list.
   """
   def properties(schema = %Schema{type: :object, properties: properties = %{}}) do
-    Map.keys(properties) ++ properties(%{schema | properties: nil})
+    for({name, property} <- properties, do: {name, default(property)}) ++
+      properties(%{schema | properties: nil})
   end
 
   def properties(%Schema{allOf: schemas}) when is_list(schemas) do
@@ -853,4 +854,7 @@ defmodule OpenApiSpex.Schema do
   end
 
   def properties(_), do: []
+
+  defp default(schema_module) when is_atom(schema_module), do: schema_module.schema().default
+  defp default(%{default: default}), do: default
 end

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -437,4 +437,24 @@ defmodule OpenApiSpex.SchemaTest do
       assert :ok = Schema.validate(schema, "bla", %{})
     end
   end
+
+  describe "Default property value" do
+    test "Available in structure" do
+      size = %Schemas.Size{}
+      assert "cm" == size.unit
+      assert 100 == size.value
+    end
+
+    test "Available after cast" do
+      api_spec = ApiSpec.spec()
+      schemas = api_spec.components.schemas
+      size = Map.fetch!(schemas, "Size")
+
+      assert {:ok, %Schemas.Size{value: 100, unit: "cm"}} ==
+               Schema.cast(size, %{}, schemas)
+
+      assert {:ok, %Schemas.Size{value: 110, unit: "cm"}} ==
+               Schema.cast(size, %{value: 110}, schemas)
+    end
+  end
 end

--- a/test/support/api_spec.ex
+++ b/test/support/api_spec.ex
@@ -7,7 +7,7 @@ defmodule OpenApiSpexTest.ApiSpec do
   def spec() do
     %OpenApi{
       servers: [
-        %Server{url: "http://example.com"},
+        %Server{url: "http://example.com"}
       ],
       info: %Info{
         title: "A",
@@ -24,7 +24,14 @@ defmodule OpenApiSpexTest.ApiSpec do
       },
       components: %Components{
         schemas:
-          for schemaMod <- [Schemas.Pet, Schemas.Cat, Schemas.Dog, Schemas.CatOrDog], into: %{} do
+          for schemaMod <- [
+                Schemas.Pet,
+                Schemas.Cat,
+                Schemas.Dog,
+                Schemas.CatOrDog,
+                Schemas.Size
+              ],
+              into: %{} do
             schema = schemaMod.schema()
             {schema.title, schema}
           end

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -2,6 +2,19 @@ defmodule OpenApiSpexTest.Schemas do
   require OpenApiSpex
   alias OpenApiSpex.Schema
 
+  defmodule Size do
+    OpenApiSpex.schema(%{
+      title: "Size",
+      description: "A size of a pet",
+      type: :object,
+      properties: %{
+        unit: %Schema{type: :string, description: "SI unit name", default: "cm"},
+        value: %Schema{type: :integer, description: "Size in given unit", default: 100}
+      },
+      required: [:unit, :value]
+    })
+  end
+
   defmodule User do
     OpenApiSpex.schema(%{
       title: "User",


### PR DESCRIPTION
There is an ability to set default value for a schema.
According to the specification:

    The default value represents what would be assumed by the consumer
    of the input as the value of the schema if one is not provided.

With the changes of this commit default value will be used when build Elixir structure.