### PR TITLE
Promote ExDoc-based operation specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ defmodule MyAppWeb.UserController do
 end
 ```
 
-Alternatively, the responses can be defined using keyword list syntax,
+The responses can also be defined using keyword list syntax,
 and the HTTP status codes can be replaced with their text equivalents:
 
 ```elixir
@@ -138,6 +138,8 @@ and the HTTP status codes can be replaced with their text equivalents:
     not_found: {"Not found", "application/json", MyAppWeb.Schema.NotFound}
   ]
 ```
+
+The full set of atom keys are defined in `Plug.Conn.Status.code/1`.
 
 Each definition in a controller action or plug operation is converted
 to an `%OpenApiSpex.Operation{}` struct. The definitions are read

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ be defined using moduledoc attributes that are supported in Elixir 1.7 and highe
 
 ```elixir
 defmodule MyAppWeb.UserController do
+  @moduledoc tags: ["users"]
+
   use MyAppWeb, :controller
   use OpenApiSpex.Controller
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,10 @@ Each definition in a controller action or plug operation is converted
 to an `%OpenApiSpex.Operation{}` struct. The definitions are read
 by your application's `ApiSpec` module, which in turn is
 called from the `OpenApiSpex.Plug.PutApiSpex` plug on each request.
-The definitions data is cached, so it does actually extract the definitions on each request.
+The definitions data is cached, so it does not actually extract the definitions on each request.
+
+Note that in the ExDoc-based definitions, the names of the OpenAPI fields follow `snake_case` naming convention instead of
+OpenAPI's (and JSON Schema's) `camelCase` convention.
 
 If the ExDoc-based operation specs don't provide the flexibiliy you need, the `%Operation{}` struct
 and related structs can be used instead. See the

--- a/examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller.ex
+++ b/examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller.ex
@@ -1,4 +1,13 @@
 defmodule PhoenixAppWeb.UserController do
+  @moduledoc """
+  Demonstration of defining OpenApi operations from the controller module
+  using the ExDoc-based operation specs.
+
+  At the module level, define a `@moduledoc` to define the tags for the controller's operations.
+  """
+
+  @moduledoc ["users"]
+
   use PhoenixAppWeb, :controller
   import OpenApiSpex.Operation, only: [parameter: 5, request_body: 4, response: 3]
   alias OpenApiSpex.Operation
@@ -7,46 +16,32 @@ defmodule PhoenixAppWeb.UserController do
 
   plug OpenApiSpex.Plug.CastAndValidate
 
-  def open_api_operation(action) do
-    apply(__MODULE__, :"#{action}_operation", [])
-  end
+  @doc """
+  List users
 
-  def index_operation() do
-    %Operation{
-      tags: ["users"],
-      summary: "List users",
-      description: "List all useres",
-      operationId: "UserController.index",
-      responses: %{
-        200 => response("User List Response", "application/json", Schemas.UsersResponse)
-      }
-    }
-  end
-
+  List all users
+  """
+  @doc responses: [
+         ok: {"User List Response", "application/json", Schemas.UserResponse}
+       ]
   def index(conn, _params) do
     users = Accounts.list_users()
     render(conn, "index.json", users: users)
   end
 
-  def create_operation() do
-    %Operation{
-      tags: ["users"],
-      summary: "Create user",
-      description: "Create a user",
-      operationId: "UserController.create",
-      parameters: [
-        Operation.parameter(:group_id, :path, :integer, "Group ID", example: 1)
-      ],
-      requestBody:
-        request_body("The user attributes", "application/json", Schemas.UserRequest,
-          required: true
-        ),
-      responses: %{
-        201 => response("User", "application/json", Schemas.UserResponse)
-      }
-    }
-  end
+  @doc """
+  Create user (this line becomes the operation's `summary`)
 
+  Create a user (this block of text becomes the operation's `description`)
+  """
+  @doc parameters: [
+         group_id: [in: :path, type: :integer, description: "Group ID", example: 1]
+       ],
+       request_body:
+         {"The user attributes", "application/json", Schemas.UserRequest, required: true},
+       responses: [
+         created: {"User", "application/json", Schemas.UserResponse}
+       ]
   def create(conn = %{body_params: %Schemas.UserRequest{user: user_params}}, %{
         group_id: _group_id
       }) do
