### PR TITLE
#244 Fix error handling for oneOf

### DIFF
--- a/lib/open_api_spex/cast/error.ex
+++ b/lib/open_api_spex/cast/error.ex
@@ -127,10 +127,7 @@ defmodule OpenApiSpex.Cast.Error do
   end
 
   def new(ctx, {:one_of, meta}) do
-    %__MODULE__{
-      reason: :one_of,
-      meta: meta
-    }
+    %__MODULE__{reason: :one_of, meta: meta}
     |> add_context_fields(ctx)
   end
 

--- a/lib/open_api_spex/cast/error.ex
+++ b/lib/open_api_spex/cast/error.ex
@@ -126,8 +126,11 @@ defmodule OpenApiSpex.Cast.Error do
     |> add_context_fields(ctx)
   end
 
-  def new(ctx, {:one_of, schema_names}) do
-    %__MODULE__{reason: :one_of, meta: %{failed_schemas: schema_names}}
+  def new(ctx, {:one_of, meta}) do
+    %__MODULE__{
+      reason: :one_of,
+      meta: meta
+    }
     |> add_context_fields(ctx)
   end
 
@@ -263,8 +266,8 @@ defmodule OpenApiSpex.Cast.Error do
     "Failed to cast value using any of: #{failed_schemas}"
   end
 
-  def message(%{reason: :one_of, meta: %{failed_schemas: failed_schemas}}) do
-    "Failed to cast value to one of: #{failed_schemas}"
+  def message(%{reason: :one_of, meta: %{message: message}}) do
+    "Failed to cast value to one of: #{message}"
   end
 
   def message(%{reason: :min_length, length: length}) do

--- a/lib/open_api_spex/cast/one_of.ex
+++ b/lib/open_api_spex/cast/one_of.ex
@@ -35,7 +35,7 @@ defmodule OpenApiSpex.Cast.OneOf do
       case {valid_schemas, failed_schemas} do
         {[], []} -> "no schemas given"
         {[], _} -> "no schemas validate"
-        {_, []} -> "more than one schema validate"
+        {_, []} -> "more than one schemas validate"
       end
 
     Cast.error(

--- a/lib/open_api_spex/cast/one_of.ex
+++ b/lib/open_api_spex/cast/one_of.ex
@@ -9,43 +9,63 @@ defmodule OpenApiSpex.Cast.OneOf do
 
   def cast(%{schema: %{type: _, oneOf: schemas}} = ctx) do
     castable_schemas =
-      Enum.reduce(schemas, {[], 0}, fn schema, {results, count} ->
+      Enum.reduce(schemas, {[], [], 0}, fn schema, {results, error_schemas, count} ->
         schema = OpenApiSpex.resolve_schema(schema, ctx.schemas)
 
         case Cast.cast(%{ctx | schema: schema}) do
-          {:ok, value} -> {[{:ok, value, schema} | results], count + 1}
-          _ -> {results, count}
+          {:ok, value} -> {[{:ok, value, schema} | results], error_schemas, count + 1}
+          _error -> {results, [schema | error_schemas], count}
         end
       end)
 
     case castable_schemas do
-      {[{:ok, %_{} = value, _}], 1} -> {:ok, value}
-      {[{:ok, value, %Schema{"x-struct": nil}}], 1} -> {:ok, value}
-      {[{:ok, value, %Schema{"x-struct": module}}], 1} -> {:ok, struct(module, value)}
-      {failed_schemas, _count} -> error(ctx, failed_schemas)
+      {[{:ok, %_{} = value, _}], _, 1} -> {:ok, value}
+      {[{:ok, value, %Schema{"x-struct": nil}}], _, 1} -> {:ok, value}
+      {[{:ok, value, %Schema{"x-struct": module}}], _, 1} -> {:ok, struct(module, value)}
+      {success_schemas, _failed_schemas, count} when count > 1 -> error(ctx, success_schemas)
+      {[], failed_schemas, _count} -> error(ctx, failed_schemas)
     end
   end
 
   ## Private functions
 
-  defp error(ctx, failed_schemas) do
-    Cast.error(ctx, {:one_of, error_message(failed_schemas)})
-  end
+  defp error(ctx, results) do
+    valid_schemas =
+      results
+      |> Enum.filter(&match?({:ok, _, _}, &1))
+      |> Enum.map(&elem(&1, 2))
 
-  defp error_message([]) do
-    "[] (no schemas provided)"
-  end
+    failed_schemas = Enum.filter(results, &match?(%Schema{}, &1))
 
-  defp error_message(failed_schemas) do
-    for {:ok, _value, schema} <- failed_schemas do
-      case schema do
-        %{title: title, type: type} when not is_nil(title) ->
-          "Schema(title: #{inspect(title)}, type: #{inspect(type)})"
-
-        %{type: type} ->
-          "Schema(type: #{inspect(type)})"
+    message =
+      case {valid_schemas, failed_schemas} do
+        {[], []} -> "no schemas given"
+        {[], _} -> "no schemas validate"
+        {_, []} -> "more than one schema validate"
       end
+
+    Cast.error(
+      ctx,
+      {:one_of,
+       %{
+         message: message,
+         failed_schemas: Enum.map(failed_schemas, &error_message_item/1),
+         valid_schemas: Enum.map(valid_schemas, &error_message_item/1)
+       }}
+    )
+  end
+
+  defp error_message_item({:ok, _value, schema}) do
+    error_message_item(schema)
+  end
+
+  defp error_message_item(schema) do
+    case schema do
+      %{title: title, type: type} when not is_nil(title) ->
+        "Schema(title: #{inspect(title)}, type: #{inspect(type)})"
+
+      %{type: type} ->
+        "Schema(type: #{inspect(type)})"
     end
-    |> Enum.join(", ")
   end
 end

--- a/test/cast/one_of_test.exs
+++ b/test/cast/one_of_test.exs
@@ -55,7 +55,7 @@ defmodule OpenApiSpex.CastOneOfTest do
                OpenApiSpex.cast_value(input, @cat_or_dog_schema, @api_spec)
     end
 
-    test "invalid when invalid against all child schemas" do
+    test "invalid when value is valid against more than one child schemas" do
       input = %{"bark" => true, "meow" => true}
       assert {:error, [error]} = OpenApiSpex.cast_value(input, @cat_or_dog_schema, @api_spec)
 
@@ -75,31 +75,6 @@ defmodule OpenApiSpex.CastOneOfTest do
                reason: :one_of,
                type: nil,
                value: %{"bark" => true, "meow" => true}
-             }
-
-      assert to_string(error) == "Failed to cast value to one of: more than one schemas validate"
-    end
-
-    test "invalid when valid against more than one child schema" do
-      input = %{"bark" => true, "meow" => true, "breed" => "Husky", "age" => 3}
-      assert {:error, [error]} = OpenApiSpex.cast_value(input, @cat_or_dog_schema, @api_spec)
-
-      assert error == %OpenApiSpex.Cast.Error{
-               format: nil,
-               length: 0,
-               meta: %{
-                 failed_schemas: [],
-                 valid_schemas: [
-                   "Schema(title: \"Dog\", type: :object)",
-                   "Schema(title: \"Cat\", type: :object)"
-                 ],
-                 message: "more than one schemas validate"
-               },
-               name: nil,
-               path: [],
-               reason: :one_of,
-               type: nil,
-               value: %{"age" => 3, "bark" => true, "breed" => "Husky", "meow" => true}
              }
 
       assert to_string(error) == "Failed to cast value to one of: more than one schemas validate"

--- a/test/cast/one_of_test.exs
+++ b/test/cast/one_of_test.exs
@@ -18,7 +18,7 @@ defmodule OpenApiSpex.CastOneOfTest do
       assert error.reason == :one_of
 
       assert Error.message(error) ==
-               "Failed to cast value to one of: more than one schema validate"
+               "Failed to cast value to one of: more than one schemas validate"
     end
 
     test "oneOf, no castable schema" do
@@ -64,7 +64,7 @@ defmodule OpenApiSpex.CastOneOfTest do
                length: 0,
                meta: %{
                  failed_schemas: [],
-                 message: "more than one schema validate",
+                 message: "more than one schemas validate",
                  valid_schemas: [
                    "Schema(title: \"Dog\", type: :object)",
                    "Schema(title: \"Cat\", type: :object)"
@@ -77,7 +77,7 @@ defmodule OpenApiSpex.CastOneOfTest do
                value: %{"bark" => true, "meow" => true}
              }
 
-      assert to_string(error) == "Failed to cast value to one of: more than one schema validate"
+      assert to_string(error) == "Failed to cast value to one of: more than one schemas validate"
     end
 
     test "invalid when valid against more than one child schema" do
@@ -93,7 +93,7 @@ defmodule OpenApiSpex.CastOneOfTest do
                    "Schema(title: \"Dog\", type: :object)",
                    "Schema(title: \"Cat\", type: :object)"
                  ],
-                 message: "more than one schema validate"
+                 message: "more than one schemas validate"
                },
                name: nil,
                path: [],
