### PR TITLE
[bugfix for issue #229] CastAndValidate should validate JSON Array as RequestBody

### DIFF
--- a/lib/open_api_spex/cast/array.ex
+++ b/lib/open_api_spex/cast/array.ex
@@ -14,6 +14,14 @@ defmodule OpenApiSpex.Cast.Array do
     end
   end
 
+  def cast(%{value: %{"_json" => items}} = ctx) when is_list(items) do
+    case cast_array(%{ctx | value: items}) do
+      {:cast, ctx} -> cast(ctx)
+      {items, []} -> Cast.ok(%{ctx | value: %{"_json" => items}})
+      {_, errors} -> {:error, errors}
+    end
+  end
+
   def cast(ctx),
     do: Cast.error(ctx, {:invalid_type, :array})
 

--- a/lib/open_api_spex/cast/array.ex
+++ b/lib/open_api_spex/cast/array.ex
@@ -14,14 +14,6 @@ defmodule OpenApiSpex.Cast.Array do
     end
   end
 
-  def cast(%{value: %{"_json" => items}} = ctx) when is_list(items) do
-    case cast_array(%{ctx | value: items}) do
-      {:cast, ctx} -> cast(ctx)
-      {items, []} -> Cast.ok(%{ctx | value: %{"_json" => items}})
-      {_, errors} -> {:error, errors}
-    end
-  end
-
   def cast(ctx),
     do: Cast.error(ctx, {:invalid_type, :array})
 

--- a/test/plug/cast_test.exs
+++ b/test/plug/cast_test.exs
@@ -298,5 +298,19 @@ defmodule OpenApiSpex.Plug.CastTest do
                "anything" => "true"
              }
     end
+
+    test "send request body as json array is validated correctly" do
+      request_body = [%{"one" => "this"}]
+
+      conn =
+        :post
+        |> Plug.Test.conn("api/utility/echo/body_params", Jason.encode!(request_body))
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> OpenApiSpexTest.Router.call([])
+
+      # Phoenix parses json body params that start with array as structs starting with _json key
+      # https://github.com/phoenixframework/phoenix/blob/3f8d0d058069b1f0a2af089a6c4c2d9efed73796/test/phoenix/test/conn_test.exs#L117
+      assert Jason.decode!(conn.resp_body) == %{"_json" => [%{"one" => "this"}]}
+    end
   end
 end

--- a/test/plug/cast_test.exs
+++ b/test/plug/cast_test.exs
@@ -309,7 +309,7 @@ defmodule OpenApiSpex.Plug.CastTest do
         |> OpenApiSpexTest.Router.call([])
 
       # Phoenix parses json body params that start with array as structs starting with _json key
-      # https://github.com/phoenixframework/phoenix/blob/3f8d0d058069b1f0a2af089a6c4c2d9efed73796/test/phoenix/test/conn_test.exs#L117
+      # https://hexdocs.pm/plug/Plug.Parsers.JSON.html
       assert Jason.decode!(conn.resp_body) == %{"_json" => [%{"one" => "this"}]}
     end
   end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -26,5 +26,6 @@ defmodule OpenApiSpexTest.Router do
     post "/pets/appointment", PetController, :appointment
 
     get "/utility/echo/any", UtilityController, :echo_any
+    post "/utility/echo/body_params", UtilityController, :echo_body_params
   end
 end

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -568,4 +568,15 @@ defmodule OpenApiSpexTest.Schemas do
       }
     })
   end
+
+  defmodule EchoBodyParamsRequest do
+    OpenApiSpex.schema(%{
+      title: "EchoBodyParamsRequest",
+      description: "Echo body params request",
+      type: :array,
+      items: %Schema{
+        type: :object,
+      }
+    })
+  end
 end

--- a/test/support/utility_controller.ex
+++ b/test/support/utility_controller.ex
@@ -2,6 +2,7 @@ defmodule OpenApiSpexTest.UtilityController do
   use Phoenix.Controller
   alias OpenApiSpex.Operation
   alias OpenApiSpex.Schema
+  alias OpenApiSpexTest.Schemas
 
   plug OpenApiSpex.Plug.CastAndValidate
 
@@ -23,6 +24,33 @@ defmodule OpenApiSpexTest.UtilityController do
         200 => response("Casted Result", "application/json", %Schema{type: :object, additionalProperties: true})
       }
     }
+  end
+
+  def echo_body_params_operation() do
+    import Operation
+
+    %Operation{
+      tags: ["utility"],
+      summary: "Echo body params",
+      operationId: "UtilityController.echo_body_params",
+      requestBody: request_body("Echo body params", "application/json", Schemas.EchoBodyParamsRequest),
+      responses: %{
+        200 =>
+          response("Echo Body Params Result", "application/json", %Schema{
+            type: :array,
+            items: %Schema{
+              type: :object,
+              properties: %{
+                one: %Schema{type: :string}
+              }
+            }
+          })
+      }
+    }
+  end
+
+  def echo_body_params(conn, _) do
+    json(conn, conn.body_params)
   end
 
   def echo_any(conn, params) do


### PR DESCRIPTION
👋  This is a fix for issue #229.

- The fix is adding another matching for key "_json" and getting the items inside as the values.
- I don't alter in any way the `conn` object, so it does not brake other plugins that might go after this one.
- I've added a test with a new endpoint inside `utility_controller` since none of the resources already existing in the test suite have a scheme starting with array.
- The fix is directly coupled to the key `_json` that [Phoenix uses to parse the array JSON](https://github.com/phoenixframework/phoenix/blob/3f8d0d058069b1f0a2af089a6c4c2d9efed73796/test/phoenix/test/conn_test.exs#L117). Another possible solution is to just get the list of items if the start type of the Scheme is `:array` and the received value is a map, but I think that opens the door to unwanted behaviors. This way is explicit in the code that this specific parsing is due to that key existing in the map.

