### PR TITLE
Separates request param validation based on their scope

### DIFF
--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -51,7 +51,7 @@ defmodule OpenApiSpex.CastParameters do
   end
 
   defp get_params_by_location(conn, :query, _) do
-    conn.query_params
+    Plug.Conn.fetch_query_params(conn).query_params
   end
 
   defp get_params_by_location(conn, :path, _) do
@@ -59,7 +59,7 @@ defmodule OpenApiSpex.CastParameters do
   end
 
   defp get_params_by_location(conn, :cookie, _) do
-    conn.req_cookies
+    Plug.Conn.fetch_cookies(conn).req_cookies
   end
 
   defp get_params_by_location(conn, :header, expected_names) do

--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -41,7 +41,7 @@ defmodule OpenApiSpex.CastParameters do
     full_cast_result =
       Enum.reduce_while(casted_params, {:ok, %{}}, fn
         {:ok, entry}, {:ok, acc} -> {:cont, {:ok, Map.merge(acc, entry)}}
-        cast_error, acc -> {:halt, cast_error}
+        cast_error, _ -> {:halt, cast_error}
       end)
 
     case full_cast_result do
@@ -64,7 +64,7 @@ defmodule OpenApiSpex.CastParameters do
 
   defp get_params_by_location(conn, :header, expected_names) do
     conn.req_headers
-    |> Enum.filter(fn {key, value} ->
+    |> Enum.filter(fn {key, _value} ->
       Enum.member?(expected_names, String.downcase(key))
     end)
     |> Map.new()
@@ -92,6 +92,6 @@ defmodule OpenApiSpex.CastParameters do
 
     properties = Map.put(location_schema.properties, parameter.name, Parameter.schema(parameter))
 
-    location_schema = %{location_schema | properties: properties, required: required}
+    %{location_schema | properties: properties, required: required}
   end
 end

--- a/test/plug/cast_test.exs
+++ b/test/plug/cast_test.exs
@@ -218,5 +218,21 @@ defmodule OpenApiSpex.Plug.CastTest do
                ]
              }
     end
+
+    test "Custom Header params" do
+      conn =
+        :post
+        |> Plug.Test.conn("/api/pets/1/adopt")
+        |> Plug.Conn.put_req_header("content-type", "application/json; charset=UTF-8")
+        |> Plug.Conn.put_req_header("x-user-id", "123456")
+        |> OpenApiSpexTest.Router.call([])
+
+      assert Jason.decode!(conn.resp_body) == %{
+               "data" => %{
+                 "pet_type" => "Dog",
+                 "bark" => "woof"
+               }
+             }
+    end
   end
 end

--- a/test/plug/cast_test.exs
+++ b/test/plug/cast_test.exs
@@ -219,7 +219,7 @@ defmodule OpenApiSpex.Plug.CastTest do
              }
     end
 
-    test "Custom Header params" do
+    test "Header params" do
       conn =
         :post
         |> Plug.Test.conn("/api/pets/1/adopt")
@@ -230,6 +230,22 @@ defmodule OpenApiSpex.Plug.CastTest do
       assert Jason.decode!(conn.resp_body) == %{
                "data" => %{
                  "pet_type" => "Dog",
+                 "bark" => "woof"
+               }
+             }
+    end
+    test "Cookie params" do
+      conn =
+        :post
+        |> Plug.Test.conn("/api/pets/1/adopt")
+        |> Plug.Conn.put_req_header("content-type", "application/json; charset=UTF-8")
+        |> Plug.Conn.put_req_header("x-user-id", "123456")
+        |> Plug.Conn.put_req_header("cookie", "debug=1")
+        |> OpenApiSpexTest.Router.call([])
+
+      assert Jason.decode!(conn.resp_body) == %{
+               "data" => %{
+                 "pet_type" => "Debug-Dog",
                  "bark" => "woof"
                }
              }

--- a/test/support/pet_controller.ex
+++ b/test/support/pet_controller.ex
@@ -87,4 +87,37 @@ defmodule OpenApiSpexTest.PetController do
       data: pet
     })
   end
+
+  def adopt_operation() do
+    import Operation
+
+    %Operation{
+      tags: ["pets"],
+      summary: "Adopt pet",
+      description: "Adopt a pet",
+      operationId: "PetController.adopt",
+      parameters: [
+        parameter(
+          "x-user-id",
+          :header,
+          :string,
+          "User that performs this action",
+          required: true
+        ),
+        parameter(:id, :path, :integer, "Pet ID", example: 123, minimum: 1)
+      ],
+      responses: %{
+        200 => response("Pet", "application/json", Schemas.PetRequest)
+      }
+    }
+  end
+
+  def adopt(conn, _) do
+    json(conn, %Schemas.PetResponse{
+      data: %Schemas.Dog{
+        pet_type: "Dog",
+        bark: "woof"
+      }
+    })
+  end
 end

--- a/test/support/pet_controller.ex
+++ b/test/support/pet_controller.ex
@@ -97,14 +97,10 @@ defmodule OpenApiSpexTest.PetController do
       description: "Adopt a pet",
       operationId: "PetController.adopt",
       parameters: [
-        parameter(
-          "x-user-id",
-          :header,
-          :string,
-          "User that performs this action",
-          required: true
-        ),
-        parameter(:id, :path, :integer, "Pet ID", example: 123, minimum: 1)
+        parameter("x-user-id", :header, :string, "User that performs this action", required: true),
+        parameter(:id, :path, :integer, "Pet ID", example: 123, minimum: 1),
+        parameter(:status, :query, :string, "New status"),
+        parameter(:debug, :cookie, %OpenApiSpex.Schema{type: :integer, enum: [0, 1], default: 0}, "Debug"),
       ],
       responses: %{
         200 => response("Pet", "application/json", Schemas.PetRequest)
@@ -112,10 +108,19 @@ defmodule OpenApiSpexTest.PetController do
     }
   end
 
-  def adopt(conn, _) do
+  def adopt(conn, %{"x-user-id" => _user_id, :id => _id, :debug => 0}) do
     json(conn, %Schemas.PetResponse{
       data: %Schemas.Dog{
         pet_type: "Dog",
+        bark: "woof"
+      }
+    })
+  end
+
+  def adopt(conn, %{"x-user-id" => _user_id, :id => _id, :debug => 1}) do
+    json(conn, %Schemas.PetResponse{
+      data: %Schemas.Dog{
+        pet_type: "Debug-Dog",
         bark: "woof"
       }
     })

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -22,5 +22,6 @@ defmodule OpenApiSpexTest.Router do
     get "/openapi", RenderSpec, []
 
     resources "/pets", PetController, only: [:create, :index, :show]
+    post "/pets/:id/adopt", PetController, :adopt
   end
 end


### PR DESCRIPTION
There is currently a issue with the validation of header parameters.

The Issue is, that when you specify a custom header parameter, for example a required `x-user-id` parameter. This will result in a error since the validator is looking for this parameters but can't finde it because currently only the path and query params will be passed to cast&validate part. 

With this PR this issue will be fixes plus the validation respects the "location" of the parameter. This means, if you pass the `x-user-id` as query parameter this will also return in a error. 

I'm not quite happy with the look of the code, so if someone finds something to improve I'm more than happy to do so