### PR TITLE
Allow property of compiled schema to be a schema

### DIFF
--- a/lib/open_api_spex.ex
+++ b/lib/open_api_spex.ex
@@ -225,7 +225,7 @@ defmodule OpenApiSpex do
   end
 
   def validate_compiled_schema({_, %Schema{} = schema}, _parent) do
-    validate_compiled_schema(schema)
+    validate_compiled_schema(Map.from_struct(schema))
   end
 
   @doc """

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -284,4 +284,15 @@ defmodule OpenApiSpexTest.Schemas do
       oneOf: [Cat, Dog]
     })
   end
+
+  defmodule PrimitiveArray do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "PrimitiveArray",
+      type: :array,
+      items: %Schema{type: "string"},
+      example: ["Foo"]
+    })
+  end
 end


### PR DESCRIPTION
Before this would raise `** (Protocol.UndefinedError) protocol
Enumerable not implemented for %OpenApiSpex.Schema{}` because at this
point the function was recursively called with a struct instead of a map
like the first time.