### PR TITLE
Allow `%Response{}` struct in doc-based spec

### DIFF
--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -92,7 +92,7 @@ defmodule OpenApiSpex.Controller do
   ```
   '''
 
-  alias OpenApiSpex.Operation
+  alias OpenApiSpex.{Operation, Response}
 
   defmacro __using__(_opts) do
     quote do
@@ -156,9 +156,13 @@ defmodule OpenApiSpex.Controller do
   defp build_parameters(_), do: []
 
   defp build_responses(%{responses: responses}) do
-    for {status, {description, mime, schema}} <- responses, into: %{} do
-      {Plug.Conn.Status.code(status), Operation.response(description, mime, schema)}
-    end
+    Map.new(responses, fn
+      {status, {description, mime, schema}} ->
+        {Plug.Conn.Status.code(status), Operation.response(description, mime, schema)}
+
+      {status, %Response{} = response} ->
+        {Plug.Conn.Status.code(status), response}
+    end)
   end
 
   defp build_responses(_), do: []

--- a/test/controller_test.exs
+++ b/test/controller_test.exs
@@ -26,6 +26,14 @@ defmodule OpenApiSpex.ControllerTest do
       assert %{responses: %{200 => _}} = @controller.open_api_operation(:update)
     end
 
+    test "has response for HTTP 401" do
+      assert %{responses: %{401 => _}} = @controller.open_api_operation(:update)
+    end
+
+    test "has response for HTTP 404" do
+      assert %{responses: %{404 => _}} = @controller.open_api_operation(:update)
+    end
+
     test "has parameter `:id`" do
       assert %{parameters: [param]} = @controller.open_api_operation(:update)
       assert param.name == :id

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -29,6 +29,79 @@ defmodule OpenApiSpexTest.Schemas do
     end
   end
 
+  defmodule Unauthorized do
+    @moduledoc """
+    401 - Unauthorized
+    """
+    require OpenApiSpex
+    alias OpenApiSpex.Operation
+
+    # OpenApiSpex.schema/1 macro can be optionally used to reduce boilerplate code
+    OpenApiSpex.schema(%{
+      title: "Unauthorized",
+      type: :object,
+      properties: %{
+        errors: %Schema{
+          type: :array,
+          items: %Schema{
+            type: :object,
+            properties: %{
+              detail: %Schema{
+                type: :string,
+                example: "Authentication credentials were not provided, or they were malformed."
+              },
+              title: %Schema{type: :string, example: "Authorization Required"}
+            }
+          }
+        }
+      }
+    })
+
+    @doc """
+    Unauthorized object, as a whole response.
+    """
+    def response do
+      Operation.response(
+        "Authorization Required",
+        "application/json",
+        __MODULE__
+      )
+    end
+  end
+
+  defmodule NotFound do
+    @moduledoc """
+    404 - Not Found
+    """
+    require OpenApiSpex
+    alias OpenApiSpex.Operation
+
+    OpenApiSpex.schema(%{
+      title: "NotFound",
+      type: :object,
+      properties: %{
+        errors: %Schema{
+          type: :array,
+          items: %Schema{
+            type: :object,
+            properties: %{
+              detail: %Schema{type: :string, example: "The requested resource cannot be found."},
+              title: %Schema{type: :string, example: "Not Found"}
+            }
+          }
+        }
+      }
+    })
+
+    def response do
+      Operation.response(
+        "Not Found",
+        "application/json",
+        __MODULE__
+      )
+    end
+  end
+
   defmodule Size do
     OpenApiSpex.schema(%{
       title: "Size",

--- a/test/support/user_controller_annotated.ex
+++ b/test/support/user_controller_annotated.ex
@@ -1,6 +1,6 @@
 defmodule OpenApiSpexTest.UserControllerAnnotated do
   use OpenApiSpex.Controller
-  alias OpenApiSpexTest.Schemas.User
+  alias OpenApiSpexTest.Schemas.{NotFound, Unauthorized, User}
 
   @moduledoc tags: ["User"]
 
@@ -14,7 +14,9 @@ defmodule OpenApiSpexTest.UserControllerAnnotated do
        ]
   @doc request_body: {"Request body to update a User", "application/json", User, required: true}
   @doc responses: [
-         ok: {"User response", "application/json", User}
+         ok: {"User response", "application/json", User},
+         unauthorized: Unauthorized.response(),
+         not_found: NotFound.response()
        ]
   def update(_conn, _params), do: :ok
 end


### PR DESCRIPTION
Currently using doc-based specs, endpoint responses can be specified using a 3-element tuple:

```
@doc responses: [
  ok: {"User response", "application/json", User}
]
```

This works fine when the response is inlined in the controller. However, to support shared responses that are defined outside the controller, it makes sense to support the longer-form format that uses the `%Response{}` struct.

```
@doc responses: [
  ok: {"User response", "application/json", User},
  not_found: NotFound.response()
]
```

...where `NotFound.response()` is:

```
def response do
  # Returns `%Response{}`
  Operation.response("Not Found", "application/json", NotFound)
end
```
