### PR TITLE
Make @doc parameters declaration consistent with open api

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ defmodule MyAppWeb.UserController do
 end
 ```
 
-There is a convinient shortcut `:type` for base data types supported by open api
+There is a convenient shortcut `:type` for base data types supported by open api
 ```elixir
 @doc parameters: [
   id: [in: :query, type: :string, required: true, description: "User ID"]

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ defmodule MyAppWeb.UserController do
   Update user
   """
   @doc parameters: [
-      id: [in: :query, type: :string, required: true, description: "User ID"]
+      id: [in: :query, schema: %OpenApiSpex.Schema{type: :string}, required: true, description: "User ID"]
     ],
     request_body: {"Request body to update a User", "application/json", User, required: true},
     responses: %{
@@ -126,6 +126,13 @@ defmodule MyAppWeb.UserController do
     end
   end
 end
+```
+
+There is a convinient shortcut `:type` for base data types supported by open api
+```elixir
+@doc parameters: [
+  id: [in: :query, type: :string, required: true, description: "User ID"]
+]
 ```
 
 The responses can also be defined using keyword list syntax,

--- a/test/controller_test.exs
+++ b/test/controller_test.exs
@@ -74,5 +74,11 @@ defmodule OpenApiSpex.ControllerTest do
         refute @controller.open_api_operation(:no_doc_specified)
       end) =~ ~r/warning:/
     end
+
+    test "fails on both type and schema specified" do
+      assert_raise ArgumentError, ~r/Both :type and :schema options were specified/,  fn ->
+        @controller.open_api_operation(:non_exlusive_paramter_type_schema_docs)
+      end
+    end
   end
 end

--- a/test/support/user_controller_annotated.ex
+++ b/test/support/user_controller_annotated.ex
@@ -47,4 +47,15 @@ defmodule OpenApiSpexTest.UserControllerAnnotated do
   def skip_this_doc(_conn, _params), do: :ok
 
   def no_doc_specified(_conn, _params), do: :ok
+
+  @doc parameters: [
+         id: [
+           in: :path,
+           type: :string,
+           schema: %OpenApiSpex.Schema{type: :string, format: :date},
+           required: true
+         ]
+       ],
+       responses: [ok: "Empty"]
+  def non_exlusive_paramter_type_schema_docs(_conn, _params), do: :ok
 end


### PR DESCRIPTION
Raised by https://github.com/open-api-spex/open_api_spex/issues/235

`parameters:` now support `:schema` key
Added exclusive `ArgumentError` check if both are specified
Updated the `readme.md` example with explicit `Schema` in parameters and shortcut usage