### PR TITLE
Allow nil property defs

### DIFF
--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -863,6 +863,7 @@ defmodule OpenApiSpex.Schema do
 
   def properties(_), do: []
 
+  defp default(default) when default in [nil, false, true], do: default
   defp default(schema_module) when is_atom(schema_module), do: schema_module.schema().default
   defp default(%{default: default}), do: default
 end

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -284,4 +284,15 @@ defmodule OpenApiSpexTest.Schemas do
       oneOf: [Cat, Dog]
     })
   end
+
+  defmodule WithNilProperties do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      type: :object,
+      properties: %{
+        meta: nil
+      }
+    })
+  end
 end


### PR DESCRIPTION
This fixes an apparent regression after v3.4.0. Setting a property definition to `nil` was causing a compile error:

```
== Compilation error in file lib/my_service_web/schemas/user/save.ex ==
** (UndefinedFunctionError) function nil.schema/0 is undefined. If you are using the dot syntax, such as map.field or module.function, make sure the left side of the dot is an atom or a map
    nil.schema()
    lib/open_api_spex/schema.ex:867: OpenApiSpex.Schema.default/1
    lib/open_api_spex/schema.ex:852: anonymous fn/2 in OpenApiSpex.Schema.properties/1
    (stdlib) maps.erl:257: :maps.fold_1/3
    lib/open_api_spex/schema.ex:852: OpenApiSpex.Schema.properties/1
    lib/my_service_web/schemas/user/save.ex:10: (module)
```
