### PR TITLE
Validate Operation.parameter/5 args

### DIFF
--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -151,7 +151,7 @@ defmodule OpenApiSpex.Controller do
     for {name, options} <- params do
       {location, options} = Keyword.pop(options, :in, :query)
       {type, options} = Keyword.pop(options, :type, :string)
-      {description, options} = Keyword.pop(options, :description, :string)
+      {description, options} = Keyword.pop(options, :description, "")
 
       Operation.parameter(name, location, type, description, options)
     end

--- a/lib/open_api_spex/operation.ex
+++ b/lib/open_api_spex/operation.ex
@@ -14,7 +14,7 @@ defmodule OpenApiSpex.Operation do
     Responses,
     Schema,
     SecurityRequirement,
-    Server,
+    Server
   }
 
   @enforce_keys :responses
@@ -80,16 +80,27 @@ defmodule OpenApiSpex.Operation do
   end
 
   @doc """
-  Shorthand for constructing a Parameter name, location, type, description and optional examples
+  Shorthand for constructing an `OpenApiSpex.Parameter` given name, location, type, description and optional examples
   """
-  @spec parameter(atom, Parameter.location, Reference.t | Schema.t | atom, String.t, keyword) :: Parameter.t
-  def parameter(name, location, type, description, opts \\ []) do
+  @spec parameter(
+          name :: atom,
+          location :: Parameter.location(),
+          type :: Reference.t() | Schema.t() | atom,
+          description :: String.t(),
+          opts :: keyword
+        ) :: Parameter.t()
+  def parameter(name, location, type, description, opts \\ [])
+      when is_atom(name) and
+             is_atom(location) and
+             (is_map(type) or is_atom(type)) and
+             is_binary(description) and
+             is_list(opts) do
     params =
       [name: name, in: location, description: description, required: location == :path]
       |> Keyword.merge(opts)
 
     Parameter
-    |> struct(params)
+    |> struct!(params)
     |> Parameter.put_schema(type)
   end
 

--- a/lib/open_api_spex/operation.ex
+++ b/lib/open_api_spex/operation.ex
@@ -74,7 +74,7 @@ defmodule OpenApiSpex.Operation do
   @doc """
   Constructs an Operation struct from plug module and opts
   """
-  @spec from_plug(module, any) :: t | nil
+  @spec from_plug(module, opts :: any) :: t | nil
   def from_plug(plug, opts) do
     plug.open_api_operation(opts)
   end
@@ -107,7 +107,12 @@ defmodule OpenApiSpex.Operation do
   @doc """
   Shorthand for constructing a RequestBody with description, media_type, schema and optional examples
   """
