### PR TITLE
Fixes issues with complex types for phoenix endpoints

### DIFF
--- a/lib/open_api_spex/cast/discriminator.ex
+++ b/lib/open_api_spex/cast/discriminator.ex
@@ -44,13 +44,12 @@ defmodule OpenApiSpex.Cast.Discriminator do
       {"", _} ->
         error(:no_value_for_discriminator, ctx)
 
-      {discriminator_value, castable_value} ->
+      {discriminator_value, _castable_value} ->
         # The cast specified by the composite key (allOf, anyOf, oneOf) MUST succeed
         # or return an error according to the Open API Spec.
         composite_ctx = %{
           ctx
-          | value: castable_value,
-            schema: %{schema | discriminator: nil},
+          | schema: %{schema | discriminator: nil},
             path: ["#{discriminator_property}" | ctx.path]
         }
 

--- a/lib/open_api_spex/cast/one_of.ex
+++ b/lib/open_api_spex/cast/one_of.ex
@@ -1,6 +1,7 @@
 defmodule OpenApiSpex.Cast.OneOf do
   @moduledoc false
   alias OpenApiSpex.Cast
+  alias OpenApiSpex.Schema
 
   def cast(%_{schema: %{type: _, oneOf: []}} = ctx) do
     error(ctx, [])
@@ -18,7 +19,8 @@ defmodule OpenApiSpex.Cast.OneOf do
       end)
 
     case castable_schemas do
-      {[{:ok, value, _schema}], 1} -> {:ok, value}
+      {[{:ok, value, %Schema{"x-struct": nil}}], 1} -> {:ok, value}
+      {[{:ok, value, %Schema{"x-struct": module}}], 1} -> {:ok, struct(module, value)}
       {failed_schemas, _count} -> error(ctx, failed_schemas)
     end
   end

--- a/lib/open_api_spex/cast/one_of.ex
+++ b/lib/open_api_spex/cast/one_of.ex
@@ -19,6 +19,7 @@ defmodule OpenApiSpex.Cast.OneOf do
       end)
 
     case castable_schemas do
+      {[{:ok, %_{} = value, _}], 1} -> {:ok, value}
       {[{:ok, value, %Schema{"x-struct": nil}}], 1} -> {:ok, value}
       {[{:ok, value, %Schema{"x-struct": module}}], 1} -> {:ok, struct(module, value)}
       {failed_schemas, _count} -> error(ctx, failed_schemas)

--- a/lib/open_api_spex/plug/json_render_error.ex
+++ b/lib/open_api_spex/plug/json_render_error.ex
@@ -25,8 +25,7 @@ defmodule OpenApiSpex.Plug.JsonRenderError do
   end
 
   defp render_error(error) do
