### PR TITLE
Support "$ref" in operation's parameters

### DIFF
--- a/lib/open_api_spex.ex
+++ b/lib/open_api_spex.ex
@@ -40,7 +40,7 @@ defmodule OpenApiSpex do
         conn = %Plug.Conn{},
         content_type \\ nil
       ) do
-    Operation2.cast(operation, conn, content_type, spec.components.schemas)
+    Operation2.cast(operation, conn, content_type, spec.components)
   end
 
   @doc """

--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -1,22 +1,29 @@
 defmodule OpenApiSpex.CastParameters do
   @moduledoc false
-  alias OpenApiSpex.{Cast, Operation, Parameter, Schema}
+  alias OpenApiSpex.{Cast, Operation, Parameter, Schema, Reference, Components}
   alias OpenApiSpex.Cast.{Error, Object}
   alias Plug.Conn
 
-  @spec cast(Plug.Conn.t(), Operation.t(), Schema.schemas()) ::
+  @spec cast(Plug.Conn.t(), Operation.t(), Components.t()) ::
           {:error, [Error.t()]} | {:ok, Conn.t()}
-  def cast(conn, operation, schemas) do
+  def cast(conn, operation, components) do
     # Taken together as a set, operation parameters are similar to an object schema type.
     # Convert parameters to an object schema, then delegate to `Cast.Object.cast/1`
 
+    # Operation's parameters list may include references - resolving here
+    resolved_parameters =
+      Enum.map(operation.parameters, fn
+        ref = %Reference{} -> Reference.resolve_parameter(ref, components.parameters)
+        param = %Parameter{} -> param
+      end)
+
     properties =
-      operation.parameters
+      resolved_parameters
       |> Enum.map(fn parameter -> {parameter.name, Parameter.schema(parameter)} end)
       |> Map.new()
 
     required =
-      operation.parameters
+      resolved_parameters
       |> Enum.filter(& &1.required)
       |> Enum.map(& &1.name)
 
@@ -28,7 +35,7 @@ defmodule OpenApiSpex.CastParameters do
 
     params = Map.merge(conn.path_params, conn.query_params)
 
-    ctx = %Cast{value: params, schema: object_schema, schemas: schemas}
+    ctx = %Cast{value: params, schema: object_schema, schemas: components.schemas}
 
     with {:ok, params} <- Object.cast(ctx) do
       {:ok, %{conn | params: params}}

--- a/lib/open_api_spex/discriminator.ex
+++ b/lib/open_api_spex/discriminator.ex
@@ -52,7 +52,7 @@ defmodule OpenApiSpex.Discriminator do
   end
 
   @spec lookup_schema(%{String.t => Schema.t}, String.t) :: {:ok, Schema.t} | {:error, String.t}
-  defp lookup_schema(schemas, "#components/schemas/" <> name) do
+  defp lookup_schema(schemas, "#/components/schemas/" <> name) do
     lookup_schema(schemas, name)
   end
   defp lookup_schema(schemas, name) do

--- a/lib/open_api_spex/parameter.ex
+++ b/lib/open_api_spex/parameter.ex
@@ -64,6 +64,8 @@ defmodule OpenApiSpex.Parameter do
     content: %{String.t => MediaType.t} | nil
   }
 
+  @type parameters :: %{String.t =>  t | Reference.t} | nil
+
   @doc """
   Sets the schema for a parameter from a simple type, reference or Schema
   """

--- a/lib/open_api_spex/reference.ex
+++ b/lib/open_api_spex/reference.ex
@@ -32,4 +32,7 @@ defmodule OpenApiSpex.Reference do
   """
   @spec resolve_schema(Reference.t, %{String.t => Schema.t}) :: Schema.t | nil
   def resolve_schema(%Reference{"$ref": "#/components/schemas/" <> name}, schemas), do: schemas[name]
+
+  @spec resolve_parameter(Reference.t, %{String.t => Parameter.t}) :: Parameter.t | nil
+  def resolve_parameter(%Reference{"$ref": "#/components/parameters/" <> name}, parameters), do: parameters[name]
 end

--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -27,7 +27,7 @@ defmodule OpenApiSpex.Schema do
             required: [:name],
             properties: %{
               name: %Schema{type: :string},
-              address: %Reference{"$ref": "#components/schemas/Address"},
+              address: %Reference{"$ref": "#/components/schemas/Address"},
               age: %Schema{type: :integer, format: :int32, minimum: 0}
             }
           })


### PR DESCRIPTION
This PR enables usage of **%Reference{}** in operation definition in a Phoenix controller:

```
  plug(OpenApiSpex.Plug.CastAndValidate)

  def some_operation do
    %Operation{
      parameters: %Reference{"$ref": "#/components/parameters/some_param"},
      ...
    }
  end
```

assuming in the API SPEC it reads:

```
 def spec do
    %OpenApi{
      ....
      components: %OpenApiSpex.Components{
        parameters: %{
          "some_param" =>
            Operation.parameter(:some_param, :query, :string, "Some parameter")
            ...
```

Without this PR, CastAndValidate plug would crash when stepping on "$ref" in parameters.