### PR TITLE
Change key name for requestBody in ExDoc operation

### DIFF
--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -44,8 +44,19 @@ defmodule OpenApiSpex.Controller do
 
   ### `requestBody`
 
-  Controlled by `:body` parameter and is defined as a tuple in form
-  `{description, mime, schema}`.
+  Controlled by `:requestBody` parameter and is defined as a tuple in form
+  `{description, mime, schema}` or `{description, mime, schema, opts} that
+  match the arguments of `OpenApiSpex.Operation.request_body/3` or
+  `OpenApiSpex.Operation.request_body/4`.
+
+  ```
+  @doc requestBody: {
+    "CartUpdateRequest",
+    "application/vnd.api+json",
+    CartUpdateRequest,
+    required: true
+  }
+  ```
 
   ### `tags`
 
@@ -56,6 +67,7 @@ defmodule OpenApiSpex.Controller do
 
   ```
   defmodule FooController do
+    use MyAppWeb, :controller
     use #{inspect(__MODULE__)}
 
     @moduledoc tags: ["Foos"]
@@ -63,17 +75,17 @@ defmodule OpenApiSpex.Controller do
     @doc """
     Endpoint summary
 
-    More docs
+    Endpoint description...
     """
-    @doc [
-      parameters: [
-        id: [in: :path, type: :string, required: true]
-      ],
-      responses: [
-        ok: {"Foo document", "application/json", FooSchema}
-      ]
-    ]
-    def show(conn, %{id: id}) do
+    @doc parameters: [
+           id: [in: :path, type: :string, required: true]
+         ],
+         requestBody: {"Request body to update Foo", "application/json", FooUpdateBody, required: true},
+         responses: [
+           ok: {"Foo document", "application/json", FooSchema}
+         ]
+    def update(conn, %{id: id}) do
+      foo_params = conn.body_params
       # …
     end
   end
@@ -151,8 +163,18 @@ defmodule OpenApiSpex.Controller do
 
   defp build_responses(_), do: []
 
-  defp build_request_body(%{body: {name, mime, schema}}),
-    do: Operation.request_body(name, mime, schema)
+  defp build_request_body(%{body: {name, mime, schema}}) do
+    IO.warn("Using :body key for requestBody is deprecated. Please use :requestBody instead.")
+    Operation.request_body(name, mime, schema)
+  end
+
+  defp build_request_body(%{requestBody: {name, mime, schema}}) do
+    Operation.request_body(name, mime, schema)
+  end
+
+  defp build_request_body(%{requestBody: {name, mime, schema, opts}}) do
+    Operation.request_body(name, mime, schema, opts)
+  end
 
   defp build_request_body(_), do: nil
 end

