### PR TITLE
Auto-populate schema title from module name

### DIFF
--- a/lib/open_api_spex.ex
+++ b/lib/open_api_spex.ex
@@ -176,7 +176,12 @@ defmodule OpenApiSpex do
       @behaviour OpenApiSpex.Schema
       @schema struct(
                 OpenApiSpex.Schema,
-                Map.put(Map.delete(unquote(body), :__struct__), :"x-struct", __MODULE__)
+                unquote(body)
+                |> Map.delete(:__struct__)
+                |> Map.put(:"x-struct", __MODULE__)
+                |> update_in([:title], fn title ->
+                  title || __MODULE__ |> Module.split() |> List.last()
+                end)
               )
 
       def schema, do: @schema

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -32,6 +32,33 @@ defmodule OpenApiSpex.SchemaTest do
     end
   end
 
+  describe "schema/1 auto-populates title" do
+    defmodule Name do
+      require OpenApiSpex
+
+      OpenApiSpex.schema(%{
+        type: :string
+      })
+    end
+
+    defmodule Age do
+      require OpenApiSpex
+
+      OpenApiSpex.schema(%{
+        title: "CustomAge",
+        type: :integer
+      })
+    end
+
+    test "autopopulated title" do
+      assert Name.schema().title == "Name"
+    end
+
+    test "custome title" do
+      assert Age.schema().title == "CustomAge"
+    end
+  end
+
   describe "cast/3" do
     test "cast request schema" do
       api_spec = ApiSpec.spec()


### PR DESCRIPTION
It's easy to forget to set the `:title` property when defining schemas that become named components. When a component's title left as `nil`, it causes strange behavior that is difficult to debug. The strange behavior happens when OpenApiSpex's is unable to resolve references. Component references are based on the schema's title, and when the title is `nil`, OpenApiSpex can't reliably find the component.

It seems like the library would be easier to use if the `:title` property wasn't required. If the title is auto-generated in a uniform way, it will make make components consistently reflect the Elixir module that defines them.