### PR TITLE
Fix oneOf for object schemas

### DIFF
--- a/lib/open_api_spex/cast/one_of.ex
+++ b/lib/open_api_spex/cast/one_of.ex
@@ -12,7 +12,7 @@ defmodule OpenApiSpex.Cast.OneOf do
       Enum.reduce(schemas, {[], 0}, fn schema, {results, count} ->
         schema = OpenApiSpex.resolve_schema(schema, ctx.schemas)
 
-        case Cast.cast(%{ctx | schema: %{schema | anyOf: nil}}) do
+        case Cast.cast(%{ctx | schema: %{schema | anyOf: nil, additionalProperties: false}}) do
           {:ok, value} -> {[{:ok, value, schema} | results], count + 1}
           _ -> {results, count}
         end

--- a/test/support/one_of_schemas.ex
+++ b/test/support/one_of_schemas.ex
@@ -1,0 +1,37 @@
+defmodule OpenApiSpexTest.OneOfSchemas do
+  alias OpenApiSpex.Schema
+  require OpenApiSpex
+
+  defmodule Cat do
+    OpenApiSpex.schema(%{
+      title: "Cat",
+      type: :object,
+      properties: %{
+        meow: %Schema{type: :boolean},
+        age: %Schema{type: :integer}
+      }
+    })
+  end
+
+  defmodule Dog do
+    OpenApiSpex.schema(%{
+      title: "Dog",
+      type: :object,
+      properties: %{
+        bark: %Schema{type: :boolean},
+        breed: %Schema{type: :string, enum: ["Dingo", "Husky", "Retriever", "Shepherd"]}
+      }
+    })
+  end
+
+  defmodule CatOrDog do
+    OpenApiSpex.schema(%{
+      title: "CatOrDog",
+      oneOf: [Cat, Dog]
+    })
+  end
+
+  def spec() do
+    OpenApiSpexTest.OpenApi.build([Cat, Dog, CatOrDog])
+  end
+end

--- a/test/support/open_api.ex
+++ b/test/support/open_api.ex
@@ -1,0 +1,22 @@
+defmodule OpenApiSpexTest.OpenApi do
+  alias OpenApiSpex.{Components, Info, OpenApi}
+
+  @doc """
+  Build an %OpenApi{} struct from a list of schema modules.
+  """
+  @spec build(schemas :: [module]) :: OpenApi.t()
+  def build(schemas) do
+    schemas_map =
+      for module <- schemas, into: %{} do
+        {module.schema().title, module.schema()}
+      end
+
+    info = %Info{
+      title: "Test schema",
+      version: "1.0.0"
+    }
+
+    %OpenApi{info: info, paths: %{}, components: %Components{schemas: schemas_map}}
+    |> OpenApiSpex.resolve_schema_modules()
+  end
+end

--- a/test/support/pet_controller.ex
+++ b/test/support/pet_controller.ex
@@ -29,7 +29,7 @@ defmodule OpenApiSpexTest.PetController do
     }
   end
 
-  def show(conn, %{id: id}) do
+  def show(conn, %{id: _id}) do
     json(conn, %Schemas.PetResponse{
       data: %Schemas.Dog{
         pet_type: "Dog",


### PR DESCRIPTION
Fixes `oneOf` casting where the input value is compared against the properties of the `oneOf` schemas.

Fixes #165.