### PR TITLE
Generate typespec based on schema types

### DIFF
--- a/lib/open_api_spex.ex
+++ b/lib/open_api_spex.ex
@@ -157,9 +157,17 @@ defmodule OpenApiSpex do
 
       @derive Enum.filter([Poison.Encoder, Jason.Encoder], &Code.ensure_loaded?/1)
       defstruct Schema.properties(@schema)
-      @type t :: %__MODULE__{}
+
+      Schema.types(@schema) |> OpenApiSpex.__type__()
 
       Map.from_struct(@schema) |> OpenApiSpex.validate_compiled_schema()
+    end
+  end
+
+  @doc false
+  defmacro __type__(types) do
+    quote bind_quoted: [types: types] do
+      @type t() :: %__MODULE__{unquote_splicing(types)}
     end
   end
 

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -3,6 +3,7 @@ defmodule OpenApiSpex.SchemaTest do
   alias OpenApiSpex.Schema
   alias OpenApiSpexTest.{ApiSpec, Schemas}
   import OpenApiSpex.Test.Assertions
+  import ExUnit.CaptureIO
 
   doctest Schema
 
@@ -19,6 +20,27 @@ defmodule OpenApiSpex.SchemaTest do
       assert_schema(Schemas.UserRequest.schema().example, "UserRequest", spec)
       assert_schema(Schemas.UserResponse.schema().example, "UserResponse", spec)
       assert_schema(Schemas.UsersResponse.schema().example, "UsersResponse", spec)
+    end
+  end
+
+  describe "type introspection" do
+    test "matches schema types" do
+      type =
+        capture_io(fn ->
+          IEx.Introspection.t(OpenApiSpexTest.Schemas.Size)
+        end)
+
+      assert type =~ "%OpenApiSpexTest.Schemas.Size{"
+      assert type =~ "unit: String.t() | nil"
+      assert type =~ "value: integer() | nil"
+
+      type =
+        capture_io(fn ->
+          IEx.Introspection.t(OpenApiSpexTest.Schemas.UsersResponse)
+        end)
+
+      assert type =~ "%OpenApiSpexTest.Schemas.UsersResponse{"
+      assert type =~ "data: [OpenApiSpexTest.Schemas.User.t()] | nil"
     end
   end
 


### PR DESCRIPTION
Naive implementation of type specification on compile time based
on types and formats of OpenApiSpex.Schema.