### PR TITLE
Keep examples' null fields

### DIFF
--- a/lib/open_api_spex/open_api.ex
+++ b/lib/open_api_spex/open_api.ex
@@ -85,7 +85,7 @@ defmodule OpenApiSpex.OpenApi do
 
         defp to_json(%Regex{source: source}), do: source
 
-        defp to_json(value = %object{}) when object in [MediaType, Schema, Example] do
+        defp to_json(%object{} = value) when object in [MediaType, Schema, Example] do
           value
           |> Extendable.to_map()
           |> Stream.map(fn
@@ -139,10 +139,7 @@ defmodule OpenApiSpex.OpenApi do
         end
 
         defp to_json_example(value) when is_list(value) do
-          Enum.map(value, fn
-            x when is_map(x) or is_list(x) -> to_json_example(x)
-            x -> to_json(x)
-          end)
+          Enum.map(value, &to_json_example/1)
         end
 
         defp to_json_example(value), do: to_json(value)

--- a/lib/open_api_spex/open_api.ex
+++ b/lib/open_api_spex/open_api.ex
@@ -6,7 +6,7 @@ defmodule   OpenApiSpex.OpenApi do
   alias OpenApiSpex.{
     Extendable, Info, Server, Paths, Components,
     SecurityRequirement, Tag, ExternalDocumentation,
-    OpenApi, MediaType
+    OpenApi, MediaType, Schema
   }
   @enforce_keys [:info, :paths]
   defstruct [
@@ -76,7 +76,7 @@ defmodule   OpenApiSpex.OpenApi do
         end
 
         defp to_json(%Regex{source: source}), do: source
-        defp to_json(value = %MediaType{}) do
+        defp to_json(value = %object{}) when object in [MediaType, Schema] do
           value
           |> Extendable.to_map()
           |> Stream.map(fn

--- a/lib/open_api_spex/open_api.ex
+++ b/lib/open_api_spex/open_api.ex
@@ -1,25 +1,33 @@
-defmodule   OpenApiSpex.OpenApi do
+defmodule OpenApiSpex.OpenApi do
   @moduledoc """
   Defines the `OpenApiSpex.OpenApi.t` type and the behaviour for application modules that
   construct an `OpenApiSpex.OpenApi.t` at runtime.
   """
   alias OpenApiSpex.{
-    Extendable, Info, Server, Paths, Components,
-    SecurityRequirement, Tag, ExternalDocumentation,
-    OpenApi, MediaType, Schema, Example
+    Extendable,
+    Info,
+    Server,
+    Paths,
+    Components,
+    SecurityRequirement,
+    Tag,
+    ExternalDocumentation,
+    OpenApi,
+    MediaType,
+    Schema,
+    Example
   }
+
   @enforce_keys [:info, :paths]
-  defstruct [
-    openapi: "3.0.0",
-    info: nil,
-    servers: [],
-    paths: nil,
-    components: nil,
-    security: [],
-    tags: [],
-    externalDocs: nil,
-    extensions: nil
-  ]
+  defstruct openapi: "3.0.0",
+            info: nil,
+            servers: [],
+            paths: nil,
+            components: nil,
+            security: [],
+            tags: [],
+            externalDocs: nil,
+            extensions: nil
 
   @typedoc """
   [OpenAPI Object](https://swagger.io/specification/#oasObject)
@@ -27,16 +35,16 @@ defmodule   OpenApiSpex.OpenApi do
   This is the root document object of the OpenAPI document.
   """
   @type t :: %OpenApi{
-    openapi: String.t,
-    info: Info.t,
-    servers: [Server.t] | nil,
-    paths: Paths.t,
-    components: Components.t | nil,
-    security: [SecurityRequirement.t] | nil,
-    tags: [Tag.t] | nil,
-    externalDocs: ExternalDocumentation.t | nil,
-    extensions: %{String.t() => any()} | nil,
-  }
+          openapi: String.t(),
+          info: Info.t(),
+          servers: [Server.t()] | nil,
+          paths: Paths.t(),
+          components: Components.t() | nil,
+          security: [SecurityRequirement.t()] | nil,
+          tags: [Tag.t()] | nil,
+          externalDocs: ExternalDocumentation.t() | nil,
+          extensions: %{String.t() => any()} | nil
+        }
 
   @doc """
   A spec/0 callback function is required for use with the `OpenApiSpex.Plug.PutApiSpec` plug.
@@ -76,31 +84,42 @@ defmodule   OpenApiSpex.OpenApi do
         end
 
         defp to_json(%Regex{source: source}), do: source
+
         defp to_json(value = %object{}) when object in [MediaType, Schema, Example] do
           value
           |> Extendable.to_map()
           |> Stream.map(fn
             {:value, v} when object == Example -> {"value", to_json_example(v)}
             {:example, v} -> {"example", to_json_example(v)}
-            {k,v} -> {to_string(k), to_json(v)}
+            {k, v} -> {to_string(k), to_json(v)}
           end)
-          |> Stream.filter(fn {_, nil} -> false; _ -> true end)
+          |> Stream.filter(fn
+            {_, nil} -> false
+            _ -> true
+          end)
           |> Enum.into(%{})
         end
+
         defp to_json(value = %{__struct__: _}) do
           value
           |> Extendable.to_map()
           |> to_json()
         end
+
         defp to_json(value) when is_map(value) do
           value
-          |> Stream.map(fn {k,v} -> {to_string(k), to_json(v)} end)
-          |> Stream.filter(fn {_, nil} -> false; _ -> true end)
+          |> Stream.map(fn {k, v} -> {to_string(k), to_json(v)} end)
+          |> Stream.filter(fn
+            {_, nil} -> false
+            _ -> true
+          end)
           |> Enum.into(%{})
         end
+
         defp to_json(value) when is_list(value) do
           Enum.map(value, &to_json/1)
         end
+
         defp to_json(nil), do: nil
         defp to_json(true), do: true
         defp to_json(false), do: false
@@ -112,17 +131,20 @@ defmodule   OpenApiSpex.OpenApi do
           |> Extendable.to_map()
           |> to_json_example()
         end
+
         defp to_json_example(value) when is_map(value) do
           value
-          |> Stream.map(fn {k,v} -> {to_string(k), to_json_example(v)} end)
+          |> Stream.map(fn {k, v} -> {to_string(k), to_json_example(v)} end)
           |> Enum.into(%{})
         end
+
         defp to_json_example(value) when is_list(value) do
           Enum.map(value, fn
             x when is_map(x) or is_list(x) -> to_json_example(x)
             x -> to_json(x)
           end)
         end
+
         defp to_json_example(value), do: to_json(value)
       end
     end

--- a/lib/open_api_spex/open_api.ex
+++ b/lib/open_api_spex/open_api.ex
@@ -6,7 +6,7 @@ defmodule   OpenApiSpex.OpenApi do
   alias OpenApiSpex.{
     Extendable, Info, Server, Paths, Components,
     SecurityRequirement, Tag, ExternalDocumentation,
-    OpenApi, MediaType, Schema
+    OpenApi, MediaType, Schema, Example
   }
   @enforce_keys [:info, :paths]
   defstruct [
@@ -76,10 +76,11 @@ defmodule   OpenApiSpex.OpenApi do
         end
 
         defp to_json(%Regex{source: source}), do: source
-        defp to_json(value = %object{}) when object in [MediaType, Schema] do
+        defp to_json(value = %object{}) when object in [MediaType, Schema, Example] do
           value
           |> Extendable.to_map()
           |> Stream.map(fn
+            {:value, v} when object == Example -> {"value", to_json_example(v)}
             {:example, v} -> {"example", to_json_example(v)}
             {k,v} -> {to_string(k), to_json(v)}
           end)

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -3,7 +3,8 @@ defmodule OpenApiSpex.EncodeTest do
 
   alias OpenApiSpex.{
     Info,
-    OpenApi
+    OpenApi,
+    Schema
   }
 
   test "Vendor extensions x-logo properly encoded" do
@@ -66,7 +67,7 @@ defmodule OpenApiSpex.EncodeTest do
     assert is_nil(decoded["extensions"])
   end
 
-  test "MediaType example properly encoded" do
+  test "Example field properly encoded (MediaType, Schema)" do
     spec = %OpenApi{
       info: %Info{
         title: "Test",
@@ -77,7 +78,7 @@ defmodule OpenApiSpex.EncodeTest do
           get: %OpenApiSpex.Operation{
             responses: %{
               200 => %OpenApiSpex.Response{
-                description: "A list of examples",
+                description: "An example",
                 content: %{
                   "application/json" => %OpenApiSpex.MediaType{
                     example: %{
@@ -89,6 +90,25 @@ defmodule OpenApiSpex.EncodeTest do
                   }
                 }
               }
+            }
+          }
+        }
+      },
+      components: %OpenApiSpex.Components{
+        schemas: %{
+          "User" => %Schema{
+            type: :object,
+            properties: %{
+              id: %Schema{type: :integer},
+              first_name: %Schema{type: :string},
+              last_name: %Schema{type: :string},
+              phone_number: %Schema{type: :string, nullable: true}
+            },
+            example: %{
+              "id" => 42,
+              "first_name" => "Jane",
+              "last_name" => "Doe",
+              "phone_number" => nil
             }
           }
         }
@@ -110,6 +130,16 @@ defmodule OpenApiSpex.EncodeTest do
                "content",
                "application/json",
                "example"
+             ]),
+             "phone_number"
+           )
+
+    assert Map.has_key?(
+             get_in(decoded, [
+               "components",
+               "schemas",
+               "User",
+               "example",
              ]),
              "phone_number"
            )

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -139,7 +139,63 @@ defmodule OpenApiSpex.EncodeTest do
                "components",
                "schemas",
                "User",
-               "example",
+               "example"
+             ]),
+             "phone_number"
+           )
+  end
+
+  test "Value field from Example object properly encoded" do
+    spec = %OpenApi{
+      info: %Info{
+        title: "Test",
+        version: "1.0.0"
+      },
+      paths: %{
+        "/example" => %OpenApiSpex.PathItem{
+          get: %OpenApiSpex.Operation{
+            responses: %{
+              200 => %OpenApiSpex.Response{
+                description: "An example",
+                content: %{
+                  "application/json" => %OpenApiSpex.MediaType{
+                    examples: %{
+                      "John" => %OpenApiSpex.Example{
+                        summary: "Its John",
+                        value: %{
+                          "id" => 678,
+                          "first_name" => "John",
+                          "last_name" => "Doe",
+                          "phone_number" => nil
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    decoded =
+      OpenApiSpex.resolve_schema_modules(spec)
+      |> Jason.encode!()
+      |> Jason.decode!()
+
+    assert Map.has_key?(
+             get_in(decoded, [
+               "paths",
+               "/example",
+               "get",
+               "responses",
+               "200",
+               "content",
+               "application/json",
+               "examples",
+               "John",
+               "value"
              ]),
              "phone_number"
            )

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -65,4 +65,53 @@ defmodule OpenApiSpex.EncodeTest do
 
     assert is_nil(decoded["extensions"])
   end
+
+  test "MediaType example properly encoded" do
+    spec = %OpenApi{
+      info: %Info{
+        title: "Test",
+        version: "1.0.0"
+      },
+      paths: %{
+        "/example" => %OpenApiSpex.PathItem{
+          get: %OpenApiSpex.Operation{
+            responses: %{
+              200 => %OpenApiSpex.Response{
+                description: "A list of examples",
+                content: %{
+                  "application/json" => %OpenApiSpex.MediaType{
+                    example: %{
+                      "id" => 678,
+                      "first_name" => "John",
+                      "last_name" => "Doe",
+                      "phone_number" => nil
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    decoded =
+      OpenApiSpex.resolve_schema_modules(spec)
+      |> Jason.encode!()
+      |> Jason.decode!()
+
+    assert Map.has_key?(
+             get_in(decoded, [
+               "paths",
+               "/example",
+               "get",
+               "responses",
+               "200",
+               "content",
+               "application/json",
+               "example"
+             ]),
+             "phone_number"
+           )
+  end
 end


### PR DESCRIPTION
This PR prevents the nil fields in examples (Schema, MediaType, Example) from being removed during the JSON encoding.  
 #141 