### PR TITLE
Support `security` doc string attribute on operations

### DIFF
--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -85,6 +85,11 @@ defmodule OpenApiSpex.Controller do
   }
   ```
 
+  ### `security`
+
+  Allows specifying the security scheme(s) required for this operation.  See
+  `OpenApiSpex.Operation` and `OpenApiSpex.SecurityRequirement`.
+
   ### `tags`
 
   Tags are controlled by `:tags` attribute. In contrast to other attributes, this
@@ -144,6 +149,7 @@ defmodule OpenApiSpex.Controller do
         parameters: build_parameters(meta),
         requestBody: build_request_body(meta),
         responses: build_responses(meta),
+        security: build_security(meta),
         tags: Map.get(mod_meta, :tags, []) ++ Map.get(meta, :tags, [])
       }
     else
@@ -251,4 +257,10 @@ defmodule OpenApiSpex.Controller do
   end
 
   defp build_request_body(_), do: nil
+
+  defp build_security(%{security: security}) do
+    security
+  end
+
+  defp build_security(_), do: nil
 end

--- a/test/controller_test.exs
+++ b/test/controller_test.exs
@@ -24,6 +24,11 @@ defmodule OpenApiSpex.ControllerTest do
       assert op.description == "Update a user\n\nFull description for this endpoint...\n"
     end
 
+    test "security matches 'foo'" do
+      op = @controller.open_api_operation(:update)
+      assert op.security == [%{"authorization" => []}]
+    end
+
     test "has response for HTTP 200" do
       assert %{responses: %{200 => _}} = @controller.open_api_operation(:update)
     end

--- a/test/support/user_controller_annotated.ex
+++ b/test/support/user_controller_annotated.ex
@@ -24,6 +24,7 @@ defmodule OpenApiSpexTest.UserControllerAnnotated do
          unauthorized: Unauthorized.response(),
          not_found: NotFound.response()
        ]
+  @doc security: [%{"authorization" => []}]
   def update(_conn, _params), do: :ok
 
   @doc """


### PR DESCRIPTION
This change adds support for the `security` attribute on docstring metadata, it works for my simple test case of just specifying `security: [%{"authorization" => []}]` on some operations.

fixes #250 