### PR TITLE
Introduce new `detail` field in the response JSON of `JsonRenderError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,7 @@ New API
 ```elixir
 defmodule PhoenixAppWeb.UserController do
   use PhoenixAppWeb, :controller
-  plug OpenApiSpex.Plug.CastAndValidate
+  plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -365,6 +365,12 @@ It will be not needed in version 4.0.
 
 For Phoenix apps, the `operation_id` can be inferred from the contents of `conn.private`.
 
+The data shape of the default error renderer follows the JSON:API spec for error responses. For
+convenience, the `OpenApiSpex.JsonErrorResponse` schema module is available that specifies
+the shape, and it can be used in your API specs.
+
+Example usage of `CastAndValidate` in a Phoenix controller:
+
 ```elixir
 defmodule MyAppWeb.UserController do
   use MyAppWeb, :controller
@@ -384,6 +390,7 @@ defmodule MyAppWeb.UserController do
        request_body: {"The user attributes", "application/json", UserRequest},
        responses: %{
          201 => {"User", "application/json", UserResponse}
+         422 => OpenApiSpex.JsonErrorResponse.response()
        }
   def create(
         conn = %{

--- a/README.md
+++ b/README.md
@@ -355,10 +355,13 @@ Add the `OpenApiSpex.Plug.CastAndValidate` plug to a controller to validate requ
 
 ```elixir
 # Phoenix
-plug OpenApiSpex.Plug.CastAndValidate
+plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
 # Plug
