### PR TITLE
Handle missing content type for requests with bodies

### DIFF
--- a/test/plug/cast_and_validate/custom_error_user_controller_test.exs
+++ b/test/plug/cast_and_validate/custom_error_user_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule OpenApiSpex.Plug.CastAndValidate.CustomErrorUserControllerTest do
   use ExUnit.Case, async: true
 
-  describe "query params - param with custom error handling" do
+  describe "index - query params - param with custom error handling" do
     test "Valid Param" do
       conn =
         :get
@@ -34,6 +34,52 @@ defmodule OpenApiSpex.Plug.CastAndValidate.CustomErrorUserControllerTest do
 
       assert conn.status == 400
       assert conn.resp_body == "Unexpected field: inValid2"
+    end
+  end
+
+  describe "create" do
+    @tag :capture_log
+    test "missing content-type" do
+      body = "{}"
+
+      conn =
+        :post
+        |> Plug.Test.conn("/api/cast_and_validate_test/custom_error_users", body)
+        |> OpenApiSpexTest.Router.call([])
+
+      assert conn.status == 400
+
+      assert conn.resp_body == "missing_content_type"
+    end
+
+    @tag :capture_log
+    test "validation error" do
+      body = "{}"
+
+      conn =
+        :post
+        |> Plug.Test.conn("/api/cast_and_validate_test/custom_error_users", body)
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> OpenApiSpexTest.Router.call([])
+
+      assert conn.status == 400
+
+      assert conn.resp_body == "Missing field: user"
+    end
+
+    test "happy path" do
+      body = "{\"user\": {\"name\": \"Jane\", \"email\": \"test@example.com\"}}"
+
+      conn =
+        :post
+        |> Plug.Test.conn("/api/cast_and_validate_test/custom_error_users", body)
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> OpenApiSpexTest.Router.call([])
+
+      assert conn.status == 201
+
+      assert conn.resp_body ==
+               "{\"data\":[{\"updated_at\":null,\"name\":\"joe user\",\"inserted_at\":null,\"id\":123,\"email\":\"joe@gmail.com\"}]}"
     end
   end
 end

--- a/test/plug/cast_and_validate/custom_error_user_controller_test.exs
+++ b/test/plug/cast_and_validate/custom_error_user_controller_test.exs
@@ -39,7 +39,7 @@ defmodule OpenApiSpex.Plug.CastAndValidate.CustomErrorUserControllerTest do
 
   describe "create" do
     @tag :capture_log
-    test "missing content-type" do
+    test "missing content-type when body is required" do
       body = "{}"
 
       conn =

--- a/test/support/cast_and_validate/custom_error_user_controller.ex
+++ b/test/support/cast_and_validate/custom_error_user_controller.ex
@@ -53,4 +53,38 @@ defmodule OpenApiSpexTest.CastAndValidate.CustomErrorUserController do
       ]
     })
   end
+
+  def create_operation() do
+    import Operation
+
+    %Operation{
+      tags: ["users"],
+      summary: "Create user",
+      operationId: "UserController.create",
+      requestBody:
+        Operation.request_body(
+          "Create User request body",
+          "application/json",
+          Schemas.UserRequest,
+          required: true
+        ),
+      responses: %{
+        200 => response("User Response", "application/json", Schemas.UserResponse)
+      }
+    }
+  end
+
+  def create(conn, _params) do
+    conn
+    |> put_status(:created)
+    |> json(%Schemas.UsersResponse{
+      data: [
+        %Schemas.User{
+          id: 123,
+          name: "joe user",
+          email: "joe@gmail.com"
+        }
+      ]
+    })
+  end
 end

--- a/test/support/cast_and_validate/custom_error_user_controller.ex
+++ b/test/support/cast_and_validate/custom_error_user_controller.ex
@@ -32,7 +32,7 @@ defmodule OpenApiSpexTest.CastAndValidate.CustomErrorUserController do
       tags: ["users"],
       summary: "List users",
       description: "List all useres",
-      operationId: "UserController.index",
+      operationId: "CustomErrorUserController.index",
       parameters: [
         parameter(:validParam, :query, :boolean, "Valid Param", example: true)
       ],
