### PR TITLE
Fix for #181 that adds minimum/maximum validation for number properties

### DIFF
--- a/lib/open_api_spex/cast.ex
+++ b/lib/open_api_spex/cast.ex
@@ -9,6 +9,7 @@ defmodule OpenApiSpex.Cast do
     Discriminator,
     Error,
     Integer,
+    Number,
     Object,
     OneOf,
     Primitive,
@@ -152,7 +153,7 @@ defmodule OpenApiSpex.Cast do
     do: Integer.cast(ctx)
 
   def cast(%__MODULE__{schema: %{type: :number}} = ctx),
-    do: Primitive.cast_number(ctx)
+    do: Number.cast(ctx)
 
   def cast(%__MODULE__{schema: %{type: :string}} = ctx),
     do: String.cast(ctx)

--- a/lib/open_api_spex/cast/error.ex
+++ b/lib/open_api_spex/cast/error.ex
@@ -12,11 +12,11 @@ defmodule OpenApiSpex.Cast.Error do
   @type max_items_error :: {:max_items, non_neg_integer(), non_neg_integer()}
   @type max_length_error :: {:max_length, non_neg_integer()}
   @type max_properties_error :: {:max_properties, non_neg_integer(), non_neg_integer()}
-  @type maximum_error :: {:maximum, integer(), integer()}
+  @type maximum_error :: {:maximum, integer() | float(), integer() | float()}
   @type min_items_error :: {:min_items, non_neg_integer(), non_neg_integer()}
   @type min_length_error :: {:min_length, non_neg_integer()}
   @type min_properties_error :: {:min_properties, non_neg_integer(), non_neg_integer()}
-  @type minimum_error :: {:minimum, integer(), integer()}
+  @type minimum_error :: {:minimum, integer() | float(), integer() | float()}
   @type missing_field_error :: {:missing_field, String.t() | atom()}
   @type missing_header_error :: {:missing_header, String.t() | atom()}
   @type invalid_header_error :: {:invalid_header, String.t() | atom()}

--- a/lib/open_api_spex/cast/number.ex
+++ b/lib/open_api_spex/cast/number.ex
@@ -1,0 +1,66 @@
+defmodule OpenApiSpex.Cast.Number do
+  @moduledoc false
+  alias OpenApiSpex.Cast
+
+  @spec cast(ctx :: Cast.t()) :: {:ok, Cast.t()} | Cast.Error.t()
+  def cast(%{value: value} = ctx) when is_number(value) do
+    case cast_number(ctx) do
+      {:cast, ctx} -> cast(ctx)
+      result -> result
+    end
+  end
+
+  # TODO We need a way to distinguish numbers in (JSON) body vs in request parameters
+  # so we can reject strings values for properties of `type: :number`
+  def cast(%{value: value} = ctx) when is_binary(value) do
+    case Float.parse(value) do
+      {value, ""} -> cast(%{ctx | value: value})
+      _ -> Cast.error(ctx, {:invalid_type, :number})
+    end
+  end
+
+  def cast(ctx) do
+    Cast.error(ctx, {:invalid_type, :number})
+  end
+
+  ## Private functions
+
+  defp cast_number(%{value: value, schema: %{minimum: minimum, exclusiveMinimum: true}} = ctx)
+       when is_number(value) and is_number(minimum) do
+    if value > minimum do
+      Cast.success(ctx, [:minimum, :exclusiveMinimum])
+    else
+      Cast.error(ctx, {:exclusive_min, minimum, value})
+    end
+  end
+
+  defp cast_number(%{value: value, schema: %{minimum: minimum}} = ctx)
+       when is_number(value) and is_number(minimum) do
+    if value >= minimum do
+      Cast.success(ctx, :minimum)
+    else
+      Cast.error(ctx, {:minimum, minimum, value})
+    end
+  end
+
+  defp cast_number(%{value: value, schema: %{maximum: maximum, exclusiveMaximum: true}} = ctx)
+       when is_number(value) and is_number(maximum) do
+    if value < maximum do
+      Cast.success(ctx, [:maximum, :exclusiveMaximum])
+    else
+      Cast.error(ctx, {:exclusive_max, maximum, value})
+    end
+  end
+
+  defp cast_number(%{value: value, schema: %{maximum: maximum}} = ctx)
+       when is_number(value) and is_number(maximum) do
+    if value <= maximum do
+      Cast.success(ctx, :maximum)
+    else
+      Cast.error(ctx, {:maximum, maximum, value})
+    end
+  end
+
+  # For now, we don't do anything with `:multipleOf` for properties of `type: :number`
+  defp cast_number(ctx), do: Cast.ok(ctx)
+end

