### PR TITLE
Handle doc false

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ and the HTTP status codes can be replaced with their text equivalents:
   ]
 ```
 
+If you need to omit the spec for some action then pass false to the generator:
+```elixir
+@doc false
+````
+
 The full set of atom keys are defined in `Plug.Conn.Status.code/1`.
 
 Each definition in a controller action or plug operation is converted

--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -167,13 +167,19 @@ defmodule OpenApiSpex.Controller do
 
         {:ok, {mod_meta, summary, description, meta}}
 
-      {_, _, _, :none, meta} ->
+      {_, _, _, :none, %{responses: _responses} = meta} ->
         summary = ""
         description = ""
         {:ok, {mod_meta, summary, description, meta}}
 
-      _ ->
+      {_, _, _, :none, %{}} ->
         IO.warn("No docs found for function #{module}.#{name}/2")
+
+      {_, _, _, :hidden, %{}} ->
+        nil
+
+      _ ->
+        IO.warn("Invalid docs declaration found for function #{module}.#{name}/2")
         nil
     end
   end

--- a/test/controller_test.exs
+++ b/test/controller_test.exs
@@ -3,6 +3,8 @@ defmodule OpenApiSpex.ControllerTest do
 
   alias OpenApiSpex.Controller, as: Subject
 
+  import ExUnit.CaptureIO
+
   doctest Subject
 
   @controller OpenApiSpexTest.UserControllerAnnotated
@@ -59,6 +61,18 @@ defmodule OpenApiSpex.ControllerTest do
       assert op.description == ""
       assert op.summary == ""
       assert %{200 => %{description: "Empty"}} = op.responses
+    end
+
+    test "has no docs when false" do
+      assert capture_io(:stderr, fn ->
+        refute @controller.open_api_operation(:skip_this_doc)
+      end) == ""
+    end
+
+    test "prints warn when no @doc specified" do
+      assert capture_io(:stderr, fn ->
+        refute @controller.open_api_operation(:no_doc_specified)
+      end) =~ ~r/warning:/
     end
   end
 end

--- a/test/support/user_controller_annotated.ex
+++ b/test/support/user_controller_annotated.ex
@@ -42,4 +42,9 @@ defmodule OpenApiSpexTest.UserControllerAnnotated do
 
   @doc responses: [ok: "Empty"]
   def minimal_docs(_conn, _params), do: :ok
+
+  @doc false
+  def skip_this_doc(_conn, _params), do: :ok
+
+  def no_doc_specified(_conn, _params), do: :ok
 end


### PR DESCRIPTION
Raised by https://github.com/open-api-spex/open_api_spex/issues/234
Allow to pass `false` to `@doc` annotation to skip the warning.
Actions without doc get warn as it was to notify the user about missing documentation.
Made a change to `readme.md` file for new setting