### PR TITLE
Remove default pop value for :type shortcut

### DIFF
--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -188,7 +188,7 @@ defmodule OpenApiSpex.Controller do
     if type != nil && schema != nil do
       raise ArgumentError,
         message: """
-        Both :type and :schema options were specified for #{inspect name}. Please specify only one.
+        Both :type and :schema options were specified for #{inspect(name)}. Please specify only one.
         :type is a shortcut for base data types https://swagger.io/docs/specification/data-models/data-types/
         which at the end imports as `%Schema{type: type}`. For more control over schemas please
         use @doc parameters: [
@@ -205,13 +205,15 @@ defmodule OpenApiSpex.Controller do
   defp build_parameters(%{parameters: params}) do
     for {name, options} <- params do
       {location, options} = Keyword.pop(options, :in, :query)
-      {type, options} = Keyword.pop(options, :type, :string)
+      {type, options} = Keyword.pop(options, :type, nil)
       {schema, options} = Keyword.pop(options, :schema, nil)
       {description, options} = Keyword.pop(options, :description, "")
 
       ensure_type_and_schema_exclusive!(name, type, schema)
 
-      Operation.parameter(name, location, type || schema, description, options)
+      schema = type || schema || :string
+
+      Operation.parameter(name, location, schema, description, options)
     end
   end
 

--- a/test/controller_test.exs
+++ b/test/controller_test.exs
@@ -74,6 +74,26 @@ defmodule OpenApiSpex.ControllerTest do
         refute @controller.open_api_operation(:no_doc_specified)
       end) =~ ~r/warning:/
     end
+  end
+
+  describe "spec parameters" do
+    test "pass when only schema specified" do
+      op = @controller.open_api_operation(:only_schema_parameter_present_docs)
+      assert [parameter] = op.parameters
+      assert %OpenApiSpex.Schema{type: :string} = parameter.schema
+      assert op.description == ""
+      assert op.summary == ""
+      assert %{200 => %{description: "Empty"}} = op.responses
+    end
+
+    test "pass when only type shortcut specified" do
+      op = @controller.open_api_operation(:only_type_parameter_present_docs)
+      assert [parameter] = op.parameters
+      assert %OpenApiSpex.Schema{type: :string} = parameter.schema
+      assert op.description == ""
+      assert op.summary == ""
+      assert %{200 => %{description: "Empty"}} = op.responses
+    end
 
     test "fails on both type and schema specified" do
       assert_raise ArgumentError, ~r/Both :type and :schema options were specified/,  fn ->

--- a/test/support/user_controller_annotated.ex
+++ b/test/support/user_controller_annotated.ex
@@ -49,6 +49,18 @@ defmodule OpenApiSpexTest.UserControllerAnnotated do
   def no_doc_specified(_conn, _params), do: :ok
 
   @doc parameters: [
+         id: [in: :path, type: :string, required: true]
+       ],
+       responses: [ok: "Empty"]
+  def only_schema_parameter_present_docs(_conn, _params), do: :ok
+
+  @doc parameters: [
+         id: [in: :path, type: :string, required: true]
+       ],
+       responses: [ok: "Empty"]
+  def only_type_parameter_present_docs(_conn, _params), do: :ok
+
+  @doc parameters: [
          id: [
            in: :path,
            type: :string,


### PR DESCRIPTION
Found a bug after PR in https://github.com/open-api-spex/open_api_spex/issues/235 with default type value at
```
{type, options} = Keyword.pop(options, :type, :string)
```
The exclusive constraint triggers in this case if I specified only `:schema`. 
Added few more tests to cover the case

Thanks
Hope nothing got damaged :)