--- a/test/cast/number_test.exs
+++ b/test/cast/number_test.exs
@@ -1,0 +1,66 @@
+defmodule OpenApiSpex.CastNumberTest do
+  use ExUnit.Case
+  alias OpenApiSpex.{Cast, Schema}
+  alias OpenApiSpex.Cast.{Error, Number}
+
+  defp cast(ctx), do: Number.cast(struct(Cast, ctx))
+
+  describe "cast/1" do
+    test "basics" do
+      schema = %Schema{type: :number}
+      assert cast(value: 1, schema: schema) == {:ok, 1}
+      assert cast(value: 1.5, schema: schema) == {:ok, 1.5}
+      assert cast(value: "1", schema: schema) == {:ok, 1}
+      assert cast(value: "1.5", schema: schema) == {:ok, 1.5}
+      assert {:error, [error]} = cast(value: "other", schema: schema)
+      assert %Error{reason: :invalid_type} = error
+      assert error.value == "other"
+    end
+
+    test "with minimum" do
+      schema = %Schema{type: :number, minimum: 2}
+      assert cast(value: 3, schema: schema) == {:ok, 3}
+      assert cast(value: 2, schema: schema) == {:ok, 2}
+      assert {:error, [error]} = cast(value: 1, schema: schema)
+      assert error.reason == :minimum
+      assert error.value == 1
+      # error.length is the minimum
+      assert error.length == 2
+      assert Error.message(error) =~ "smaller than inclusive minimum"
+    end
+
+    test "with maximum" do
+      schema = %Schema{type: :number, maximum: 2}
+      assert cast(value: 1, schema: schema) == {:ok, 1}
+      assert cast(value: 2, schema: schema) == {:ok, 2}
+      assert {:error, [error]} = cast(value: 3, schema: schema)
+      assert error.reason == :maximum
+      assert error.value == 3
+      # error.length is the maximum
+      assert error.length == 2
+      assert Error.message(error) =~ "larger than inclusive maximum"
+    end
+
+    test "with minimum w/ exclusiveMinimum" do
+      schema = %Schema{type: :number, minimum: 2, exclusiveMinimum: true}
+      assert cast(value: 3, schema: schema) == {:ok, 3}
+      assert {:error, [error]} = cast(value: 2, schema: schema)
+      assert error.reason == :exclusive_min
+      assert error.value == 2
+      # error.length is the minimum
+      assert error.length == 2
+      assert Error.message(error) =~ "smaller than exclusive minimum"
+    end
+
+    test "with maximum w/ exclusiveMaximum" do
+      schema = %Schema{type: :number, maximum: 2, exclusiveMaximum: true}
+      assert cast(value: 1, schema: schema) == {:ok, 1}
+      assert {:error, [error]} = cast(value: 2, schema: schema)
+      assert error.reason == :exclusive_max
+      assert error.value == 2
+      # error.length is the maximum
+      assert error.length == 2
+      assert Error.message(error) =~ "larger than exclusive maximum"
+    end
+  end
+end

--- a/test/cast/number_test.exs
+++ b/test/cast/number_test.exs
@@ -8,10 +8,10 @@ defmodule OpenApiSpex.CastNumberTest do
   describe "cast/1" do
     test "basics" do
       schema = %Schema{type: :number}
-      assert cast(value: 1, schema: schema) == {:ok, 1}
-      assert cast(value: 1.5, schema: schema) == {:ok, 1.5}
-      assert cast(value: "1", schema: schema) == {:ok, 1}
-      assert cast(value: "1.5", schema: schema) == {:ok, 1.5}
+      assert cast(value: 1, schema: schema) === {:ok, 1}
+      assert cast(value: 1.5, schema: schema) === {:ok, 1.5}
+      assert cast(value: "1", schema: schema) === {:ok, 1.0}
+      assert cast(value: "1.5", schema: schema) === {:ok, 1.5}
       assert {:error, [error]} = cast(value: "other", schema: schema)
       assert %Error{reason: :invalid_type} = error
       assert error.value == "other"
@@ -19,25 +19,25 @@ defmodule OpenApiSpex.CastNumberTest do
 
     test "with minimum" do
       schema = %Schema{type: :number, minimum: 2}
-      assert cast(value: 3, schema: schema) == {:ok, 3}
-      assert cast(value: 2, schema: schema) == {:ok, 2}
+      assert cast(value: 3, schema: schema) === {:ok, 3}
+      assert cast(value: 2, schema: schema) === {:ok, 2}
       assert {:error, [error]} = cast(value: 1, schema: schema)
       assert error.reason == :minimum
-      assert error.value == 1
+      assert error.value === 1
       # error.length is the minimum
-      assert error.length == 2
+      assert error.length === 2
       assert Error.message(error) =~ "smaller than inclusive minimum"
     end
 
     test "with maximum" do
       schema = %Schema{type: :number, maximum: 2}
-      assert cast(value: 1, schema: schema) == {:ok, 1}
-      assert cast(value: 2, schema: schema) == {:ok, 2}
+      assert cast(value: 1, schema: schema) === {:ok, 1}
+      assert cast(value: 2, schema: schema) === {:ok, 2}
       assert {:error, [error]} = cast(value: 3, schema: schema)
-      assert error.reason == :maximum
-      assert error.value == 3
+      assert error.reason === :maximum
+      assert error.value === 3
       # error.length is the maximum
-      assert error.length == 2
+      assert error.length === 2
       assert Error.message(error) =~ "larger than inclusive maximum"
     end
 


### PR DESCRIPTION
- Added `OpenApiSpex.Cast.Number` (patterned after `OpenApiSpex.Cast.Integer`),
- Added corresponding `number_test.exs`
- Fixed the `Error` type spec to allow `float()` as well as `integer()` for `:minimum`/`:maximum`