### PR TITLE
Allow property def to be a Reference

### DIFF
--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -383,8 +383,8 @@ defmodule OpenApiSpex.Schema do
   end
 
   def cast(schema = %Schema{oneOf: one_of}, value, schemas)
-                                                 when is_list(one_of),
-    do: OpenApiSpex.Cast.cast(schema, value, schemas)
+      when is_list(one_of),
+      do: OpenApiSpex.Cast.cast(schema, value, schemas)
 
   def cast(%Schema{oneOf: []}, _value, _schemas) do
     {:error, "Failed to cast to any schema in oneOf"}
@@ -858,5 +858,6 @@ defmodule OpenApiSpex.Schema do
   def properties(_), do: []
 
   defp default(schema_module) when is_atom(schema_module), do: schema_module.schema().default
+  defp default(%Reference{}), do: nil
   defp default(%{default: default}), do: default
 end

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -1,6 +1,6 @@
 defmodule OpenApiSpex.SchemaTest do
   use ExUnit.Case
-  alias OpenApiSpex.Schema
+  alias OpenApiSpex.{Reference, Schema}
   alias OpenApiSpexTest.{ApiSpec, Schemas}
   import OpenApiSpex.TestAssertions
 
@@ -29,6 +29,20 @@ defmodule OpenApiSpex.SchemaTest do
     test "Primitive Schema example matches schema" do
       api_spec = ApiSpec.spec()
       assert_schema(Schemas.Primitive.schema().example, "Primitive", api_spec)
+    end
+
+    test "object property can be a Reference" do
+      schema = %Schema{
+        type: :object,
+        properties: %{
+          address: %Reference{"$ref": "#/components/schemas/Address"}
+        }
+      }
+
+      # `Schema.properties/1` is called by `schema/1`
+      struct_props = Schema.properties(schema)
+
+      assert [address: nil] = struct_props
     end
   end
 


### PR DESCRIPTION
The [example in schema.ex line 30](https://github.com/open-api-spex/open_api_spex/blob/master/lib/open_api_spex/schema.ex#L30) doesn't compile. The `OpenApiSpex.schema/1` macro doesn't know how to handle a object property definition that is a `%Reference{}`, so it blows up with a function clause error. It needs to resolve the properties defs to build the keyword list that makes up the schema's struct definition. It needs to resolve each property definition to determine the default value of each field in the struct.

This PR allows a `%Reference{}` for a property definition.

However, because the Reference can't be resolved at compile time, `schema/1` can't determine the referenced schema's default value, so this PR makes the default `nil` for this case.