### PR TITLE
Cast upload

### DIFF
--- a/lib/open_api_spex/cast/string.ex
+++ b/lib/open_api_spex/cast/string.ex
@@ -29,6 +29,10 @@ defmodule OpenApiSpex.Cast.String do
         Cast.error(ctx, {:invalid_format, :"date-time"})
     end
   end
+  
+  def cast(%{value: value = %Plug.Upload{}, schema: %{format: :binary}}) do
+    {:ok, value}
+  end
 
   def cast(%{value: value} = ctx) when is_binary(value) do
     apply_validation(ctx, @schema_fields)

--- a/lib/open_api_spex/cast/string.ex
+++ b/lib/open_api_spex/cast/string.ex
@@ -29,7 +29,7 @@ defmodule OpenApiSpex.Cast.String do
         Cast.error(ctx, {:invalid_format, :"date-time"})
     end
   end
-  
+
   def cast(%{value: value = %Plug.Upload{}, schema: %{format: :binary}}) do
     {:ok, value}
   end

--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -324,6 +324,10 @@ defmodule OpenApiSpex.Schema do
       error = {:error, _reason} -> error
     end
   end
+  
+  def cast(%Schema{type: :string, format: :binary}, %Plug.Upload{} = value, _schemas) do
+    {:ok, value}
+  end
 
   def cast(%Schema{type: :string}, value, _schemas) when is_binary(value), do: {:ok, value}
 
@@ -555,6 +559,10 @@ defmodule OpenApiSpex.Schema do
   end
 
   def validate(%Schema{type: :string, format: :"date-time"}, %DateTime{}, _path, _schemas) do
+    :ok
+  end
+  
+  def validate(%Schema{type: :string, format: :binary}, %Plug.Upload{}, _path, _schemas) do
     :ok
   end
 

--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -324,7 +324,7 @@ defmodule OpenApiSpex.Schema do
       error = {:error, _reason} -> error
     end
   end
-  
+
   def cast(%Schema{type: :string, format: :binary}, %Plug.Upload{} = value, _schemas) do
     {:ok, value}
   end
@@ -561,7 +561,7 @@ defmodule OpenApiSpex.Schema do
   def validate(%Schema{type: :string, format: :"date-time"}, %DateTime{}, _path, _schemas) do
     :ok
   end
-  
+
   def validate(%Schema{type: :string, format: :binary}, %Plug.Upload{}, _path, _schemas) do
     :ok
   end

--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,7 @@ defmodule OpenApiSpex.Mixfile do
       {:poison, "~> 3.1", optional: true},
       {:jason, "~> 1.0", optional: true},
       {:plug, "~> 1.7"},
-      {:phoenix, "~> 1.3", only: :test},
+      {:phoenix, "~> 1.3", only: [:dev, :test]},
       {:ex_doc, "~> 0.19", only: :dev, runtime: false},
       {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false}
     ]

--- a/test/cast/string_test.exs
+++ b/test/cast/string_test.exs
@@ -44,6 +44,13 @@ defmodule OpenApiSpex.CastStringTest do
       assert error.format == :date
     end
 
+    test "file upload" do
+      schema = %Schema{type: :string, format: :binary}
+      upload = %Plug.Upload{}
+      assert {:ok, %Plug.Upload{}} = cast(value: upload, schema: schema)
+      # There is no error case when a regular string is passed
+    end
+
     # Note: we measure length of string after trimming leading and trailing whitespace
     test "minLength" do
       schema = %Schema{type: :string, minLength: 1}
@@ -73,10 +80,10 @@ defmodule OpenApiSpex.CastStringTest do
     end
 
     test "minLength and pattern" do
-      schema = %Schema{type: :string, minLength: 1, pattern: ~r/\d-\d/ }
+      schema = %Schema{type: :string, minLength: 1, pattern: ~r/\d-\d/}
       assert {:error, errors} = cast(value: "", schema: schema)
       assert length(errors) == 2
-      assert Enum.map(errors, &(&1.reason)) == [:invalid_format, :min_length]
+      assert Enum.map(errors, & &1.reason) == [:invalid_format, :min_length]
     end
   end
 end


### PR DESCRIPTION
Replaces #121, #122.

The Open API docs describe how file uploads can be represented in an Open API schema:
https://swagger.io/docs/specification/describing-request-body/file-upload/

This PR lets open_api_spex support file uploads in the manner described by the docs.