### PR TITLE
Doc based specs fixes

### DIFF
--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -66,11 +66,11 @@ defmodule OpenApiSpex.Controller do
   ## Example
 
   ```
-  defmodule FooController do
+  defmodule UserController do
+    @moduledoc tags: ["Users"]
+
     use MyAppWeb, :controller
     use #{inspect(__MODULE__)}
-
-    @moduledoc tags: ["Foos"]
 
     @doc """
     Endpoint summary
@@ -80,12 +80,13 @@ defmodule OpenApiSpex.Controller do
     @doc parameters: [
            id: [in: :path, type: :string, required: true]
          ],
-         request_body: {"Request body to update Foo", "application/json", FooUpdateBody, required: true},
+         request_body: {"Request body to update User", "application/json", UserUpdateBody, required: true},
          responses: [
-           ok: {"Foo document", "application/json", FooSchema}
+           ok: {"User document", "application/json", UserSchema},
+           {302, "Redirect", "text/html", EmptyResponse, headers: %{"Location" => %Header{description: "Redirect Location"}}}
          ]
     def update(conn, %{id: id}) do
-      foo_params = conn.body_params
+      user_params = conn.body_params
       # …
     end
   end
@@ -160,6 +161,9 @@ defmodule OpenApiSpex.Controller do
     Map.new(responses, fn
       {status, {description, mime, schema}} ->
         {Plug.Conn.Status.code(status), Operation.response(description, mime, schema)}
+
+      {status, {description, mime, schema, opts}} ->
+        {Plug.Conn.Status.code(status), Operation.response(description, mime, schema, opts)}
 
       {status, %Response{} = response} ->
         {Plug.Conn.Status.code(status), response}

--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -133,12 +133,16 @@ defmodule OpenApiSpex.Controller do
         _ -> false
       end)
 
-    doc_for_function || raise "No docs found for function #{module}.#{name}/2"
-    {_, _, _, docs, meta} = doc_for_function
-    docs = Map.get(docs, "en", "")
-    [summary | _] = String.split(docs, ~r/\n\s*\n/, parts: 2)
+    if doc_for_function do
+      {_, _, _, docs, meta} = doc_for_function
+      docs = Map.get(docs, "en", "")
+      [summary | _] = String.split(docs, ~r/\n\s*\n/, parts: 2)
 
-    {:ok, {mod_meta, summary, docs, meta}}
+      {:ok, {mod_meta, summary, docs, meta}}
+    else
+      IO.warn("No docs found for function #{module}.#{name}/2")
+      nil
+    end
   end
 
   defp build_operation_id(meta, mod, name) do

--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -126,21 +126,18 @@ defmodule OpenApiSpex.Controller do
   defp get_docs(module, name) do
     {:docs_v1, _anno, _lang, _format, _module_doc, mod_meta, mod_docs} = Code.fetch_docs(module)
 
-    {_, _, _, docs, meta} =
+    doc_for_function =
       Enum.find(mod_docs, fn
         {{:function, ^name, _}, _, _, _, _} -> true
         _ -> false
       end)
 
-    if docs == :none do
-      :error
-    else
-      docs = Map.get(docs, "en", "")
+    doc_for_function || raise "No docs found for function #{module}.#{name}/2"
+    {_, _, _, docs, meta} = doc_for_function
+    docs = Map.get(docs, "en", "")
+    [summary | _] = String.split(docs, ~r/\n\s*\n/, parts: 2)
 
-      [summary | _] = String.split(docs, ~r/\n\s*\n/, parts: 2)
-
-      {:ok, {mod_meta, summary, docs, meta}}
-    end
+    {:ok, {mod_meta, summary, docs, meta}}
   end
 
   defp build_operation_id(meta, mod, name) do

--- a/test/support/user_controller_annotated.ex
+++ b/test/support/user_controller_annotated.ex
@@ -1,8 +1,9 @@
 defmodule OpenApiSpexTest.UserControllerAnnotated do
-  use OpenApiSpex.Controller
-  alias OpenApiSpexTest.Schemas.{NotFound, Unauthorized, User}
-
   @moduledoc tags: ["User"]
+
+  use OpenApiSpex.Controller
+  alias OpenApiSpex.Header
+  alias OpenApiSpexTest.Schemas.{NotFound, Unauthorized, User}
 
   @doc """
   Update a user
@@ -14,7 +15,12 @@ defmodule OpenApiSpexTest.UserControllerAnnotated do
        ]
   @doc request_body: {"Request body to update a User", "application/json", User, required: true}
   @doc responses: [
-         ok: {"User response", "application/json", User},
+         ok: {
+           "User response",
+           "application/json",
+           User,
+           headers: %{"token" => %Header{description: "Access token"}}
+         },
          unauthorized: Unauthorized.response(),
          not_found: NotFound.response()
        ]


### PR DESCRIPTION
## Fix \#1

More informative exception when docs are missing for controller action

Before:
```
** (MatchError) no match of right hand side value: nil
```

After:
```
[warn] No docs found for function Elixir.SppWeb.Api.MessageController.indexb/2
```

## Fix \#2

Allow response spec to have 4th "opts" argument

The shape of a response in the `@doc responses:` keyword-list/map was:

```elixir
{http_status, {description, mime_type, schema}}
```

A fourth element of the inner tuple was previously accepted (maybe it ignored?), but a recent
revision of OpenApiSpex made it a raised exception:

```
** (FunctionClauseError) no function clause matching in anonymous fn/1 in OpenApiSpex.Controller.build_responses/1
```

This commit change passes an optional fourth element to the `opts` argument of `Operation.response/4`.