### PR TITLE
Make 'properties' key option when parsing doc

### DIFF
--- a/lib/open_api_spex/open_api/decode.ex
+++ b/lib/open_api_spex/open_api/decode.ex
@@ -203,7 +203,7 @@ defmodule OpenApiSpex.OpenApi.Decode do
 
   defp to_struct(%{"type" => "object"} = map, Schema) do
     map
-    |> Map.update!("properties", fn v ->
+    |> Map.update("properties", %{}, fn v ->
       v
       |> Map.new(fn {k, v} ->
         {String.to_atom(k), v}


### PR DESCRIPTION
I don't think a `properties` key needs to be present in an OpenSchema object schema, does it?