### PR TITLE
Allow additional properties to pass through in cast

### DIFF
--- a/lib/open_api_spex/cast.ex
+++ b/lib/open_api_spex/cast.ex
@@ -68,7 +68,8 @@ defmodule OpenApiSpex.Cast do
       ...>    type: :object,
       ...>    properties: %{
       ...>      name: nil
-      ...>    }
+      ...>    },
+      ...>    additionalProperties: false
       ...> }
       iex> Cast.cast(schema, %{"name" => "spex"})
       {:ok, %{name: "spex"}}

--- a/lib/open_api_spex/cast/object.ex
+++ b/lib/open_api_spex/cast/object.ex
@@ -12,11 +12,13 @@ defmodule OpenApiSpex.Cast.Object do
   end
 
   def cast(%{value: value, schema: schema} = ctx) do
+    original_value = value
     schema_properties = schema.properties || %{}
 
     with :ok <- check_unrecognized_properties(ctx, schema_properties),
          value = cast_atom_keys(value, schema_properties),
          ctx = %{ctx | value: value},
+         ctx = cast_additional_properties(ctx, original_value),
          :ok <- check_required_fields(ctx, schema),
          :ok <- check_max_properties(ctx),
          :ok <- check_min_properties(ctx),
@@ -110,6 +112,31 @@ defmodule OpenApiSpex.Cast.Object do
       _, error ->
         error
     end)
+  end
+
+  # Pass additional properties through when `additionalProperties` is true.
+  # Map string keys are not converted to atoms. That would require calling `String.to_atom/1`, which is not safe.
+  defp cast_additional_properties(%{schema: %{additionalProperties: true}} = ctx, original_value) do
+    recognized_keys = Map.keys(ctx.schema.properties || %{})
+    # Create MapSet with both atom and string versions of the property keys
+    recognized_keys = MapSet.new(recognized_keys ++ Enum.map(recognized_keys, &to_string/1))
+
+    additional_properties =
+      Enum.reduce(original_value, %{}, fn {key, value}, props ->
+        if MapSet.member?(recognized_keys, key) do
+          props
+        else
+          Map.put(props, key, value)
+        end
+      end)
+
+    updated_value = Map.merge(ctx.value, additional_properties)
+
+    %{ctx | value: updated_value}
+  end
+
+  defp cast_additional_properties(ctx, _original_value) do
+    ctx
   end
 
   defp cast_property(%{key: key, schema: schema_properties} = ctx, output) do

--- a/lib/open_api_spex/cast/object.ex
+++ b/lib/open_api_spex/cast/object.ex
@@ -30,7 +30,8 @@ defmodule OpenApiSpex.Cast.Object do
   end
 
   # When additionalProperties is true, extra properties are allowed in input
-  defp check_unrecognized_properties(%{schema: %{additionalProperties: true}}, _expected_keys) do
+  defp check_unrecognized_properties(%{schema: %{additionalProperties: ap}}, _expected_keys)
+       when ap in [nil, true] do
     :ok
   end
 
@@ -116,7 +117,8 @@ defmodule OpenApiSpex.Cast.Object do
 
   # Pass additional properties through when `additionalProperties` is true.
   # Map string keys are not converted to atoms. That would require calling `String.to_atom/1`, which is not safe.
-  defp cast_additional_properties(%{schema: %{additionalProperties: true}} = ctx, original_value) do
+  defp cast_additional_properties(%{schema: %{additionalProperties: ap}} = ctx, original_value)
+       when ap in [nil, true] do
     recognized_keys = Map.keys(ctx.schema.properties || %{})
     # Create MapSet with both atom and string versions of the property keys
     recognized_keys = MapSet.new(recognized_keys ++ Enum.map(recognized_keys, &to_string/1))

--- a/test/cast/object_test.exs
+++ b/test/cast/object_test.exs
@@ -41,7 +41,7 @@ defmodule OpenApiSpex.ObjectTest do
     end
 
     test "with empty schema properties, given unknown input property" do
-      schema = %Schema{type: :object, properties: %{}}
+      schema = %Schema{type: :object, properties: %{}, additionalProperties: false}
       assert cast(value: %{}, schema: schema) == {:ok, %{}}
       assert {:error, [error]} = cast(value: %{"unknown" => "hello"}, schema: schema)
       assert %Error{} = error
@@ -63,7 +63,8 @@ defmodule OpenApiSpex.ObjectTest do
     test "unexpected field" do
       schema = %Schema{
         type: :object,
-        properties: %{}
+        properties: %{},
+        additionalProperties: false
       }
 
       assert {:error, [error]} = cast(value: %{foo: "foo"}, schema: schema)
@@ -156,6 +157,16 @@ defmodule OpenApiSpex.ObjectTest do
         type: :object,
         properties: %{},
         additionalProperties: true
+      }
+
+      assert cast(value: %{"foo" => "foo"}, schema: schema) == {:ok, %{"foo" => "foo"}}
+    end
+
+    test "allow unrecognized fields when additionalProperties is nil" do
+      schema = %Schema{
+        type: :object,
+        properties: %{},
+        additionalProperties: nil
       }
 
       assert cast(value: %{"foo" => "foo"}, schema: schema) == {:ok, %{"foo" => "foo"}}

--- a/test/cast/object_test.exs
+++ b/test/cast/object_test.exs
@@ -15,7 +15,7 @@ defmodule OpenApiSpex.ObjectTest do
     end
 
     test "input map can have atom keys" do
