### PR TITLE
Fixes #144 - makes sure proper Schema type provided if :properties key is present

### DIFF
--- a/lib/open_api_spex/schema_consistency.ex
+++ b/lib/open_api_spex/schema_consistency.ex
@@ -1,0 +1,37 @@
+defmodule OpenApiSpex.SchemaConsistency do
+  @moduledoc """
+  Rules of API Schema consistency.
+  If these rules are not followed, tricky run-time bugs may appear.
+  Related issues: #144
+  """
+
+  alias OpenApiSpex.Schema
+
+  @doc "Returns a list of compile-time warnings"
+  @spec warnings(Schema.t()) :: list(binary())
+  def warnings(schema) do
+    [
+      &validate_type_key/1
+    ]
+    |> Enum.reduce([], fn validator, acc ->
+      case apply(validator, [schema]) do
+        :ok -> acc
+        {:error, message} -> [message | acc]
+      end
+    end)
+  end
+
+  ## Specific validations
+
+  # if :type is missing or nil, :properties are ignored and the nested schemas are not validated
+
+  defp validate_type_key(%Schema{properties: %{}, type: type}) do
+    case type do
+      :object -> :ok
+      nil -> {:error, ":properties provided, but :type is missing or nil (expected :object)"}
+      type -> {:error, ":properties provided, but :type is #{inspect(type)} (expected :object)"}
+    end
+  end
+
+  defp validate_type_key(_), do: :ok
+end

--- a/test/schema_consistency_test.exs
+++ b/test/schema_consistency_test.exs
@@ -1,0 +1,35 @@
+defmodule OpenApiSpex.SchemaConsistencyTest do
+  use ExUnit.Case
+  alias OpenApiSpex.{Schema, SchemaConsistency}
+
+  @valid_schema %Schema{
+    title: "Size",
+    description: "A size of a pet",
+    type: :object,
+    properties: %{
+      unit: %Schema{type: :string, description: "SI unit name", default: "cm"}
+    },
+    required: [:unit]
+  }
+
+  describe "warnings/1" do
+    test "valid schema -> []" do
+      assert SchemaConsistency.warnings(@valid_schema) == []
+    end
+
+    test "missing :type -> [error]" do
+      %{@valid_schema | type: nil}
+      |> assert_validation_error(~r/:type is missing or nil/)
+    end
+
+    test "invalid :type -> [error]" do
+      %{@valid_schema | type: :integer}
+      |> assert_validation_error(~r/:type is :integer/)
+    end
+  end
+
+  defp assert_validation_error(body, pattern) do
+    assert [reason] = SchemaConsistency.warnings(body)
+    assert reason =~ pattern
+  end
+end


### PR DESCRIPTION
Prints compile-time warnings whenever an inconsistent schema is detected.

This PR comes with just one consistency check: `type: :object`.

Whenever the validation fails, the user will see a compile-time error, and the stack trace will point to the invalid schema definition:

```
warning: Inconsistent schema: :properties provided, but :type is missing or nil (expected :object)
  lib/schemas.ex:23: UserSchema (module)
```