-    path = error.path |> Enum.map(&to_string/1) |> Path.join()
-    pointer = "/" <> path
+    pointer = OpenApiSpex.path_to_string(error)
 
     %{
       title: "Invalid value",

--- a/test/cast/all_of_test.exs
+++ b/test/cast/all_of_test.exs
@@ -10,6 +10,9 @@ defmodule OpenApiSpex.CastAllOfTest do
     test "allOf" do
       schema = %Schema{allOf: [%Schema{type: :integer}, %Schema{type: :string}]}
       assert {:ok, 1} = cast(value: "1", schema: schema)
+      assert {:error, [error]} = cast(value: "one", schema: schema)
+      assert Error.message(error) ==
+               "Failed to cast value as integer. Value must be castable using `allOf` schemas listed."
     end
 
     test "allOf, uncastable schema" do
@@ -17,7 +20,7 @@ defmodule OpenApiSpex.CastAllOfTest do
       assert {:error, [error]} = cast(value: [:whoops], schema: schema)
 
       assert Error.message(error) ==
-               "Failed to cast value as string. Value must be castable using `allOf` schemas listed."
+               "Failed to cast value as integer. Value must be castable using `allOf` schemas listed."
 
       schema_with_title = %Schema{allOf: [%Schema{title: "Age", type: :integer}]}
 

--- a/test/cast/discriminator_test.exs
+++ b/test/cast/discriminator_test.exs
@@ -48,18 +48,21 @@ defmodule OpenApiSpex.CastDiscriminatorTest do
   setup do
     dog_schema =
       build_schema("Dog", %{
+        animal_type: %Schema{type: :string},
         breed: %Schema{type: :string},
         age: %Schema{type: :integer}
       })
 
     wolf_schema =
       build_schema("Wolf", %{
+        animal_type: %Schema{type: :string},
         breed: %Schema{type: :string, minLength: 5},
         age: %Schema{type: :integer}
       })
 
     cat_schema =
       build_schema("Cat", %{
+        animal_type: %Schema{type: :string},
         breed: %Schema{type: :string},
         lives: %Schema{type: :integer}
       })
@@ -77,7 +80,7 @@ defmodule OpenApiSpex.CastDiscriminatorTest do
         build_discriminator_schema([dog, wolf], :anyOf, String.to_atom(@discriminator), nil)
 
       # Note: We're expecting to getting atoms back, not strings
-      expected = {:ok, %{age: 1, breed: "Pug"}}
+      expected = {:ok, %{age: 1, breed: "Pug", animal_type: "Dog"}}
 
       assert cast(value: input_value, schema: discriminator_schema) == expected
     end
@@ -91,7 +94,7 @@ defmodule OpenApiSpex.CastDiscriminatorTest do
         build_discriminator_schema([dog, wolf], :allOf, String.to_atom(@discriminator), nil)
 
       # Note: We're expecting to getting atoms back, not strings
-      expected = {:ok, %{age: 1, breed: "Corgi"}}
+      expected = {:ok, %{age: 1, breed: "Corgi", animal_type: "Dog"}}
 
       assert cast(value: input_value, schema: discriminator_schema) == expected
     end
@@ -105,7 +108,7 @@ defmodule OpenApiSpex.CastDiscriminatorTest do
         build_discriminator_schema([dog, wolf], :oneOf, String.to_atom(@discriminator), nil)
 
       # Note: We're expecting to getting atoms back, not strings
-      expected = {:ok, %{age: 1, breed: "Pug"}}
+      expected = {:ok, %{age: 1, breed: "Pug", animal_type: "Dog"}}
 
       assert cast(value: input_value, schema: discriminator_schema) == expected
     end
@@ -122,7 +125,7 @@ defmodule OpenApiSpex.CastDiscriminatorTest do
         build_discriminator_schema([dog, cat], :anyOf, String.to_atom(@discriminator), mapping)
 
       # Note: We're expecting to getting atoms back, not strings
-      expected = {:ok, %{age: 1, breed: "Corgi"}}
+      expected = {:ok, %{age: 1, breed: "Corgi", animal_type: "dag"}}
 
       assert cast(value: input_value, schema: discriminator_schema) == expected
     end
@@ -188,7 +191,7 @@ defmodule OpenApiSpex.CastDiscriminatorTest do
       }
 
       # Note: We're expecting to getting atoms back, not strings
-      expected = {:ok, %{data: %{age: 1, breed: "Corgi"}}}
+      expected = {:ok, %{data: %{age: 1, breed: "Corgi", animal_type: "Dog"}}}
 
       assert expected == cast_cast(value: input_value, schema: discriminator_schema)
     end

--- a/test/plug/cast_test.exs
+++ b/test/plug/cast_test.exs
@@ -158,7 +158,6 @@ defmodule OpenApiSpex.Plug.CastTest do
   end
 
   describe "oneOf body params" do
-    @tag :mr_wip3
     test "Valid Request" do
       request_body = %{
         "pet" => %{

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -117,9 +117,12 @@ defmodule OpenApiSpex.SchemaTest do
         ]
       }
 
+      # The following object is valid against both schemas, so it will result in an error
+      # – it should be valid against only one of the schemas, since we are using the oneOf keyword.
+      # @see https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/#oneof
       result = Schema.cast(schema, "123", %{})
 
-      assert {:ok, 123.0} = result
+      assert {:error, _} = result
     end
 
     test "Cast integer to float" do