-      schema = %Schema{type: :object}
+      schema = %Schema{type: :object, properties: %{one: %Schema{type: :string}}}
       assert {:ok, map} = cast(value: %{one: "one"}, schema: schema)
       assert map == %{one: "one"}
     end
@@ -149,6 +149,16 @@ defmodule OpenApiSpex.ObjectTest do
       assert %Error{} = error
       assert error.reason == :invalid_type
       assert error.path == [:age]
+    end
+
+    test "allow unrecognized fields when additionalProperties is true" do
+      schema = %Schema{
+        type: :object,
+        properties: %{},
+        additionalProperties: true
+      }
+
+      assert cast(value: %{"foo" => "foo"}, schema: schema) == {:ok, %{"foo" => "foo"}}
     end
 
     defmodule User do

--- a/test/operation2_test.exs
+++ b/test/operation2_test.exs
@@ -155,17 +155,6 @@ defmodule OpenApiSpex.Operation2Test do
       assert conn.params == %{age: 31, member: true, name: "Rubi", include_archived: true}
     end
 
-    test "validate undefined query param name" do
-      query_params = %{"unknown" => "asdf"}
-
-      assert {:error, [error]} = do_index_cast(query_params)
-
-      assert %Error{} = error
-      assert error.reason == :unexpected_field
-      assert error.name == "unknown"
-      assert error.path == ["unknown"]
-    end
-
     test "validate invalid data type for query param" do
       query_params = %{"age" => "asdf"}
       assert {:error, [error]} = do_index_cast(query_params)

--- a/test/plug/cast_and_validate/custom_error_user_controller_test.exs
+++ b/test/plug/cast_and_validate/custom_error_user_controller_test.exs
@@ -6,6 +6,7 @@ defmodule OpenApiSpex.Plug.CastAndValidate.CustomErrorUserControllerTest do
       conn =
         :get
         |> Plug.Test.conn("/api/custom_error_users?validParam=true")
+        |> Plug.Test.conn("/api/custom_error_users?validParam=true")
         |> OpenApiSpexTest.Router.call([])
 
       assert conn.status == 200
@@ -27,11 +28,11 @@ defmodule OpenApiSpex.Plug.CastAndValidate.CustomErrorUserControllerTest do
     test "Invalid Param" do
       conn =
         :get
-        |> Plug.Test.conn("/api/custom_error_users?validParam=123&inValidParam=123&inValid2=hi")
+        |> Plug.Test.conn("/api/custom_error_users?validParam=123")
         |> OpenApiSpexTest.Router.call([])
 
       assert conn.status == 400
-      assert conn.resp_body == "Unexpected field: inValid2"
+      assert conn.resp_body == "Invalid boolean. Got: string"
     end
   end
 end

--- a/test/plug/cast_and_validate/custom_error_user_controller_test.exs
+++ b/test/plug/cast_and_validate/custom_error_user_controller_test.exs
@@ -6,7 +6,6 @@ defmodule OpenApiSpex.Plug.CastAndValidate.CustomErrorUserControllerTest do
       conn =
         :get
         |> Plug.Test.conn("/api/custom_error_users?validParam=true")
-        |> Plug.Test.conn("/api/custom_error_users?validParam=true")
         |> OpenApiSpexTest.Router.call([])
 
       assert conn.status == 200

--- a/test/plug/cast_and_validate_test.exs
+++ b/test/plug/cast_and_validate_test.exs
@@ -79,11 +79,11 @@ defmodule OpenApiSpex.Plug.CastTest do
     test "Invalid Param" do
       conn =
         :get
-        |> Plug.Test.conn("/api/custom_error_users?validParam=123&inValidParam=123&inValid2=hi")
+        |> Plug.Test.conn("/api/custom_error_users?validParam=123")
         |> OpenApiSpexTest.Router.call([])
 
       assert conn.status == 400
-      assert conn.resp_body == "Unexpected field: inValid2"
+      assert conn.resp_body == "Invalid boolean. Got: string"
     end
   end
 

--- a/test/plug/cast_and_validate_test.exs
+++ b/test/plug/cast_and_validate_test.exs
@@ -23,7 +23,7 @@ defmodule OpenApiSpex.Plug.CastTest do
     test "Invalid Param" do
       conn =
         :get
-        |> Plug.Test.conn("/api/users?validParam=123&inValidParam=123&inValid2=hi")
+        |> Plug.Test.conn("/api/users?validParam=123")
         |> OpenApiSpexTest.Router.call([])
 
       assert conn.status == 422
@@ -32,8 +32,8 @@ defmodule OpenApiSpex.Plug.CastTest do
       assert error_resp == %{
                "errors" => [
                  %{
-                   "message" => "Unexpected field: inValid2",
-                   "source" => %{"pointer" => "/inValid2"},
+                   "message" => "Invalid boolean. Got: string",
+                   "source" => %{"pointer" => "/validParam"},
                    "title" => "Invalid value"
                  }
                ]


### PR DESCRIPTION
OpenApiSpex was not adhering to the OpenAPI spec for object schemas that have `additionalProperties` set to `true`. OpenApiSpex treated the input value as valid for that case, but it didn't pass the object's properties through.

It now passes unrecognized properties though, but it does not convert string property keys to atoms, because that would require a call to `String.to_atom/1` which is not safe in this context.