@@ -59,23 +54,16 @@ defmodule PhoenixAppWeb.UserController do
   end
 
   @doc """
-  API Spec for :show action
-  """
-  def show_operation() do
-    %Operation{
-      tags: ["users"],
-      summary: "Show user",
-      description: "Show a user by ID",
-      operationId: "UserController.show",
-      parameters: [
-        parameter(:id, :path, :integer, "User ID", example: 123, required: true)
-      ],
-      responses: %{
-        200 => response("User", "application/json", Schemas.UserResponse)
-      }
-    }
-  end
+  Show user.
 
+  Show a user by ID.
+  """
+  @doc parameters: [
+         id: [in: :path, type: :integer, description: "User ID", example: 123, required: true]
+       ],
+       responses: [
+         ok: {"User", "application/json", Schemas.UserResponse}
+       ]
   def show(conn, %{id: id}) do
     user = Accounts.get_user!(id)
     render(conn, "show.json", user: user)

--- a/examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller.ex
+++ b/examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller.ex
@@ -6,7 +6,7 @@ defmodule PhoenixAppWeb.UserController do
   At the module level, define a `@moduledoc` to define the tags for the controller's operations.
   """
 
-  @moduledoc ["users"]
+  @moduledoc tags: ["users"]
 
   use PhoenixAppWeb, :controller
   alias OpenApiSpex.{Operation, Schema}

--- a/examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller.ex
+++ b/examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller.ex
@@ -9,8 +9,7 @@ defmodule PhoenixAppWeb.UserController do
   @moduledoc ["users"]
 
   use PhoenixAppWeb, :controller
-  import OpenApiSpex.Operation, only: [parameter: 5, request_body: 4, response: 3]
-  alias OpenApiSpex.Operation
+  alias OpenApiSpex.{Operation, Schema}
   alias PhoenixApp.{Accounts, Accounts.User}
   alias PhoenixAppWeb.Schemas
 