-plug OpenApiSpex.Plug.CastAndValidate, operation_id: "UserController.create"
+plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true, operation_id: "UserController.create"
 ```
+
+The `json_render_error_v2: true` is a work-around for a bug in the format of the default error renderer.
+It will be not needed in version 4.0.
 
 For Phoenix apps, the `operation_id` can be inferred from the contents of `conn.private`.
 
@@ -368,7 +371,7 @@ defmodule MyAppWeb.UserController do
   alias OpenApiSpex.Operation
   alias MyAppWeb.Schemas.{User, UserRequest, UserResponse}
 
-  plug OpenApiSpex.Plug.CastAndValidate
+  plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
 
   @doc """
   Create user.

--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ defmodule MyErrorRendererPlug do
   alias OpenApiSpex.OpenApi
 
   @impl Plug
-  def init(opts), do: opts
+  def init(errors), do: errors
 
   @impl Plug
   def call(conn, errors) when is_list(errors) do

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,3 +2,4 @@
 
 - Remove need for `json_render_error_v2: true` option for `CastAndValidate`
 - Remove `OpenApiSpex.Plug.Cast`, and rename `Cast2` to `Cast`.
+- Simplify interface for error rendering modules

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,4 @@
+# Version 4
+
+- Remove need for `json_render_error_v2: true` option for `CastAndValidate`
+- Remove `OpenApiSpex.Plug.Cast`, and rename `Cast2` to `Cast`.

--- a/examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller.ex
+++ b/examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller.ex
@@ -15,7 +15,7 @@ defmodule PhoenixAppWeb.UserController do
   alias PhoenixApp.{Accounts, Accounts.User}
   alias PhoenixAppWeb.Schemas
 
-  plug OpenApiSpex.Plug.CastAndValidate
+  plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
 
   @doc """
   List users

--- a/examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller_with_struct_specs.ex
+++ b/examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller_with_struct_specs.ex
@@ -9,7 +9,7 @@ defmodule PhoenixAppWeb.UserControllerWithStructSpecs do
   alias PhoenixApp.{Accounts, Accounts.User}
   alias PhoenixAppWeb.Schemas
 
-  plug OpenApiSpex.Plug.CastAndValidate
+  plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
 
   @doc """
   The controller will need to define a callback function `open_api_operation/1`

--- a/examples/plug_app/lib/plug_app/user_handler.ex
+++ b/examples/plug_app/lib/plug_app/user_handler.ex
@@ -7,7 +7,10 @@ defmodule PlugApp.UserHandler do
   defmodule Index do
     use Plug.Builder
 
-    plug OpenApiSpex.Plug.CastAndValidate, operation_id: "UserHandler.Index"
+    plug OpenApiSpex.Plug.CastAndValidate,
+      json_render_error_v2: true,
+      operation_id: "UserHandler.Index"
+
     plug :index
 
     def open_api_operation(_) do
@@ -41,7 +44,10 @@ defmodule PlugApp.UserHandler do
   defmodule Show do
     use Plug.Builder
 
-    plug OpenApiSpex.Plug.CastAndValidate, operation_id: "UserHandler.Show"
+    plug OpenApiSpex.Plug.CastAndValidate,
+      json_render_error_v2: true,
+      operation_id: "UserHandler.Show"
+
     plug :load
     plug :show
 
@@ -90,7 +96,10 @@ defmodule PlugApp.UserHandler do
   defmodule Create do
     use Plug.Builder
 
-    plug OpenApiSpex.Plug.CastAndValidate, operation_id: "UserHandler.Create"
+    plug OpenApiSpex.Plug.CastAndValidate,
+      json_render_error_v2: true,
+      operation_id: "UserHandler.Create"
+
     plug :create
 
     def open_api_operation(_) do

--- a/lib/open_api_spex/json_error_response.ex
+++ b/lib/open_api_spex/json_error_response.ex
@@ -1,0 +1,56 @@
+defmodule OpenApiSpex.JsonErrorResponse do
+  @moduledoc """
+  Schema for the default error renderer used by `OpenApiSpex.Plug.CastAndValidate`.
+
+  ## Examples
+
+      @doc responses: %{
+             201 => {"User", "application/json", UserResponse}
+             422 => {"Unprocessable Entity"], "application/json", OpenApiSpex.JsonApiErrorResponse}
+           }
+  """
+  require OpenApiSpex
+  alias OpenApiSpex.{Operation, Schema}
+
+  OpenApiSpex.schema(%{
+    type: :object,
+    properties: %{
+      errors: %Schema{
+        type: :array,
+        items: %Schema{
+          properties: %{
+            title: %Schema{type: :string, example: "Invalid value"},
+            source: %Schema{
+              type: :object,
+              properties: %{
+                pointer: %Schema{type: :string, example: "/data/attributes/petName"}
+              },
+              required: [:pointer]
+            },
+            detail: %Schema{type: :string, example: "null value where string expected"}
+          },
+          required: [:title, :source, :detail]
+        }
+      }
+    },
+    required: [:errors]
+  })
+
+  @doc """
+  Convenience function to return that wraps JsonApiErrorResponse in an Operation response.
+
+  ## Examples
+
+      @doc responses: %{
+             201 => {"User", "application/json", UserResponse}
+             422 => OpenApiSpex.JsonApiErrorResponse.response()
+           }
+  """
+  def response do
+    Operation.response(
+      "Unprocessible Entity",
+      "application/json",
+      __MODULE__
+    )
+  end
+end

--- a/lib/open_api_spex/plug/cast_and_validate.ex
+++ b/lib/open_api_spex/plug/cast_and_validate.ex
@@ -4,7 +4,9 @@ defmodule OpenApiSpex.Plug.CastAndValidate do
 
   The operation_id can be given at compile time as an argument to `init`:
 
-      plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true , operation_id: "MyApp.ShowUser"
+      plug OpenApiSpex.Plug.CastAndValidate,
+        json_render_error_v2: true,
+        operation_id: "MyApp.ShowUser"
 
   For phoenix applications, the operation_id can be obtained at runtime automatically.
 
@@ -47,11 +49,9 @@ defmodule OpenApiSpex.Plug.CastAndValidate do
     opts = Map.new(opts)
 
     error_renderer =
-      if opts[:json_render_error_v2] do
-        OpenApiSpex.Plug.JsonRenderErrorV2
-      else
-        OpenApiSpex.Plug.JsonRenderError
-      end
+      if opts[:json_render_error_v2],
+        do: OpenApiSpex.Plug.JsonRenderErrorV2,
+        else: OpenApiSpex.Plug.JsonRenderError
 
     Map.put_new(opts, :render_error, error_renderer)
   end

--- a/lib/open_api_spex/plug/default_render_error.ex
+++ b/lib/open_api_spex/plug/default_render_error.ex
@@ -1,5 +1,5 @@
 defmodule OpenApiSpex.Plug.DefaultRenderError do
-
+  @deprecated "#{__MODULE__} is no longer the default error renderer"
   @behaviour Plug
 
   alias Plug.Conn

--- a/lib/open_api_spex/plug/json_render_error.ex
+++ b/lib/open_api_spex/plug/json_render_error.ex
@@ -1,4 +1,7 @@
 defmodule OpenApiSpex.Plug.JsonRenderError do
+  @doc """
+  Renders errors using a json:api-compliant data shape.
+  """
   @behaviour Plug
 
   alias Plug.Conn
@@ -32,6 +35,8 @@ defmodule OpenApiSpex.Plug.JsonRenderError do
       source: %{
         pointer: pointer
       },
+      detail: to_string(error),
+      # message is deprecated because it isn't part of the json:api spec.
       message: to_string(error)
     }
   end

--- a/lib/open_api_spex/plug/json_render_error_v2.ex
+++ b/lib/open_api_spex/plug/json_render_error_v2.ex
@@ -1,9 +1,12 @@
-defmodule OpenApiSpex.Plug.JsonRenderError do
-  @moduledoc false
+defmodule OpenApiSpex.Plug.JsonRenderErrorV2 do
+  @moduledoc """
+  Renders errors using a quasi-json:api-compliant data shape.
 
-  # Renders errors using a quasi-json:api-compliant data shape.
-  # This module will change in a backwards-incompatible way in version 4.0.
+  WARNING: Do not use this module directly. It will be renamed in version 4.0
+  To use this module in a backwards-compatible way, call CastAndValidate like this:
 
+      plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
+  """
   @behaviour Plug
 
   alias Plug.Conn
@@ -37,7 +40,7 @@ defmodule OpenApiSpex.Plug.JsonRenderError do
       source: %{
         pointer: pointer
       },
-      message: to_string(error)
+      detail: to_string(error)
     }
   end
 end

--- a/test/plug/cast_test.exs
+++ b/test/plug/cast_test.exs
@@ -11,6 +11,7 @@ defmodule OpenApiSpex.Plug.CastTest do
       assert conn.status == 200
     end
 
+    @tag :capture_log
     test "Invalid value" do
       conn =
         :get
@@ -20,6 +21,7 @@ defmodule OpenApiSpex.Plug.CastTest do
       assert conn.status == 422
     end
 
+    @tag :capture_log
     test "Invalid Param" do
       conn =
         :get
@@ -30,11 +32,11 @@ defmodule OpenApiSpex.Plug.CastTest do
       error_resp = Jason.decode!(conn.resp_body)
       assert %{"errors" => [error]} = error_resp
 
-      assert %{
+      assert error == %{
                "detail" => "Invalid boolean. Got: string",
                "source" => %{"pointer" => "/validParam"},
                "title" => "Invalid value"
-             } = error
+             }
     end
 
     test "with requestBody" do
@@ -64,6 +66,7 @@ defmodule OpenApiSpex.Plug.CastTest do
       assert conn.status == 200
     end
 
+    @tag :capture_log
     test "Invalid value" do
       conn =
         :get
@@ -73,6 +76,7 @@ defmodule OpenApiSpex.Plug.CastTest do
       assert conn.status == 400
     end
 
+    @tag :capture_log
     test "Invalid Param" do
       conn =
         :get
@@ -121,6 +125,7 @@ defmodule OpenApiSpex.Plug.CastTest do
              }
     end
 
+    @tag :capture_log
     test "Invalid Request" do
       request_body = %{
         "user" => %{
@@ -142,11 +147,11 @@ defmodule OpenApiSpex.Plug.CastTest do
       resp_data = Jason.decode!(conn.resp_body)
       assert %{"errors" => [error]} = resp_data
 
-      assert %{
+      assert error == %{
                "detail" => "Invalid format. Expected ~r/[a-zA-Z][a-zA-Z0-9_]+/",
                "source" => %{"pointer" => "/user/name"},
                "title" => "Invalid value"
-             } = error
+             }
     end
   end
 
@@ -200,13 +205,13 @@ defmodule OpenApiSpex.Plug.CastTest do
       resp_body = Jason.decode!(conn.resp_body)
       assert %{"errors" => [error]} = resp_body
 
-      assert %{
+      assert error == %{
                "source" => %{
                  "pointer" => "/pet"
                },
                "title" => "Invalid value",
                "detail" => "Failed to cast value to one of: [] (no schemas provided)"
-             } = error
+             }
     end
 
     test "Header params" do

--- a/test/plug/cast_test.exs
+++ b/test/plug/cast_test.exs
@@ -28,16 +28,13 @@ defmodule OpenApiSpex.Plug.CastTest do
 
       assert conn.status == 422
       error_resp = Jason.decode!(conn.resp_body)
+      assert %{"errors" => [error]} = error_resp
 
-      assert error_resp == %{
-               "errors" => [
-                 %{
-                   "message" => "Invalid boolean. Got: string",
-                   "source" => %{"pointer" => "/validParam"},
-                   "title" => "Invalid value"
-                 }
-               ]
-             }
+      assert %{
+               "detail" => "Invalid boolean. Got: string",
+               "source" => %{"pointer" => "/validParam"},
+               "title" => "Invalid value"
+             } = error
     end
 
     test "with requestBody" do
@@ -143,17 +140,13 @@ defmodule OpenApiSpex.Plug.CastTest do
       assert conn.status == 422
 
       resp_data = Jason.decode!(conn.resp_body)
+      assert %{"errors" => [error]} = resp_data
 
-      assert resp_data ==
-               %{
-                 "errors" => [
-                   %{
-                     "message" => "Invalid format. Expected ~r/[a-zA-Z][a-zA-Z0-9_]+/",
-                     "source" => %{"pointer" => "/user/name"},
-                     "title" => "Invalid value"
-                   }
-                 ]
-               }
+      assert %{
+               "detail" => "Invalid format. Expected ~r/[a-zA-Z][a-zA-Z0-9_]+/",
+               "source" => %{"pointer" => "/user/name"},
+               "title" => "Invalid value"
+             } = error
     end
   end
 
@@ -205,18 +198,15 @@ defmodule OpenApiSpex.Plug.CastTest do
       assert conn.status == 422
 
       resp_body = Jason.decode!(conn.resp_body)
+      assert %{"errors" => [error]} = resp_body
 
-      assert resp_body == %{
-               "errors" => [
-                 %{
-                   "source" => %{
-                     "pointer" => "/pet"
-                   },
-                   "title" => "Invalid value",
-                   "message" => "Failed to cast value to one of: no schemas validate"
-                 }
-               ]
-             }
+      assert %{
+               "source" => %{
+                 "pointer" => "/pet"
+               },
+               "title" => "Invalid value",
+               "detail" => "Failed to cast value to one of: [] (no schemas provided)"
+             } = error
     end
 
     test "Header params" do

--- a/test/plug/cast_test.exs
+++ b/test/plug/cast_test.exs
@@ -206,11 +206,9 @@ defmodule OpenApiSpex.Plug.CastTest do
       assert %{"errors" => [error]} = resp_body
 
       assert error == %{
-               "source" => %{
-                 "pointer" => "/pet"
-               },
-               "title" => "Invalid value",
-               "detail" => "Failed to cast value to one of: [] (no schemas provided)"
+               "detail" => "Failed to cast value to one of: no schemas validate",
+               "source" => %{"pointer" => "/pet"},
+               "title" => "Invalid value"
              }
     end
 

--- a/test/plug/json_render_error_test.exs
+++ b/test/plug/json_render_error_test.exs
@@ -1,0 +1,24 @@
+defmodule OpenApiSpex.Plug.JsonRenderErrorTest do
+  use ExUnit.Case, async: true
+
+  test "render error" do
+    conn =
+      :get
+      |> Plug.Test.conn("/api/json_render_error?validParam=invalid")
+      |> OpenApiSpexTest.Router.call([])
+
+    assert conn.status == 422
+    resp_body = Jason.decode!(conn.resp_body)
+
+    assert resp_body == %{
+             "errors" => [
+               %{
+                 "detail" => "Invalid boolean. Got: string",
+                 "message" => "Invalid boolean. Got: string",
+                 "source" => %{"pointer" => "/validParam"},
+                 "title" => "Invalid value"
+               }
+             ]
+           }
+  end
+end

--- a/test/plug/json_render_error_test.exs
+++ b/test/plug/json_render_error_test.exs
@@ -1,6 +1,7 @@
 defmodule OpenApiSpex.Plug.JsonRenderErrorTest do
   use ExUnit.Case, async: true
 
+  @tag :capture_log
   test "render error" do
     conn =
       :get
@@ -14,7 +15,6 @@ defmodule OpenApiSpex.Plug.JsonRenderErrorTest do
              "errors" => [
                %{
                  "detail" => "Invalid boolean. Got: string",
-                 "message" => "Invalid boolean. Got: string",
                  "source" => %{"pointer" => "/validParam"},
                  "title" => "Invalid value"
                }

--- a/test/support/controllers/json_render_error_controller.ex
+++ b/test/support/controllers/json_render_error_controller.ex
@@ -1,0 +1,30 @@
+defmodule OpenApiSpexTest.JsonRenderErrorController do
+  use Phoenix.Controller
+  use OpenApiSpex.Controller
+  alias OpenApiSpexTest.Schemas
+
+  plug OpenApiSpex.Plug.CastAndValidate
+
+  @doc """
+  List users
+
+  List all users
+  """
+  @doc parameters: [
+         validParam: [in: :query, type: :boolean, description: "Valid Param", example: true]
+       ],
+       responses: [
+         ok: {"User List Response", "application/json", Schemas.UsersResponse}
+       ]
+  def index(conn, _params) do
+    json(conn, %Schemas.UsersResponse{
+      data: [
+        %Schemas.User{
+          id: 123,
+          name: "joe user",
+          email: "joe@gmail.com"
+        }
+      ]
+    })
+  end
+end

--- a/test/support/controllers/json_render_error_controller.ex
+++ b/test/support/controllers/json_render_error_controller.ex
@@ -3,7 +3,7 @@ defmodule OpenApiSpexTest.JsonRenderErrorController do
   use OpenApiSpex.Controller
   alias OpenApiSpexTest.Schemas
 
-  plug OpenApiSpex.Plug.CastAndValidate
+  plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
 
   @doc """
   List users
@@ -14,17 +14,9 @@ defmodule OpenApiSpexTest.JsonRenderErrorController do
          validParam: [in: :query, type: :boolean, description: "Valid Param", example: true]
        ],
        responses: [
-         ok: {"User List Response", "application/json", Schemas.UsersResponse}
+         no_content: Schemas.NoContent.response()
        ]
   def index(conn, _params) do
-    json(conn, %Schemas.UsersResponse{
-      data: [
-        %Schemas.User{
-          id: 123,
-          name: "joe user",
-          email: "joe@gmail.com"
-        }
-      ]
-    })
+    json(conn, %{})
   end
 end

--- a/test/support/pet_controller.ex
+++ b/test/support/pet_controller.ex
@@ -6,7 +6,7 @@ defmodule OpenApiSpexTest.PetController do
   alias OpenApiSpex.Schema
   alias OpenApiSpexTest.Schemas
 
-  plug OpenApiSpex.Plug.CastAndValidate
+  plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
 
   @doc """
   Show pet.

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -27,5 +27,7 @@ defmodule OpenApiSpexTest.Router do
 
     get "/utility/echo/any", UtilityController, :echo_any
     post "/utility/echo/body_params", UtilityController, :echo_body_params
+
+    get "/json_render_error", JsonRenderErrorController, :index
   end
 end

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -102,6 +102,21 @@ defmodule OpenApiSpexTest.Schemas do
     end
   end
 
+  defmodule NoContent do
+    require OpenApiSpex
+    alias OpenApiSpex.Operation
+
+    OpenApiSpex.schema(%{type: :object, properties: %{}, additionalProperties: false})
+
+    def response do
+      Operation.response(
+        "No Content",
+        "application/json",
+        __MODULE__
+      )
+    end
+  end
+
   defmodule Size do
     OpenApiSpex.schema(%{
       title: "Size",
@@ -575,7 +590,7 @@ defmodule OpenApiSpexTest.Schemas do
       description: "Echo body params request",
       type: :array,
       items: %Schema{
-        type: :object,
+        type: :object
       }
     })
   end

--- a/test/support/user_controller.ex
+++ b/test/support/user_controller.ex
@@ -7,7 +7,7 @@ defmodule OpenApiSpexTest.UserController do
   alias OpenApiSpex.Schema
   alias OpenApiSpexTest.Schemas
 
-  plug OpenApiSpex.Plug.CastAndValidate
+  plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
 
   @doc """
   Show user

--- a/test/support/utility_controller.ex
+++ b/test/support/utility_controller.ex
@@ -9,7 +9,7 @@ defmodule OpenApiSpexTest.UtilityController do
   alias OpenApiSpex.Schema
   alias OpenApiSpexTest.Schemas
 
-  plug OpenApiSpex.Plug.CastAndValidate
+  plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
 
   @doc "Echo body params"
   @doc [


### PR DESCRIPTION
Deprecate the `message` field. It was originally added by mistake. The original intent was to make the error shape compatible with json:api. Adds `detail` in its place.

Also adds documentation explaining that a module-based schema doesn't need a `:title`. Leaving the title off and letting OpenApiSpex generate it makes the code more resilient to renaming changes, and fewer difficult debugging sessions.