--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -46,8 +46,8 @@ defmodule OpenApiSpex.Controller do
 
   Controlled by `:requestBody` parameter and is defined as a tuple in form
   `{description, mime, schema}` or `{description, mime, schema, opts} that
-  match the arguments of `OpenApiSpex.Operation.request_body/3` or
-  `OpenApiSpex.Operation.request_body/4`.
+  matches the arguments of `OpenApiSpex.Operation.request_body/3` or
+  `OpenApiSpex.Operation.request_body/4`, respectively.
 
   ```
   @doc requestBody: {

--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -42,7 +42,7 @@ defmodule OpenApiSpex.Controller do
 
   Where atoms are the same as `Plug.Conn.Status.code/1` values.
 
-  ### `request_body`
+  ### `requestBody`
 
   Controlled by `:request_body` parameter and is defined as a tuple in form
   `{description, mime, schema}` or `{description, mime, schema, opts} that

--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -42,15 +42,15 @@ defmodule OpenApiSpex.Controller do
 
   Where atoms are the same as `Plug.Conn.Status.code/1` values.
 
-  ### `requestBody`
+  ### `request_body`
 
-  Controlled by `:requestBody` parameter and is defined as a tuple in form
+  Controlled by `:request_body` parameter and is defined as a tuple in form
   `{description, mime, schema}` or `{description, mime, schema, opts} that
   matches the arguments of `OpenApiSpex.Operation.request_body/3` or
   `OpenApiSpex.Operation.request_body/4`, respectively.
 
   ```
-  @doc requestBody: {
+  @doc request_body: {
     "CartUpdateRequest",
     "application/vnd.api+json",
     CartUpdateRequest,
@@ -80,7 +80,7 @@ defmodule OpenApiSpex.Controller do
     @doc parameters: [
            id: [in: :path, type: :string, required: true]
          ],
-         requestBody: {"Request body to update Foo", "application/json", FooUpdateBody, required: true},
+         request_body: {"Request body to update Foo", "application/json", FooUpdateBody, required: true},
          responses: [
            ok: {"Foo document", "application/json", FooSchema}
          ]
@@ -164,15 +164,15 @@ defmodule OpenApiSpex.Controller do
   defp build_responses(_), do: []
 
   defp build_request_body(%{body: {name, mime, schema}}) do
-    IO.warn("Using :body key for requestBody is deprecated. Please use :requestBody instead.")
+    IO.warn("Using :body key for requestBody is deprecated. Please use :request_body instead.")
     Operation.request_body(name, mime, schema)
   end
 
-  defp build_request_body(%{requestBody: {name, mime, schema}}) do
+  defp build_request_body(%{request_body: {name, mime, schema}}) do
     Operation.request_body(name, mime, schema)
   end
 
-  defp build_request_body(%{requestBody: {name, mime, schema, opts}}) do
+  defp build_request_body(%{request_body: {name, mime, schema, opts}}) do
     Operation.request_body(name, mime, schema, opts)
   end
 

--- a/test/controller_test.exs
+++ b/test/controller_test.exs
@@ -13,21 +13,32 @@ defmodule OpenApiSpex.ControllerTest do
     end
 
     test "has defined OpenApiSpex.Operation for show action" do
-      assert %OpenApiSpex.Operation{} = @controller.open_api_operation(:show)
+      assert %OpenApiSpex.Operation{} = @controller.open_api_operation(:update)
     end
 
     test "summary matches 'Endpoint summary'" do
-      assert %{summary: "Endpoint summary"} = @controller.open_api_operation(:show)
+      op = @controller.open_api_operation(:update)
+      assert op.summary == "Update a user"
+      assert op.description == "Update a user\n\nFull description for this endpoint...\n"
     end
 
     test "has response for HTTP 200" do
-      assert %{responses: %{200 => _}} = @controller.open_api_operation(:show)
+      assert %{responses: %{200 => _}} = @controller.open_api_operation(:update)
     end
 
     test "has parameter `:id`" do
-      assert %{parameters: [param]} = @controller.open_api_operation(:show)
+      assert %{parameters: [param]} = @controller.open_api_operation(:update)
       assert param.name == :id
       assert param.required
+    end
+
+    test "has a requestBody" do
+      op = @controller.open_api_operation(:update)
+      assert %OpenApiSpex.RequestBody{} = op.requestBody
+      assert op.requestBody.description == "Request body to update a User"
+      assert op.requestBody.required == true
+      assert %OpenApiSpex.MediaType{schema: schema} = op.requestBody.content["application/json"]
+      assert schema == OpenApiSpexTest.Schemas.User
     end
   end
 end

--- a/test/support/user_controller_annotated.ex
+++ b/test/support/user_controller_annotated.ex
@@ -12,7 +12,7 @@ defmodule OpenApiSpexTest.UserControllerAnnotated do
   @doc parameters: [
          id: [in: :path, type: :string, required: true]
        ]
-  @doc requestBody: {"Request body to update a User", "application/json", User, required: true}
+  @doc request_body: {"Request body to update a User", "application/json", User, required: true}
   @doc responses: [
          ok: {"User response", "application/json", User}
        ]

--- a/test/support/user_controller_annotated.ex
+++ b/test/support/user_controller_annotated.ex
@@ -1,19 +1,20 @@
 defmodule OpenApiSpexTest.UserControllerAnnotated do
   use OpenApiSpex.Controller
+  alias OpenApiSpexTest.Schemas.User
 
-  @moduledoc tags: ["Foo"]
+  @moduledoc tags: ["User"]
 
   @doc """
-  Endpoint summary
+  Update a user
 
-  More docs
+  Full description for this endpoint...
   """
   @doc parameters: [
-    id: [in: :path, type: :string, required: true]
-  ]
+         id: [in: :path, type: :string, required: true]
+       ]
+  @doc requestBody: {"Request body to update a User", "application/json", User, required: true}
   @doc responses: [
-    ok: {"Foo document", "application/json", FooSchema}
-  ]
-  def show, do: :ok
+         ok: {"User response", "application/json", User}
+       ]
+  def update(_conn, _params), do: :ok
 end
-


### PR DESCRIPTION
Changes the name of the key that the requestBody is defined under. It was `body`, but it's now `requestBody` to be consistent with the Open API name.

Also updates the docs and tests to document and test the `requestBody`.