@@ -59,7 +58,14 @@ defmodule PhoenixAppWeb.UserController do
   Show a user by ID.
   """
   @doc parameters: [
-         id: [in: :path, type: :integer, description: "User ID", example: 123, required: true]
+         id: [
+           in: :path,
+           # `:type` can be an atom, %Schema{}, or %Reference{}
+           type: %Schema{type: :integer, minimum: 1},
+           description: "User ID",
+           example: 123,
+           required: true
+         ]
        ],
        responses: [
          ok: {"User", "application/json", Schemas.UserResponse}

--- a/examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller_with_struct_specs.ex
+++ b/examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller_with_struct_specs.ex
@@ -1,0 +1,100 @@
+defmodule PhoenixAppWeb.UserControllerWithStructSpecs do
+  @moduledoc """
+  Demonstration of using `%Operation{}` struct and related structs directly instead
+  of using the ExDoc-based operation specs.
+  """
+  use PhoenixAppWeb, :controller
+  import OpenApiSpex.Operation, only: [parameter: 5, request_body: 4, response: 3]
+  alias OpenApiSpex.Operation
+  alias PhoenixApp.{Accounts, Accounts.User}
+  alias PhoenixAppWeb.Schemas
+
+  plug OpenApiSpex.Plug.CastAndValidate
+
+  @doc """
+  The controller will need to define a callback function `open_api_operation/1`
+
+  This function takes an `action` atom that is the MVC controller action's function
+  name, and returns the `%Operation{}` struct for that action.
+
+  For improved code organization, it is recommended to decompose `open_api_operation/1`
+  into child functions, and delegate to those.
+  """
+  def open_api_operation(action) do
+    apply(__MODULE__, :"#{action}_operation", [])
+  end
+
+  @doc """
+  The `*_operation` functions are called by `open_api_operation/1`. They return the `%Operation{}`
+  for the given `action`.
+  """
+  def index_operation() do
+    %Operation{
+      tags: ["users"],
+      summary: "List users",
+      description: "List all useres",
+      operationId: "UserController.index",
+      responses: %{
+        200 => response("User List Response", "application/json", Schemas.UsersResponse)
+      }
+    }
+  end
+
+  def index(conn, _params) do
+    users = Accounts.list_users()
+    render(conn, "index.json", users: users)
+  end
+
+  def create_operation() do
+    %Operation{
+      tags: ["users"],
+      summary: "Create user",
+      description: "Create a user",
+      operationId: "UserController.create",
+      parameters: [
+        Operation.parameter(:group_id, :path, :integer, "Group ID", example: 1)
+      ],
+      requestBody:
+        request_body("The user attributes", "application/json", Schemas.UserRequest,
+          required: true
+        ),
+      responses: %{
+        201 => response("User", "application/json", Schemas.UserResponse)
+      }
+    }
+  end
+
+  def create(conn = %{body_params: %Schemas.UserRequest{user: user_params}}, %{
+        group_id: _group_id
+      }) do
+    with {:ok, %User{} = user} <- Accounts.create_user(user_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", user_path(conn, :show, user))
+      |> render("show.json", user: user)
+    end
+  end
+
+  @doc """
+  API Spec for :show action
+  """
+  def show_operation() do
+    %Operation{
+      tags: ["users"],
+      summary: "Show user",
+      description: "Show a user by ID",
+      operationId: "UserController.show",
+      parameters: [
+        parameter(:id, :path, :integer, "User ID", example: 123, required: true)
+      ],
+      responses: %{
+        200 => response("User", "application/json", Schemas.UserResponse)
+      }
+    }
+  end
+
+  def show(conn, %{id: id}) do
+    user = Accounts.get_user!(id)
+    render(conn, "show.json", user: user)
+  end
+end

--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -152,15 +152,16 @@ defmodule OpenApiSpex.Controller do
         _ -> false
       end)
 
-    if doc_for_function do
-      {_, _, _, docs, meta} = doc_for_function
-      docs = Map.get(docs, "en", "")
-      [summary | _] = String.split(docs, ~r/\n\s*\n/, parts: 2)
+    case doc_for_function do
+      {_, _, _, docs, meta} when is_map(docs) ->
+        docs = Map.get(docs, "en", "")
+        [summary | _] = String.split(docs, ~r/\n\s*\n/, parts: 2)
 
-      {:ok, {mod_meta, summary, docs, meta}}
-    else
-      IO.warn("No docs found for function #{module}.#{name}/2")
-      nil
+        {:ok, {mod_meta, summary, docs, meta}}
+
+      _ ->
+        IO.warn("No docs found for function #{module}.#{name}/2")
+        nil
     end
   end
 

--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -57,6 +57,14 @@ defmodule OpenApiSpex.Controller do
   ]
   ```
 
+  If a response has no body, the definition may be simplified further:
+
+  ```
+  [
+    no_content: "Empty response"
+  ]
+  ```
+
   For each key in the key-value list of map, either an HTTP status code can be used or its atom equivalent.
 
   The full set of atom keys are defined in `Plug.Conn.Status.code/1`.
@@ -191,6 +199,9 @@ defmodule OpenApiSpex.Controller do
 
       {status, %Response{} = response} ->
         {Plug.Conn.Status.code(status), response}
+
+      {status, description} when is_binary(description) ->
+        {Plug.Conn.Status.code(status), %Response{description: description}}
     end)
   end
 

--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -11,6 +11,7 @@ defmodule OpenApiSpex.Controller do
   documentation will be used as `description` field.
 
   ### `operation_id`
+
   The action's `operation_id` can be set explicitly using a `@doc` tag.
   If no `operation_id` is specified, it will default to the action's module path: `Module.Name.function_name`
 
@@ -28,6 +29,14 @@ defmodule OpenApiSpex.Controller do
   Where `definition` is `OpenApiSpex.Parameter.t()` structure or map or keyword
   list that accepts the same arguments.
 
+  Example:
+
+  ```elixir
+  @doc parameters: [
+    group_id: [in: :path, type: :integer, description: "Group ID", example: 1]
+  ]
+  ```
+
   ### `responses`
 
   Responses are controlled by `:responses` tag. Responses must be defined as
@@ -40,7 +49,17 @@ defmodule OpenApiSpex.Controller do
   }
   ```
 
-  Where atoms are the same as `Plug.Conn.Status.code/1` values.
+  Or:
+  ```
+  [
+    ok: {"Response name", "application/json", schema},
+    not_found: {"Response name", "application/json", schema}
+  ]
+  ```
+
+  For each key in the key-value list of map, either an HTTP status code can be used or its atom equivalent.
+
+  The full set of atom keys are defined in `Plug.Conn.Status.code/1`.
 
   ### `requestBody`
 

--- a/test/operation_test.exs
+++ b/test/operation_test.exs
@@ -8,29 +8,35 @@ defmodule OpenApiSpex.OperationTest do
       plug = UserController
       plug_opts = :show
 
-      route = Phoenix.Router.Route.build(
-        _line = nil,
-        _kind = :match,
-        _verb = :atom,
-        _path = nil,
-        _host = nil,
-        plug,
-        plug_opts,
-        _helper = nil,
-        _pipe_through = [],
-        _private = %{},
-        _assigns = %{}
-      )
-      assert Operation.from_route(route) == UserController.show_operation()
+      route =
+        Phoenix.Router.Route.build(
+          _line = nil,
+          _kind = :match,
+          _verb = :atom,
+          _path = nil,
+          _host = nil,
+          plug,
+          plug_opts,
+          _helper = nil,
+          _pipe_through = [],
+          _private = %{},
+          _assigns = %{}
+        )
+
+      assert Operation.from_route(route) ==
+               UserController.open_api_operation(:show)
     end
 
     test "from_route ~ phoenix v1.4.7+" do
       route = %{plug: UserController, plug_opts: :show}
-      assert Operation.from_route(route) == UserController.show_operation()
+
+      assert Operation.from_route(route) ==
+               UserController.open_api_operation(:show)
     end
 
     test "from_plug" do
-      assert Operation.from_plug(UserController, :show) == UserController.show_operation()
+      assert Operation.from_plug(UserController, :show) ==
+               UserController.open_api_operation(:show)
     end
   end
 end

--- a/test/path_item_test.exs
+++ b/test/path_item_test.exs
@@ -11,10 +11,11 @@ defmodule OpenApiSpex.PathItemTest do
             do: route
 
       path_item = PathItem.from_routes(routes)
+
       assert path_item == %PathItem{
-        get: UserController.index_operation(),
-        post: UserController.create_operation()
-      }
+               get: UserController.open_api_operation(:index),
+               post: UserController.open_api_operation(:create)
+             }
     end
   end
 end

--- a/test/support/cast_and_validate/custom_error_user_controller.ex
+++ b/test/support/cast_and_validate/custom_error_user_controller.ex
@@ -1,6 +1,5 @@
 defmodule OpenApiSpexTest.CastAndValidate.CustomErrorUserController do
   use Phoenix.Controller
-  alias OpenApiSpex.Operation
   alias OpenApiSpexTest.Schemas
   alias Plug.Conn
 
@@ -21,27 +20,17 @@ defmodule OpenApiSpexTest.CastAndValidate.CustomErrorUserController do
 
   plug OpenApiSpex.Plug.CastAndValidate, render_error: CustomRenderErrorPlug
 
-  def open_api_operation(action) do
-    apply(__MODULE__, :"#{action}_operation", [])
-  end
+  @doc """
+  List users
 
