### PR TITLE
Fix casting when schema composition is used

### DIFF
--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -95,6 +95,20 @@ defmodule OpenApiSpex.SchemaTest do
                Schema.cast(cat_or_dog, input, schemas)
     end
 
+    test "Cast Cat from oneOf [cat, dog] schema" do
+      api_spec = ApiSpec.spec()
+      schemas = api_spec.components.schemas
+      cat_or_dog = Map.fetch!(schemas, "CatOrDog")
+
+      input = %{
+        "pet_type" => "Cat",
+        "meow" => "meow"
+      }
+
+      assert {:ok, %Schemas.Cat{meow: "meow", pet_type: "Cat"}} =
+               Schema.cast(cat_or_dog, input, schemas)
+    end
+
     test "Cast number to string or number" do
       schema = %Schema{
         oneOf: [

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -87,11 +87,11 @@ defmodule OpenApiSpex.SchemaTest do
       cat_or_dog = Map.fetch!(schemas, "CatOrDog")
 
       input = %{
-        "pet_type" => "Cat",
-        "meow" => "meow"
+        "pet_type" => "Dog",
+        "bark" => "bowow"
       }
 
-      assert {:ok, %Schemas.Cat{meow: "meow", pet_type: "Cat"}} =
+      assert {:ok, %Schemas.Dog{bark: "bowow", pet_type: "Dog"}} =
                Schema.cast(cat_or_dog, input, schemas)
     end
 


### PR DESCRIPTION
There was wrong casting to improper Elixir structure when `oneOf` is used. A simple change in `test/schema_test.exs` in the first commit showed the error. I was trying to fix the issue and it seems working for the tests in the library now. Also, we tried this fix against more complex specs in one of the projects.