### PR TITLE
Handle explicit %Reference{} in schemas during compilation

### DIFF
--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -869,4 +869,5 @@ defmodule OpenApiSpex.Schema do
 
   defp default(schema_module) when is_atom(schema_module), do: schema_module.schema().default
   defp default(%{default: default}), do: default
+  defp default(%Reference{}), do: nil
 end


### PR DESCRIPTION
Schemas using explicit References would fail to compile.
With this change they will work with with the limitation that the `default` value declared in the referenced schema is not declared in the struct associated with the schema.

The use case for an explicit reference over a module is to enable recursive schemas.