@@ -60,7 +60,7 @@ defmodule OpenApiSpexTest.CastAndValidate.CustomErrorUserController do
     %Operation{
       tags: ["users"],
       summary: "Create user",
-      operationId: "UserController.create",
+      operationId: "CustomErrorUserController.create",
       requestBody:
         Operation.request_body(
           "Create User request body",

--- a/test/support/cast_and_validate_user_controller.ex
+++ b/test/support/cast_and_validate_user_controller.ex
@@ -19,7 +19,7 @@ defmodule OpenApiSpexTest.CastAndValidateUserController do
       tags: ["users"],
       summary: "Show user",
       description: "Show a user by ID",
-      operationId: "UserController.show",
+      operationId: "CastAndValidateUserController.show",
       parameters: [
         parameter(:id, :path, :integer, "User ID", example: 123, minimum: 1)
       ],
@@ -46,7 +46,7 @@ defmodule OpenApiSpexTest.CastAndValidateUserController do
       tags: ["users"],
       summary: "List users",
       description: "List all useres",
-      operationId: "UserController.index",
+      operationId: "CastAndValidateUserController.index",
       parameters: [
         parameter(:validParam, :query, :boolean, "Valid Param", example: true)
       ],
@@ -75,9 +75,12 @@ defmodule OpenApiSpexTest.CastAndValidateUserController do
       tags: ["users"],
       summary: "Create user",
       description: "Create a user",
-      operationId: "UserController.create",
+      operationId: "CastAndValidateUserController.create",
       parameters: [],
-      requestBody: request_body("The user attributes", "application/json", Schemas.UserRequest),
+      requestBody:
+        request_body("The user attributes", "application/json", Schemas.UserRequest,
+          required: true
+        ),
       responses: %{
         201 => response("User", "application/json", Schemas.UserResponse)
       }
@@ -97,11 +100,12 @@ defmodule OpenApiSpexTest.CastAndValidateUserController do
       tags: ["users"],
       summary: "Update contact info",
       description: "Update contact info",
-      operationId: "UserController.contact_info",
+      operationId: "CastAndValidateUserController.contact_info",
       parameters: [
         parameter(:id, :path, :integer, "user ID")
       ],
-      requestBody: request_body("Contact info", "application/json", Schemas.ContactInfo),
+      requestBody:
+        request_body("Contact info", "application/json", Schemas.ContactInfo, required: true),
       responses: %{
         200 => %OpenApiSpex.Response{
           description: "OK"
@@ -111,7 +115,9 @@ defmodule OpenApiSpexTest.CastAndValidateUserController do
   end
 
   # POST /contact_info
-  def contact_info(conn = %{body_params: %Schemas.ContactInfo{}}, %{id: id}) do
+  def contact_info(conn, %{id: id}) do
+    %Schemas.ContactInfo{} = Map.get(conn, :body_params)
+
     conn
     |> put_status(200)
     |> json(%{id: id})
@@ -124,7 +130,7 @@ defmodule OpenApiSpexTest.CastAndValidateUserController do
       tags: ["users"],
       summary: "Show user payment details",
       description: "Shows a users payment details",
-      operationId: "UserController.payment_details",
+      operationId: "CastAndValidateUserController.payment_details",
       parameters: [
         parameter(:id, :path, :integer, "User ID", example: 123, minimum: 1)
       ],
@@ -162,7 +168,7 @@ defmodule OpenApiSpexTest.CastAndValidateUserController do
       tags: ["EntityWithDict"],
       summary: "Create an EntityWithDict",
       description: "Create an EntityWithDict",
-      operationId: "UserController.create_entity",
+      operationId: "CastAndValidateUserController.create_entity",
       parameters: [],
       requestBody: request_body("Entity attributes", "application/json", Schemas.EntityWithDict),
       responses: %{

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -23,7 +23,9 @@ defmodule OpenApiSpexTest.Router do
       post "/users", CastAndValidateUserController, :create
       post "/users/:id/contact_info", CastAndValidateUserController, :contact_info
       post "/users/:id/payment_details", CastAndValidateUserController, :payment_details
-      resources "/custom_error_users", CastAndValidate.CustomErrorUserController, only: [:index]
+
+      resources "/custom_error_users", CastAndValidate.CustomErrorUserController,
+        only: [:index, :create]
     end
 
     get "/users/:id/payment_details", UserController, :payment_details

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -119,6 +119,7 @@ defmodule OpenApiSpexTest.Schemas do
       properties: %{
         user: User
       },
+      required: [:user],
       example: %{
         "user" => %{
           "name" => "Joe User",


### PR DESCRIPTION
Resolves #109

When an endpoint accepts a `requestBody` and it is marked as `required`, but there's no `content-type` header in the request, respond with a validation error. Otherwise, if the `requestBody` is not marked as `required`, skip casting and validating of the request body.