### PR TITLE
Improve reporting of assertion failures

### DIFF
--- a/lib/open_api_spex/test/assertions2.ex
+++ b/lib/open_api_spex/test/assertions2.ex
@@ -25,7 +25,12 @@ defmodule OpenApiSpex.Test.Assertions2 do
         data
 
       {:error, errors} ->
-        errors = Enum.map(errors, &to_string/1)
+        errors =
+          Enum.map(errors, fn error ->
+            message = OpenApiSpex.Cast.Error.message(error)
+            path = OpenApiSpex.Cast.Error.path_to_string(error)
+            "#{message} at #{path}"
+          end)
 
         flunk(
           "Value does not conform to schema #{schema_title}: #{Enum.join(errors, "\n")}\n#{

--- a/lib/open_api_spex/test/assertions2.ex
+++ b/lib/open_api_spex/test/assertions2.ex
@@ -2,9 +2,9 @@ defmodule OpenApiSpex.Test.Assertions2 do
   @moduledoc """
   Defines helpers for testing API responses and examples against API spec schemas.
   """
-  alias OpenApiSpex.OpenApi
-  alias OpenApiSpex.Cast
   import ExUnit.Assertions
+  alias OpenApiSpex.{Cast, OpenApi}
+  alias OpenApiSpex.Cast.Error
 
   @dialyzer {:no_match, assert_schema: 3}
 
@@ -27,8 +27,8 @@ defmodule OpenApiSpex.Test.Assertions2 do
       {:error, errors} ->
         errors =
           Enum.map(errors, fn error ->
-            message = OpenApiSpex.Cast.Error.message(error)
-            path = OpenApiSpex.Cast.Error.path_to_string(error)
+            message = Error.message(error)
+            path = Error.path_to_string(error)
             "#{message} at #{path}"
           end)
 


### PR DESCRIPTION
In asserting data against a schema, the error message for failures now shows the path into the data, for better debugging.

Before, it was very difficult to determine what in the input value didn't match with the schema.