### PR TITLE
Update minimum elixir version to 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: elixir
 
 elixir:
-    - 1.6
     - 1.7
     - 1.8
+    - 1.9
 
 otp_release:
     - 20.3
-    - 21.0
     - 21.2
+    - 22.0
 
 script:
     - mix compile --warnings-as-errors

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule OpenApiSpex.Mixfile do
     [
       app: :open_api_spex,
       version: @version,
-      elixir: "~> 1.6",
+      elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       description: description(),


### PR DESCRIPTION
Travis matrix now includes elixir 1.7-1.9 and OTP 20 - 22