-  def index_operation() do
-    import Operation
-
-    %Operation{
-      tags: ["users"],
-      summary: "List users",
-      description: "List all useres",
-      operationId: "UserController.index",
-      parameters: [
-        parameter(:validParam, :query, :boolean, "Valid Param", example: true)
-      ],
-      responses: %{
-        200 => response("User List Response", "application/json", Schemas.UsersResponse)
-      }
-    }
-  end
-
+  List all users
+  """
+  @doc parameters: [
+         validParam: [in: :query, type: :boolean, description: "Valid Param", example: true]
+       ],
+       responses: [
+         ok: {"User List Response", "application/json", Schemas.UsersResponse}
+       ]
   def index(conn, _params) do
     json(conn, %Schemas.UsersResponse{
       data: [

--- a/test/support/custom_error_user_controller.ex
+++ b/test/support/custom_error_user_controller.ex
@@ -1,6 +1,7 @@
 defmodule OpenApiSpexTest.CustomErrorUserController do
   use Phoenix.Controller
-  alias OpenApiSpex.Operation
+  use OpenApiSpex.Controller
+
   alias OpenApiSpexTest.Schemas
   alias Plug.Conn
 
@@ -21,27 +22,17 @@ defmodule OpenApiSpexTest.CustomErrorUserController do
 
   plug OpenApiSpex.Plug.CastAndValidate, render_error: CustomRenderErrorPlug
 
-  def open_api_operation(action) do
-    apply(__MODULE__, :"#{action}_operation", [])
-  end
+  @doc """
+  List users
 
