### PR TITLE
Better inspect

### DIFF
--- a/lib/open_api_spex/inspect/for_schema.ex
+++ b/lib/open_api_spex/inspect/for_schema.ex
@@ -1,0 +1,16 @@
+defimpl Inspect, for: OpenApiSpex.Schema do
+  import Inspect.Algebra
+
+  def inspect(parameter, opts) do
+    map =
+      parameter
+      |> Map.from_struct()
+      |> Enum.filter(fn
+        {_key, nil} -> false
+        {_key, _value} -> true
+      end)
+      |> Map.new()
+
+    concat(["%OpenApiSpex.Schema", to_doc(map, opts)])
+  end
+end

--- a/test/inspect/for_schema_test.exs
+++ b/test/inspect/for_schema_test.exs
@@ -1,0 +1,10 @@
+defmodule OpenApiSpex.Inspect.ForSchemaTest do
+  use ExUnit.Case, async: true
+  alias OpenApiSpex.Schema
+
+  test "inspect schema" do
+    schema = %Schema{title: "Hello"}
+    output = inspect(schema)
+    assert output == "%OpenApiSpex.Schema%{title: \"Hello\"}"
+  end
+end


### PR DESCRIPTION
When inspecting `%Schema{}`, it produces a large amount of output that is difficult to parse. It gets worse when working with schema from actual codebases that use OpenApiSpex.

This PR makes the output of Elixir's `inspect()` call more compact when inspecting `%Schema{}`.

Running `IO.inspect(%OpenApiSpex.Schema{title: "Hello"})`, before and after:

Before:
```
%OpenApiSpex.Schema{discriminator: nil, uniqueItems: nil, additionalProperties: nil, minLength: nil, maxProperties: nil, deprecated: nil, required: nil, pattern: nil, minItems: nil, oneOf: nil, readOnly: nil, writeOnly: nil, description: nil, exclusiveMaximum: nil, format: nil, nullable: nil, maxLength: nil, title: "Hello", allOf: nil, type: nil, anyOf: nil, enum: nil, "x-struct": nil, xml: nil, exclusiveMinimum: nil, maximum: nil, externalDocs: nil, not: nil, maxItems: nil, multipleOf: nil, minimum: nil, properties: nil, items: nil, example: nil, minProperties: nil, default: nil}
```

After:
```
%OpenApiSpex.Schema%{title: "Hello"}
```