### PR TITLE
add `display_operation_id` option

### DIFF
--- a/lib/open_api_spex/plug/swagger_ui.ex
+++ b/lib/open_api_spex/plug/swagger_ui.ex
@@ -116,7 +116,8 @@ defmodule OpenApiSpex.Plug.SwaggerUI do
         requestInterceptor: function(request){
           request.headers["x-csrf-token"] = "<%= csrf_token %>";
           return request;
-        }
+        },
+        displayOperationId: <%= display_operation_id %>
       })
       window.ui = ui
     }
@@ -127,12 +128,17 @@ defmodule OpenApiSpex.Plug.SwaggerUI do
   """
 
   @impl Plug
-  def init(path: path), do: %{path: path}
+  def init(opts) when is_list(opts) do
+    opts
+    |> Enum.into(%{})
+    |> Map.put_new(:path, "/api/openapi")
+    |> Map.put_new(:display_operation_id, false)
+  end
 
   @impl Plug
-  def call(conn, %{path: path}) do
+  def call(conn, %{path: path, display_operation_id: display_operation_id}) do
     csrf_token = Plug.CSRFProtection.get_csrf_token()
-    html = render(path, csrf_token)
+    html = render(path, csrf_token, display_operation_id)
 
     conn
     |> Plug.Conn.put_resp_content_type("text/html")
@@ -140,5 +146,5 @@ defmodule OpenApiSpex.Plug.SwaggerUI do
   end
 
   require EEx
-  EEx.function_from_string(:defp, :render, @html, [:path, :csrf_token])
+  EEx.function_from_string(:defp, :render, @html, [:path, :csrf_token, :display_operation_id])
 end

--- a/lib/open_api_spex/plug/swagger_ui.ex
+++ b/lib/open_api_spex/plug/swagger_ui.ex
@@ -127,11 +127,20 @@ defmodule OpenApiSpex.Plug.SwaggerUI do
     </html>
   """
 
+  @doc """
+  Initializes the plug.
+
+  Required params: `[:path]`
+
+  ## Example
+
+      use OpenApiSpex.Plug.SwaggerUI, path: "/api/openapi"
+
+  """
   @impl Plug
   def init(opts) when is_list(opts) do
     opts
     |> Enum.into(%{})
-    |> Map.put_new(:path, "/api/openapi")
     |> Map.put_new(:display_operation_id, false)
   end
 


### PR DESCRIPTION
This PR adds a new configuration option to `OpenApiSpex.Plug.SwaggerUI` to toggle `displayOperationId` on/off (defaults to off).

#### `display_operation_id: false`
![image](https://user-images.githubusercontent.com/18172185/63527604-44ddf680-c4b6-11e9-8623-4e2e75250378.png)

#### `display_operation_id: true`
![image](https://user-images.githubusercontent.com/18172185/63527659-5c1ce400-c4b6-11e9-817a-9dbfdc5dd161.png)

Accepting additional configuration options required changing the format of `init/1`, and I'm not sure my implementation captures the original intent of requiring `path` to be set, so please feel free to refactor.