-  def index_operation() do
-    import Operation
-
-    %Operation{
-      tags: ["users"],
-      summary: "List users",
-      description: "List all useres",
-      operationId: "UserController.index",
-      parameters: [
-        parameter(:validParam, :query, :boolean, "Valid Param", example: true)
-      ],
-      responses: %{
-        200 => response("User List Response", "application/json", Schemas.UsersResponse)
-      }
-    }
-  end
-
+  List all users
+  """
+  @doc parameters: [
+         validParam: [in: :query, type: :boolean, description: "Valid Param", example: true]
+       ],
+       responses: [
+         ok: {"User List Response", "application/json", Schemas.UsersResponse}
+       ]
   def index(conn, _params) do
     json(conn, %Schemas.UsersResponse{
       data: [

--- a/test/support/pet_controller.ex
+++ b/test/support/pet_controller.ex
@@ -1,9 +1,9 @@
 defmodule OpenApiSpexTest.PetController do
-  @moduledoc ["pets"]
+  @moduledoc tags: ["pets"]
 
   use Phoenix.Controller
   use OpenApiSpex.Controller
-  alias OpenApiSpex.{Operation, Schema}
+  alias OpenApiSpex.Schema
   alias OpenApiSpexTest.Schemas
 
   plug OpenApiSpex.Plug.CastAndValidate
@@ -13,7 +13,7 @@ defmodule OpenApiSpexTest.PetController do
 
   Show a pet by ID.
   """