-  @spec request_body(String.t, String.t, (Schema.t | Reference.t | module), keyword) :: RequestBody.t
+  @spec request_body(
+          description :: String.t(),
+          media_type :: String.t(),
+          schema_ref :: Schema.t() | Reference.t() | module,
+          opts :: keyword
+        ) :: RequestBody.t()
   def request_body(description, media_type, schema_ref, opts \\ []) do
     %RequestBody{
       description: description,
@@ -125,12 +130,17 @@ defmodule OpenApiSpex.Operation do
   @doc """
   Shorthand for constructing a Response with description, media_type, schema and optional examples
   """
-  @spec response(String.t, String.t, (Schema.t | Reference.t | module), keyword) :: Response.t
+  @spec response(
+          description :: String.t(),
+          media_type :: String.t(),
+          schema_ref :: Schema.t() | Reference.t() | module,
+          opts :: keyword
+        ) :: Response.t()
   def response(description, media_type, schema_ref, opts \\ []) do
     %Response{
       description: description,
       content: %{
-        media_type => %MediaType {
+        media_type => %MediaType{
           schema: schema_ref,
           example: opts[:example],
           examples: opts[:examples]
@@ -142,51 +152,76 @@ defmodule OpenApiSpex.Operation do
   @doc """
   Cast params to the types defined by the schemas of the operation parameters and requestBody
   """
-  @spec cast(Operation.t, Conn.t, String.t | nil, %{String.t => Schema.t}) :: {:ok, Plug.Conn.t} | {:error, String.t}
+  @spec cast(
+          Operation.t(),
+          Conn.t(),
+          content_type :: String.t() | nil,
+          schemas :: %{String.t() => Schema.t()}
+        ) :: {:ok, Plug.Conn.t()} | {:error, String.t()}
   def cast(operation = %Operation{}, conn = %Plug.Conn{}, content_type, schemas) do
-    parameters = Enum.filter(operation.parameters || [], fn p -> Map.has_key?(conn.params, Atom.to_string(p.name)) end)
+    parameters =
+      Enum.filter(operation.parameters || [], fn p ->
+        Map.has_key?(conn.params, Atom.to_string(p.name))
+      end)
+
     with :ok <- check_query_params_defined(conn, operation.parameters),
          {:ok, parameter_values} <- cast_parameters(parameters, conn.params, schemas),
-         {:ok, body} <- cast_request_body(operation.requestBody, conn.body_params, content_type, schemas) do
+         {:ok, body} <-
+           cast_request_body(operation.requestBody, conn.body_params, content_type, schemas) do
       {:ok, %{conn | params: parameter_values, body_params: body}}
     end
   end
 
-  @spec check_query_params_defined(Conn.t, list | nil) :: :ok | {:error, String.t}
-  defp check_query_params_defined(%Plug.Conn{} = conn, defined_params) when is_nil(defined_params) do
+  @spec check_query_params_defined(Conn.t(), list | nil) :: :ok | {:error, String.t()}
+  defp check_query_params_defined(%Plug.Conn{} = conn, defined_params)
+       when is_nil(defined_params) do
     case conn.query_params do
       %{} -> :ok
       _ -> {:error, "No query parameters defined for this operation"}
     end
   end
-  defp check_query_params_defined(%Plug.Conn{} = conn, defined_params) when is_list(defined_params) do
-    defined_query_params = for param <- defined_params, param.in == :query, into: MapSet.new(), do: to_string(param.name)
+
+  defp check_query_params_defined(%Plug.Conn{} = conn, defined_params)
+       when is_list(defined_params) do
+    defined_query_params =
+      for param <- defined_params,
+          param.in == :query,
+          into: MapSet.new(),
+          do: to_string(param.name)
+
     case validate_parameter_keys(Map.keys(conn.query_params), defined_query_params) do
       {:error, param} -> {:error, "Undefined query parameter: #{inspect(param)}"}
       :ok -> :ok
     end
   end
 
-  @spec validate_parameter_keys([String.t], MapSet.t) ::  {:error, String.t} | :ok
+  @spec validate_parameter_keys([String.t()], MapSet.t()) :: {:error, String.t()} | :ok
   defp validate_parameter_keys([], _defined_params), do: :ok
-  defp validate_parameter_keys([param|params], defined_params) do
+
+  defp validate_parameter_keys([param | params], defined_params) do
     case MapSet.member?(defined_params, param) do
       false -> {:error, param}
       _ -> validate_parameter_keys(params, defined_params)
     end
   end
 
-  @spec cast_parameters([Parameter.t], map, %{String.t => Schema.t}) :: {:ok, map} | {:error, String.t}
+  @spec cast_parameters([Parameter.t()], map, %{String.t() => Schema.t()}) ::
+          {:ok, map} | {:error, String.t()}
   defp cast_parameters([], _params, _schemas), do: {:ok, %{}}
+
   defp cast_parameters([p | rest], params = %{}, schemas) do
-    with {:ok, cast_val} <- Schema.cast(Parameter.schema(p), params[Atom.to_string(p.name)], schemas),
+    with {:ok, cast_val} <-
+           Schema.cast(Parameter.schema(p), params[Atom.to_string(p.name)], schemas),
          {:ok, cast_tail} <- cast_parameters(rest, params, schemas) do
       {:ok, Map.put_new(cast_tail, p.name, cast_val)}
     end
   end
 
-  @spec cast_request_body(RequestBody.t | nil, map, String.t | nil, %{String.t => Schema.t}) :: {:ok, map} | {:error, String.t}
+  @spec cast_request_body(RequestBody.t() | nil, map, String.t() | nil, %{
+          String.t() => Schema.t()
+        }) :: {:ok, map} | {:error, String.t()}
   defp cast_request_body(nil, _, _, _), do: {:ok, %{}}
+
   defp cast_request_body(%RequestBody{content: content}, params, content_type, schemas) do
     schema = content[content_type].schema
     Schema.cast(schema, params, schemas)
@@ -195,17 +230,20 @@ defmodule OpenApiSpex.Operation do
   @doc """
   Validate params against the schemas of the operation parameters and requestBody
   """
-  @spec validate(Operation.t, Conn.t, String.t | nil, %{String.t => Schema.t}) :: :ok | {:error, String.t}
+  @spec validate(Operation.t(), Conn.t(), String.t() | nil, %{String.t() => Schema.t()}) ::
+          :ok | {:error, String.t()}
   def validate(operation = %Operation{}, conn = %Plug.Conn{}, content_type, schemas) do
     with :ok <- validate_required_parameters(operation.parameters || [], conn.params),
-         parameters <- Enum.filter(operation.parameters || [], &Map.has_key?(conn.params, &1.name)),
+         parameters <-
+           Enum.filter(operation.parameters || [], &Map.has_key?(conn.params, &1.name)),
          :ok <- validate_parameter_schemas(parameters, conn.params, schemas),
-         :ok <- validate_body_schema(operation.requestBody, conn.body_params, content_type, schemas) do
+         :ok <-
+           validate_body_schema(operation.requestBody, conn.body_params, content_type, schemas) do
       :ok
     end
   end
 
-  @spec validate_required_parameters([Parameter.t], map) :: :ok | {:error, String.t}
+  @spec validate_required_parameters([Parameter.t()], map) :: :ok | {:error, String.t()}
   defp validate_required_parameters(parameter_list, params = %{}) do
     required =
       parameter_list
@@ -213,6 +251,7 @@ defmodule OpenApiSpex.Operation do
       |> Enum.map(fn parameter -> parameter.name end)
 
     missing = required -- Map.keys(params)
+
     case missing do
       [] -> :ok
       _ -> {:error, "Missing required parameters: #{inspect(missing)}"}
@@ -225,16 +264,25 @@ defmodule OpenApiSpex.Operation do
 
   defp validate_parameter_schemas([p | rest], %{} = params, schemas) do
     {:ok, parameter_value} = Map.fetch(params, p.name)
+
     with :ok <- Schema.validate(Parameter.schema(p), parameter_value, schemas) do
       validate_parameter_schemas(rest, params, schemas)
     end
   end
 
-  @spec validate_body_schema(RequestBody.t | nil, map, String.t | nil, %{String.t => Schema.t}) :: :ok | {:error, String.t}
+  @spec validate_body_schema(
+          RequestBody.t() | nil,
+          params :: map,
+          content_type :: String.t() | nil,
+          schemas :: %{String.t() => Schema.t()}
+        ) :: :ok | {:error, String.t()}
   defp validate_body_schema(nil, _, _, _), do: :ok
-  defp validate_body_schema(%RequestBody{required: false}, params, _content_type, _schemas) when map_size(params) == 0 do
+
+  defp validate_body_schema(%RequestBody{required: false}, params, _content_type, _schemas)
+       when map_size(params) == 0 do
     :ok
   end
+
   defp validate_body_schema(%RequestBody{content: content}, params, content_type, schemas) do
     content
     |> Map.get(content_type)

--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -216,7 +216,7 @@ defmodule OpenApiSpex.Schema do
           maxProperties: integer | nil,
           minProperties: integer | nil,
           required: [atom] | nil,
-          enum: [String.t()] | nil,
+          enum: [any] | nil,
           type: data_type | nil,
           allOf: [Schema.t() | Reference.t() | module] | nil,
           oneOf: [Schema.t() | Reference.t() | module] | nil,
@@ -383,8 +383,8 @@ defmodule OpenApiSpex.Schema do
   end
 
   def cast(schema = %Schema{oneOf: one_of}, value, schemas)
-                                                 when is_list(one_of),
-    do: OpenApiSpex.Cast.cast(schema, value, schemas)
+      when is_list(one_of),
+      do: OpenApiSpex.Cast.cast(schema, value, schemas)
 
   def cast(%Schema{oneOf: []}, _value, _schemas) do
     {:error, "Failed to cast to any schema in oneOf"}

--- a/test/cast_parameters_test.exs
+++ b/test/cast_parameters_test.exs
@@ -27,6 +27,21 @@ defmodule OpenApiSpex.CastParametersTest do
 
       assert expected_response == cast_result
     end
+
+    test "default parameter values are supplied" do
+      conn = create_conn()
+      operation = create_operation()
+      components = create_empty_components()
+      {:ok, conn} = CastParameters.cast(conn, operation, components)
+      assert %{params: %{includeInactive: false}} = conn
+    end
+  end
+
+  defp create_conn() do
+    :get
+    |> Plug.Test.conn("/api/users/")
+    |> Plug.Conn.put_req_header("content-type", "application/json")
+    |> Plug.Conn.fetch_query_params()
   end
 
   defp create_conn_with_unexpected_path_param() do
@@ -39,11 +54,12 @@ defmodule OpenApiSpex.CastParametersTest do
   defp create_operation() do
     %Operation{
       parameters: [
+        Operation.parameter(:id, :query, :string, "User ID", example: "1"),
         Operation.parameter(
-          :id,
+          :includeInactive,
           :query,
-          :string,
-          example: "1"
+          %Schema{type: :boolean, default: false},
+          "Include inactive users"
         )
       ],
       responses: %{

--- a/test/support/pet_controller.ex
+++ b/test/support/pet_controller.ex
@@ -1,6 +1,6 @@
 defmodule OpenApiSpexTest.PetController do
   use Phoenix.Controller
-  alias OpenApiSpex.Operation
+  alias OpenApiSpex.{Operation, Schema}
   alias OpenApiSpexTest.Schemas
 
   plug OpenApiSpex.Plug.CastAndValidate
@@ -21,7 +21,7 @@ defmodule OpenApiSpexTest.PetController do
       description: "Show a pet by ID",
       operationId: "PetController.show",
       parameters: [
-        parameter(:id, :path, :integer, "Pet ID", example: 123, minimum: 1)
+        parameter(:id, :path, %Schema{type: :integer, minimum: 1}, "Pet ID", example: 123)
       ],
       responses: %{
         200 => response("Pet", "application/json", Schemas.PetResponse)
@@ -98,9 +98,14 @@ defmodule OpenApiSpexTest.PetController do
       operationId: "PetController.adopt",
       parameters: [
         parameter(:"x-user-id", :header, :string, "User that performs this action", required: true),
-        parameter(:id, :path, :integer, "Pet ID", example: 123, minimum: 1),
+        parameter(:id, :path, %Schema{type: :integer, minimum: 1}, "Pet ID", example: 123),
         parameter(:status, :query, Schemas.PetStatus, "New status"),
-        parameter(:debug, :cookie, %OpenApiSpex.Schema{type: :integer, enum: [0, 1], default: 0}, "Debug"),
+        parameter(
+          :debug,
+          :cookie,
+          %Schema{type: :integer, enum: [0, 1], default: 0},
+          "Debug"
+        )
       ],
       responses: %{
         200 => response("Pet", "application/json", Schemas.PetRequest)
@@ -135,7 +140,8 @@ defmodule OpenApiSpexTest.PetController do
       description: "Create a pet",
       operationId: "PetController.appointment",
       parameters: [],
-      requestBody: request_body("The pet attributes", "application/json", Schemas.PetAppointmentRequest),
+      requestBody:
+        request_body("The pet attributes", "application/json", Schemas.PetAppointmentRequest),
       responses: %{
         201 => response("Pet", "application/json", Schemas.PetResponse)
       }
@@ -144,7 +150,7 @@ defmodule OpenApiSpexTest.PetController do
 
   def appointment(conn, _) do
     json(conn, %Schemas.PetResponse{
-          data: [%{pet_type: "Dog", bark: "bow wow"}]
-})
+      data: [%{pet_type: "Dog", bark: "bow wow"}]
+    })
   end
 end

--- a/test/support/user_controller.ex
+++ b/test/support/user_controller.ex
@@ -1,6 +1,6 @@
 defmodule OpenApiSpexTest.UserController do
   use Phoenix.Controller
-  alias OpenApiSpex.Operation
+  alias OpenApiSpex.{Operation, Schema}
   alias OpenApiSpexTest.Schemas
 
   plug OpenApiSpex.Plug.CastAndValidate
@@ -21,7 +21,7 @@ defmodule OpenApiSpexTest.UserController do
       description: "Show a user by ID",
       operationId: "UserController.show",
       parameters: [
-        parameter(:id, :path, :integer, "User ID", example: 123, minimum: 1)
+        parameter(:id, :path, %Schema{type: :integer, minimum: 1}, "User ID", example: 123)
       ],
       responses: %{
         200 => response("User", "application/json", Schemas.UserResponse)
@@ -125,7 +125,7 @@ defmodule OpenApiSpexTest.UserController do
       description: "Shows a users payment details",
       operationId: "UserController.payment_details",
       parameters: [
-        parameter(:id, :path, :integer, "User ID", example: 123, minimum: 1)
+        parameter(:id, :path, %Schema{type: :integer, minimum: 1}, "User ID", example: 123)
       ],
       responses: %{
         200 => response("Payment Details", "application/json", Schemas.PaymentDetails)


### PR DESCRIPTION
This PR adds some validation to `Operation.parameter/5`, helping to avoid a couple of mis-uses of this function, including

 - Omitting the description, causing the keyword opts to be placed in the description parameter
 - Passing invalid options in the opts, eg `default:` which should be in the `Schema`, not the `Parameter`

The code now has a guards for the types of all parameters, uses `struct!` to validate
opts, and has better documentation for the parameters types.

I've fixed the test support code where it was being misused.