### PR TITLE
Improve oneOf casting

### DIFF
--- a/lib/open_api_spex/cast/one_of.ex
+++ b/lib/open_api_spex/cast/one_of.ex
@@ -12,7 +12,7 @@ defmodule OpenApiSpex.Cast.OneOf do
       Enum.reduce(schemas, {[], 0}, fn schema, {results, count} ->
         schema = OpenApiSpex.resolve_schema(schema, ctx.schemas)
 
-        case Cast.cast(%{ctx | schema: %{schema | anyOf: nil, additionalProperties: false}}) do
+        case Cast.cast(%{ctx | schema: schema}) do
           {:ok, value} -> {[{:ok, value, schema} | results], count + 1}
           _ -> {results, count}
         end

--- a/test/cast/one_of_test.exs
+++ b/test/cast/one_of_test.exs
@@ -47,7 +47,14 @@ defmodule OpenApiSpex.CastOneOfTest do
                OpenApiSpex.cast_value(input, @cat_or_dog_schema, @api_spec)
     end
 
-    test "should be invalid (not valid against both schemas)" do
+    test "ignores additional properties" do
+      input = %{"bark" => true, "breed" => "Dingo", "age" => 12}
+
+      assert {:ok, %Dog{bark: true, breed: "Dingo"}} =
+               OpenApiSpex.cast_value(input, @cat_or_dog_schema, @api_spec)
+    end
+
+    test "should be invalid (not valid against any)" do
       input = %{"bark" => true, "meow" => true}
       assert {:error, _} = OpenApiSpex.cast_value(input, @cat_or_dog_schema, @api_spec)
     end

--- a/test/support/one_of_schemas.ex
+++ b/test/support/one_of_schemas.ex
@@ -9,7 +9,8 @@ defmodule OpenApiSpexTest.OneOfSchemas do
       properties: %{
         meow: %Schema{type: :boolean},
         age: %Schema{type: :integer}
-      }
+      },
+      required: [:meow]
     })
   end
 
@@ -20,7 +21,8 @@ defmodule OpenApiSpexTest.OneOfSchemas do
       properties: %{
         bark: %Schema{type: :boolean},
         breed: %Schema{type: :string, enum: ["Dingo", "Husky", "Retriever", "Shepherd"]}
-      }
+      },
+      required: [:bark]
     })
   end
 


### PR DESCRIPTION
Accompanying PR for #226 

As described by https://github.com/swagger-api/swagger.io/issues/253 i added some required fields and because of that was able to remove the forced `additionalProperties: false`.
I guess forcing this to false was only needed because the example was wrong...

Obviously if people expect this behaviour, then it might break their current implementation. But probably because their sub schemas lack the required fields...

I don't fully understand why `anyOf: nil` was being set, but all tests were happy without it. If there is a valid reason to keep it, maybe a test should be added (happy to do that if needed) ?
