### PR TITLE
Allow a reference to be used for an Operation's request body

### DIFF
--- a/lib/open_api_spex/open_api/decode.ex
+++ b/lib/open_api_spex/open_api/decode.ex
@@ -271,6 +271,8 @@ defmodule OpenApiSpex.OpenApi.Decode do
     |> prop_to_struct(:servers, Server)
   end
 
+  defp to_struct(%{"$ref" => _} = map, RequestBody), do: struct_from_map(Reference, map)
+
   defp to_struct(map, RequestBody) do
     RequestBody
     |> struct_from_map(map)

--- a/lib/open_api_spex/reference.ex
+++ b/lib/open_api_spex/reference.ex
@@ -3,7 +3,7 @@ defmodule OpenApiSpex.Reference do
   Defines the `OpenApiSpex.Reference.t` type.
   """
 
-  alias OpenApiSpex.{Components, Reference}
+  alias OpenApiSpex.{Components, Reference, RequestBody}
 
   @enforce_keys :"$ref"
   defstruct [
@@ -37,4 +37,12 @@ defmodule OpenApiSpex.Reference do
   @spec resolve_parameter(Reference.t(), %{String.t() => Parameter.t()}) :: Parameter.t() | nil
   def resolve_parameter(%Reference{"$ref": "#/components/parameters/" <> name}, parameters),
     do: parameters[name]
+
+  @spec resolve_request_body(Reference.t(), %{String.t() => RequestBody.t()}) ::
+          RequestBody.t() | nil
+  def resolve_request_body(
+        %Reference{"$ref": "#/components/requestBodies/" <> name},
+        request_bodies
+      ),
+      do: request_bodies[name]
 end

--- a/test/open_api/decode_test.exs
+++ b/test/open_api/decode_test.exs
@@ -311,6 +311,20 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
                      description: "Find more info here",
                      url: "https://example.com"
                    }
+                 },
+                 patch: %OpenApiSpex.Operation{
+                   parameters: [],
+                   deprecated: false,
+                   operationId: "example-patch-test",
+                   requestBody: %OpenApiSpex.Reference{
+                     "$ref": "#/components/requestBodies/test"
+                   },
+                   callbacks: %{},
+                   responses: operationResponses,
+                   security: operationSecurity,
+                   tags: ["test"],
+                   summary: "/example patch summary",
+                   description: "/example patch description"
                  }
                }
              } = paths

--- a/test/support/encoded_schema.json
+++ b/test/support/encoded_schema.json
@@ -441,6 +441,40 @@
           "url": "https://example.com"
         }
       },
+      "patch": {
+        "operationId": "example-patch-test",
+        "parameters": [],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/test"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "first_name": "John",
+                  "id": 678,
+                  "last_name": "Doe",
+                  "phone_number": null
+                }
+              }
+            },
+            "description": "An example"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets"
+            ]
+          }
+        ],
+        "tags": [
+          "test"
+        ],
+        "summary": "/example patch summary",
+        "description": "/example patch description"
+      },
       "servers": [
         {
           "description": "Development server",


### PR DESCRIPTION
The Open API Specification states the [Operation Object](https://swagger.io/specification/#operationObject) allows the `requestBody` field to be defined as either a [Request Body Object](https://swagger.io/specification/#request-body-object) or a [Reference Object](https://swagger.io/specification/#reference-object). The typespec for the `OpenApiSpex.Operation` module also matches the spec and is defined as `RequestBody.t() | Reference.t() | nil`.

This pull request adds support for using a reference as an Operation's request body.

Fixes #259.