@@ -102,7 +102,7 @@ defmodule OpenApiSpex.CastOneOfTest do
                value: %{"age" => 3, "bark" => true, "breed" => "Husky", "meow" => true}
              }
 
-      assert to_string(error) == "Failed to cast value to one of: more than one schema validate"
+      assert to_string(error) == "Failed to cast value to one of: more than one schemas validate"
     end
   end
 end

--- a/test/plug/cast_test.exs
+++ b/test/plug/cast_test.exs
@@ -213,7 +213,7 @@ defmodule OpenApiSpex.Plug.CastTest do
                      "pointer" => "/pet"
                    },
                    "title" => "Invalid value",
-                   "message" => "Failed to cast value to one of: [] (no schemas provided)"
+                   "message" => "Failed to cast value to one of: no schemas validate"
                  }
                ]
              }
@@ -244,11 +244,11 @@ defmodule OpenApiSpex.Plug.CastTest do
         |> OpenApiSpexTest.Router.call([])
 
       assert Jason.decode!(conn.resp_body) == %{
-        "data" => %{
-          "pet_type" => "Dog",
-          "bark" => "woof"
-        }
-      }
+               "data" => %{
+                 "pet_type" => "Dog",
+                 "bark" => "woof"
+               }
+             }
     end
 
     test "Cookie params" do
@@ -282,7 +282,9 @@ defmodule OpenApiSpex.Plug.CastTest do
         |> Plug.Conn.put_req_header("content-type", "application/json")
         |> OpenApiSpexTest.Router.call([])
 
-      assert Jason.decode!(conn.resp_body) == %{"data" => [%{"pet_type" => "Dog", "bark" => "bow wow"}]}
+      assert Jason.decode!(conn.resp_body) == %{
+               "data" => [%{"pet_type" => "Dog", "bark" => "bow wow"}]
+             }
     end
 
     test "freeForm params" do


### PR DESCRIPTION
Fixes #244 

* Fixes incorrect string error message
* Cleans up string error message to summarize why the oneOf failed.
* Tracks failures to validate against child schemas, and separates tracking from successful validation against child schemas.
