### PR TITLE
Handle missing description

### DIFF
--- a/examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller.ex
+++ b/examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller.ex
@@ -9,7 +9,9 @@ defmodule PhoenixAppWeb.UserController do
   @moduledoc tags: ["users"]
 
   use PhoenixAppWeb, :controller
-  alias OpenApiSpex.{Operation, Schema}
+  use OpenApiSpex.Controller
+
+  alias OpenApiSpex.Schema
   alias PhoenixApp.{Accounts, Accounts.User}
   alias PhoenixAppWeb.Schemas
 

--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -136,14 +136,14 @@ defmodule OpenApiSpex.Controller do
   @doc false
   @spec __api_operation__(module(), atom()) :: Operation.t() | nil
   def __api_operation__(mod, name) do
-    with {:ok, {mod_meta, summary, docs, meta}} <- get_docs(mod, name) do
+    with {:ok, {mod_meta, summary, description, meta}} <- get_docs(mod, name) do
       %Operation{
-        description: docs,
+        summary: summary,
+        description: description,
         operationId: build_operation_id(meta, mod, name),
         parameters: build_parameters(meta),
         requestBody: build_request_body(meta),
         responses: build_responses(meta),
-        summary: summary,
         tags: Map.get(mod_meta, :tags, []) ++ Map.get(meta, :tags, [])
       }
     else
@@ -162,10 +162,15 @@ defmodule OpenApiSpex.Controller do
 
     case doc_for_function do
       {_, _, _, docs, meta} when is_map(docs) ->
-        docs = Map.get(docs, "en", "")
-        [summary | _] = String.split(docs, ~r/\n\s*\n/, parts: 2)
+        description = Map.get(docs, "en", "")
+        [summary | _] = String.split(description, ~r/\n\s*\n/, parts: 2)
 
-        {:ok, {mod_meta, summary, docs, meta}}
+        {:ok, {mod_meta, summary, description, meta}}
+
+      {_, _, _, :none, meta} ->
+        summary = ""
+        description = ""
+        {:ok, {mod_meta, summary, description, meta}}
 
       _ ->
         IO.warn("No docs found for function #{module}.#{name}/2")

--- a/test/controller_test.exs
+++ b/test/controller_test.exs
@@ -53,5 +53,12 @@ defmodule OpenApiSpex.ControllerTest do
       op = @controller.open_api_operation(:show)
       assert op.operationId == "show_user"
     end
+
+    test "handles missing description docs" do
+      op = @controller.open_api_operation(:minimal_docs)
+      assert op.description == ""
+      assert op.summary == ""
+      assert %{200 => %{description: "Empty"}} = op.responses
+    end
   end
 end

--- a/test/support/user_controller_annotated.ex
+++ b/test/support/user_controller_annotated.ex
@@ -39,4 +39,7 @@ defmodule OpenApiSpexTest.UserControllerAnnotated do
          ok: {"User response", "application/json", User}
        ]
   def show(_conn, _params), do: :ok
+
+  @doc responses: [ok: "Empty"]
+  def minimal_docs(_conn, _params), do: :ok
 end


### PR DESCRIPTION
Gracefully handle cases where a user omits the `@doc` string for an operation.

