### PR TITLE
Fixes README.md responses example typo "unprocessible"

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ and the HTTP status codes can be replaced with their text equivalents:
 ```elixir
   @doc responses: [
     ok: {"User", "application/json", MyAppWeb.Schema.User}
-    unprocessible_entity: {"Bad request parameters", "application/json", MyAppWeb.Schema.BadRequestParameters},
+    unprocessable_entity: {"Bad request parameters", "application/json", MyAppWeb.Schema.BadRequestParameters},
     not_found: {"Not found", "application/json", MyAppWeb.Schema.NotFound}
   ]
 ```


### PR DESCRIPTION
This PR fixes #247.

The current responses example has a typo in what should be `unprocessable_entity` (currently _unprocessible_) according to the documentation of `Plug.Conn.Status`, making it to not compile when trying to directly follow the example.

Example of the issue:

```elixir
  @doc responses: [
    ok: {"User", "application/json", MyAppWeb.Schema.User}
    unprocessible_entity: {"Bad request parameters", "application/json", MyAppWeb.Schema.BadRequestParameters},
    not_found: {"Not found", "application/json", MyAppWeb.Schema.NotFound}
  ]
```