-  @def parameters: [
+  @doc parameters: [
          id: [
            in: :path,
            type: %Schema{type: :integer, minimum: 1},
@@ -33,6 +33,9 @@ defmodule OpenApiSpexTest.PetController do
     })
   end
 
+  @doc """
+  Get a list of pets.
+  """
   def index(conn, _params) do
     json(conn, %Schemas.PetsResponse{
       data: [

--- a/test/support/pet_controller.ex
+++ b/test/support/pet_controller.ex
@@ -1,34 +1,29 @@
 defmodule OpenApiSpexTest.PetController do
+  @moduledoc ["pets"]
+
   use Phoenix.Controller
+  use OpenApiSpex.Controller
   alias OpenApiSpex.{Operation, Schema}
   alias OpenApiSpexTest.Schemas
 
   plug OpenApiSpex.Plug.CastAndValidate
 
-  def open_api_operation(action) do
-    apply(__MODULE__, :"#{action}_operation", [])
-  end
-
   @doc """
-  API Spec for :show action
+  Show pet.
+
+  Show a pet by ID.
   """
-  def show_operation() do
-    import Operation
-
-    %Operation{
-      tags: ["pets"],
-      summary: "Show pet",
-      description: "Show a pet by ID",
-      operationId: "PetController.show",
-      parameters: [
-        parameter(:id, :path, %Schema{type: :integer, minimum: 1}, "Pet ID", example: 123)
-      ],
-      responses: %{
-        200 => response("Pet", "application/json", Schemas.PetResponse)
-      }
-    }
-  end
-
+  @def parameters: [
+         id: [
+           in: :path,
+           type: %Schema{type: :integer, minimum: 1},
+           description: "Pet ID",
+           example: 123
+         ]
+       ],
+       responses: [
+         ok: {"Pet", "application/json", Schemas.PetResponse}
+       ]
   def show(conn, %{id: _id}) do
     json(conn, %Schemas.PetResponse{
       data: %Schemas.Dog{
@@ -36,23 +31,6 @@ defmodule OpenApiSpexTest.PetController do
         bark: "woof"
       }
     })
-  end
-
-  def index_operation() do
-    import Operation
-
-    %Operation{
-      tags: ["pets"],
-      summary: "List pets",
-      description: "List all petes",
-      operationId: "PetController.index",
-      parameters: [
-        parameter(:validParam, :query, :boolean, "Valid Param", example: true)
-      ],
-      responses: %{
-        200 => response("Pet List Response", "application/json", Schemas.PetsResponse)
-      }
-    }
   end
 
   def index(conn, _params) do
@@ -66,53 +44,51 @@ defmodule OpenApiSpexTest.PetController do
     })
   end
 
-  def create_operation() do
-    import Operation
+  @doc """
+  Create pet.
 
-    %Operation{
-      tags: ["pets"],
-      summary: "Create pet",
-      description: "Create a pet",
-      operationId: "PetController.create",
-      parameters: [],
-      requestBody: request_body("The pet attributes", "application/json", Schemas.PetRequest),
-      responses: %{
-        201 => response("Pet", "application/json", Schemas.PetRequest)
-      }
-    }
-  end
+  Create a pet.
+  """
+  @doc request_body:
+         {"The pet attributes", "application/json", Schemas.PetRequest, required: true},
+       responses: [
+         created: {"Pet", "application/json", Schemas.PetRequest}
+       ]
+  def create(conn, _) do
+    %Schemas.PetRequest{pet: pet} = Map.get(conn, :body_params)
 
-  def create(conn = %{body_params: %Schemas.PetRequest{pet: pet}}, _) do
     json(conn, %Schemas.PetResponse{
       data: pet
     })
   end
 
-  def adopt_operation() do
-    import Operation
+  @doc """
+  Adopt pet.
 
-    %Operation{
-      tags: ["pets"],
-      summary: "Adopt pet",
-      description: "Adopt a pet",
-      operationId: "PetController.adopt",
-      parameters: [
-        parameter(:"x-user-id", :header, :string, "User that performs this action", required: true),
-        parameter(:id, :path, %Schema{type: :integer, minimum: 1}, "Pet ID", example: 123),
-        parameter(:status, :query, Schemas.PetStatus, "New status"),
-        parameter(
-          :debug,
-          :cookie,
-          %Schema{type: :integer, enum: [0, 1], default: 0},
-          "Debug"
-        )
-      ],
-      responses: %{
-        200 => response("Pet", "application/json", Schemas.PetRequest)
-      }
-    }
-  end
-
+  Adopt a pet.
+  """
+  @doc parameters: [
+         {:"x-user-id",
+          in: :header,
+          type: :string,
+          description: "User that performs this action",
+          required: true},
+         id: [
+           in: :path,
+           type: %Schema{type: :integer, minimum: 1},
+           description: "Pet ID",
+           example: 123
+         ],
+         status: [in: :query, type: Schemas.PetStatus, description: "New status"],
+         debug: [
+           in: :cookie,
+           type: %Schema{type: :integer, enum: [0, 1], default: 0},
+           description: "Debug"
+         ]
+       ],
+       responses: [
+         ok: {"Pet", "application/json", Schemas.PetResponse}
+       ]
   def adopt(conn, %{:"x-user-id" => _user_id, :id => _id, :debug => 0}) do
     json(conn, %Schemas.PetResponse{
       data: %Schemas.Dog{
@@ -131,23 +107,16 @@ defmodule OpenApiSpexTest.PetController do
     })
   end
 
-  def appointment_operation() do
-    import Operation
+  @doc """
+  Create pet.
 
-    %Operation{
-      tags: ["pets"],
-      summary: "Create pet",
-      description: "Create a pet",
-      operationId: "PetController.appointment",
-      parameters: [],
-      requestBody:
-        request_body("The pet attributes", "application/json", Schemas.PetAppointmentRequest),
-      responses: %{
-        201 => response("Pet", "application/json", Schemas.PetResponse)
-      }
-    }
-  end
-
+  Create a pet.
+  """
+  @doc request_body:
+         {"The pet attributes", "application/json", Schemas.PetAppointmentRequest, required: true},
+       responses: [
+         created: {"Pet", "application/json", Schemas.PetResponse}
+       ]
   def appointment(conn, _) do
     json(conn, %Schemas.PetResponse{
       data: [%{pet_type: "Dog", bark: "bow wow"}]

--- a/test/support/user_controller.ex
+++ b/test/support/user_controller.ex
@@ -84,7 +84,7 @@ defmodule OpenApiSpexTest.UserController do
        request_body: {"Contact info", "application/json", Schemas.ContactInfo},
        responses: [
          # TODO allow specifyng no respond body
-         no_content: {"OK", nil, nil}
+         no_content: "OK"
        ]
   def contact_info(conn = %{body_params: %Schemas.ContactInfo{}}, %{id: id}) do
     conn

--- a/test/support/user_controller.ex
+++ b/test/support/user_controller.ex
@@ -1,34 +1,30 @@
 defmodule OpenApiSpexTest.UserController do
+  @moduledoc tags: ["users"]
+
   use Phoenix.Controller
-  alias OpenApiSpex.{Operation, Schema}
+  use OpenApiSpex.Controller
+
+  alias OpenApiSpex.Schema
   alias OpenApiSpexTest.Schemas
 
   plug OpenApiSpex.Plug.CastAndValidate
 
-  def open_api_operation(action) do
-    apply(__MODULE__, :"#{action}_operation", [])
-  end
-
   @doc """
-  API Spec for :show action
+  Show user
+
+  Show a user by ID
   """
-  def show_operation() do
-    import Operation
-
-    %Operation{
-      tags: ["users"],
-      summary: "Show user",
-      description: "Show a user by ID",
-      operationId: "UserController.show",
-      parameters: [
-        parameter(:id, :path, %Schema{type: :integer, minimum: 1}, "User ID", example: 123)
-      ],
-      responses: %{
-        200 => response("User", "application/json", Schemas.UserResponse)
-      }
-    }
-  end
-
+  @doc parameters: [
+         id: [
+           in: :path,
+           type: %Schema{type: :integer, minimum: 1},
+           description: "User ID",
+           example: 123
+         ]
+       ],
+       responses: [
+         ok: {"User", "application/json", Schemas.UserResponse}
+       ]
   def show(conn, %{id: id}) do
     json(conn, %Schemas.UserResponse{
       data: %Schemas.User{
@@ -39,23 +35,17 @@ defmodule OpenApiSpexTest.UserController do
     })
   end
 
-  def index_operation() do
-    import Operation
+  @doc """
+  List users
 
-    %Operation{
-      tags: ["users"],
-      summary: "List users",
-      description: "List all useres",
-      operationId: "UserController.index",
-      parameters: [
-        parameter(:validParam, :query, :boolean, "Valid Param", example: true)
-      ],
-      responses: %{
-        200 => response("User List Response", "application/json", Schemas.UsersResponse)
-      }
-    }
-  end
-
+  List all users
+  """
+  @doc parameters: [
+         validParam: [in: :query, type: :boolean, description: "Valid Param", example: true]
+       ],
+       responses: [
+         ok: {"User List Response", "application/json", Schemas.UsersResponse}
+       ]
   def index(conn, _params) do
     json(conn, %Schemas.UsersResponse{
       data: [
@@ -68,71 +58,56 @@ defmodule OpenApiSpexTest.UserController do
     })
   end
 
-  def create_operation() do
-    import Operation
+  @doc """
+  Create user.
 
-    %Operation{
-      tags: ["users"],
-      summary: "Create user",
-      description: "Create a user",
-      operationId: "UserController.create",
-      parameters: [],
-      requestBody: request_body("The user attributes", "application/json", Schemas.UserRequest),
-      responses: %{
-        201 => response("User", "application/json", Schemas.UserResponse)
-      }
-    }
-  end
-
+  Create a user.
+  """
+  @doc request_body: {"The user attributes", "application/json", Schemas.UserRequest},
+       responses: [
+         created: {"User", "application/json", Schemas.UserResponse}
+       ]
   def create(conn = %{body_params: %Schemas.UserRequest{user: user = %Schemas.User{}}}, _) do
     json(conn, %Schemas.UserResponse{
       data: %{user | id: 1234}
     })
   end
 
-  def contact_info_operation() do
-    import Operation
+  @doc """
+  Update contact info
 
-    %Operation{
-      tags: ["users"],
-      summary: "Update contact info",
-      description: "Update contact info",
-      operationId: "UserController.contact_info",
-      parameters: [
-        parameter(:id, :path, :integer, "user ID")
-      ],
-      requestBody: request_body("Contact info", "application/json", Schemas.ContactInfo),
-      responses: %{
-        200 => %OpenApiSpex.Response{
-          description: "OK"
-        }
-      }
-    }
-  end
-
+  Update contact info
+  """
+  @doc parameters: [
+         id: [in: :path, type: :integer, description: "user ID"]
+       ],
+       request_body: {"Contact info", "application/json", Schemas.ContactInfo},
+       responses: [
+         # TODO allow specifyng no respond body
+         no_content: {"OK", nil, nil}
+       ]
   def contact_info(conn = %{body_params: %Schemas.ContactInfo{}}, %{id: id}) do
     conn
     |> put_status(200)
     |> json(%{id: id})
   end
 
-  def payment_details_operation() do
-    import Operation
+  @doc """
+  Show user payment details.
 
-    %Operation{
-      tags: ["users"],
-      summary: "Show user payment details",
-      description: "Shows a users payment details",
-      operationId: "UserController.payment_details",
-      parameters: [
-        parameter(:id, :path, %Schema{type: :integer, minimum: 1}, "User ID", example: 123)
-      ],
-      responses: %{
-        200 => response("Payment Details", "application/json", Schemas.PaymentDetails)
-      }
-    }
-  end
-
+  Shows a users payment details.
+  """
+  @doc parameters: [
+         id: [
+           in: :path,
+           type: %Schema{type: :integer, minimum: 1},
+           description: "User ID",
+           example: 123
+         ]
+       ],
+       responses: [
+         ok: {"Payment Details", "application/json", Schemas.PaymentDetails}
+       ]
   def payment_details(conn, %{"id" => id}) do
     response =
       case rem(id, 2) do
@@ -154,22 +129,16 @@ defmodule OpenApiSpexTest.UserController do
     json(conn, response)
   end
 
-  def create_entity_operation() do
-    import Operation
+  @doc """
+  Create an EntityWithDict
 
-    %Operation{
-      tags: ["EntityWithDict"],
-      summary: "Create an EntityWithDict",
-      description: "Create an EntityWithDict",
-      operationId: "UserController.create_entity",
-      parameters: [],
-      requestBody: request_body("Entity attributes", "application/json", Schemas.EntityWithDict),
-      responses: %{
-        201 => response("EntityWithDict", "application/json", Schemas.EntityWithDict)
-      }
-    }
-  end
-
+  Create an EntityWithDict
+  """
+  @doc tags: ["EntityWithDict"],
+       request_body: {"Entity attributes", "application/json", Schemas.EntityWithDict},
+       responses: [
+         created: {"EntityWithDict", "application/json", Schemas.EntityWithDict}
+       ]
   def create_entity(conn, %Schemas.EntityWithDict{} = entity) do
     json(conn, Map.put(entity, :id, 123))
   end

--- a/test/support/utility_controller.ex
+++ b/test/support/utility_controller.ex
@@ -1,30 +1,26 @@
 defmodule OpenApiSpexTest.UtilityController do
   use Phoenix.Controller
-  alias OpenApiSpex.Operation
+  use OpenApiSpex.Controller
+
   alias OpenApiSpex.Schema
 
   plug OpenApiSpex.Plug.CastAndValidate
 
-  def open_api_operation(action) do
-    apply(__MODULE__, :"#{action}_operation", [])
-  end
-
-  def echo_any_operation() do
-    import Operation
-
-    %Operation{
-      tags: ["utility"],
-      summary: "Echo parameters",
-      operationId: "UtilityController.echo",
-      parameters: [
-        parameter(:freeForm, :query, %Schema{type: :object, additionalProperties: true}, "unspecified list of anything")
-      ],
-      responses: %{
-        200 => response("Casted Result", "application/json", %Schema{type: :object, additionalProperties: true})
-      }
-    }
-  end
-
+  @doc """
+  Echo parameters
+  """
+  @doc parameters: [
+         freeForm: [
+           in: :query,
+           type: %Schema{type: :object, additionalProperties: true},
+           description: "unspecified list of anything"
+         ]
+       ],
+       responses: [
+         ok:
+           {"Casted Result", "application/json",
+            %Schema{type: :object, additionalProperties: true}}
+       ]
   def echo_any(conn, params) do
     json(conn, params)
   end


### PR DESCRIPTION
Converts to using ExDoc-based operation specs. All struct-based specs have been converted throughout the codebase, except for examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller_with_struct_specs.ex.

The README now uses ExDoc-based operation spec examples exclusively.

Also adds two small spec parsing improvements to `OpenApiSpex.Controller` to reduce sharp edges a bit.