--- a/test/support/api_spec.ex
+++ b/test/support/api_spec.ex
@@ -26,6 +26,7 @@ defmodule OpenApiSpexTest.ApiSpec do
         schemas:
           for schemaMod <- [
                 Schemas.Pet,
+                Schemas.PetType,
                 Schemas.Cat,
                 Schemas.Dog,
                 Schemas.CatOrDog,

--- a/test/support/pet_controller.ex
+++ b/test/support/pet_controller.ex
@@ -1,0 +1,90 @@
+defmodule OpenApiSpexTest.PetController do
+  use Phoenix.Controller
+  alias OpenApiSpex.Operation
+  alias OpenApiSpexTest.Schemas
+
+  plug OpenApiSpex.Plug.CastAndValidate
+
+  def open_api_operation(action) do
+    apply(__MODULE__, :"#{action}_operation", [])
+  end
+
+  @doc """
+  API Spec for :show action
+  """
+  def show_operation() do
+    import Operation
+
+    %Operation{
+      tags: ["pets"],
+      summary: "Show pet",
+      description: "Show a pet by ID",
+      operationId: "PetController.show",
+      parameters: [
+        parameter(:id, :path, :integer, "Pet ID", example: 123, minimum: 1)
+      ],
+      responses: %{
+        200 => response("Pet", "application/json", Schemas.PetResponse)
+      }
+    }
+  end
+
+  def show(conn, %{id: id}) do
+    json(conn, %Schemas.PetResponse{
+      data: %Schemas.Dog{
+        pet_type: "Dog",
+        bark: "woof"
+      }
+    })
+  end
+
+  def index_operation() do
+    import Operation
+
+    %Operation{
+      tags: ["pets"],
+      summary: "List pets",
+      description: "List all petes",
+      operationId: "PetController.index",
+      parameters: [
+        parameter(:validParam, :query, :boolean, "Valid Param", example: true)
+      ],
+      responses: %{
+        200 => response("Pet List Response", "application/json", Schemas.PetsResponse)
+      }
+    }
+  end
+
+  def index(conn, _params) do
+    json(conn, %Schemas.PetsResponse{
+      data: [
+        %Schemas.Dog{
+          pet_type: "Dog",
+          bark: "joe@gmail.com"
+        }
+      ]
+    })
+  end
+
+  def create_operation() do
+    import Operation
+
+    %Operation{
+      tags: ["pets"],
+      summary: "Create pet",
+      description: "Create a pet",
+      operationId: "PetController.create",
+      parameters: [],
+      requestBody: request_body("The pet attributes", "application/json", Schemas.PetRequest),
+      responses: %{
+        201 => response("Pet", "application/json", Schemas.PetRequest)
+      }
+    }
+  end
+
+  def create(conn = %{body_params: %Schemas.PetRequest{pet: pet}}, _) do
+    json(conn, %Schemas.PetResponse{
+      data: pet
+    })
+  end
+end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -20,5 +20,7 @@ defmodule OpenApiSpexTest.Router do
     post "/users/:id/contact_info", UserController, :contact_info
     post "/users/create_entity", UserController, :create_entity
     get "/openapi", RenderSpec, []
+
+    resources "/pets", PetController, only: [:create, :index, :show]
   end
 end


### PR DESCRIPTION
- Fixes `anyOf`/`oneOf`/`allOf` definitions for `Pet`, extracts discriminating field from `Pet` to `PetType`, but keeps the discrimination definition on `Pet`. `Cats` and `Dogs` will now extend the `PetType` definition instead of `Pet` = remove circular reference.
- If `x-struct` is set in `allOf` schema, the values will now be casted to the given struct.
- Forward `Schema.cast/3` for `oneOf`/`allOf` Schemas to `Cast.cast()` (#160) 
- Fixes issue with `json_render` when a error occurs on root-level (`path: []`)
- Implements `PhoenixController` for pets for the purpose of testing the `oneOf/allOf` Struct-Casting thing

Please let me know if you'r not happy with some of the changes :smile: 