### PR TITLE
Allow SwaggerUI to be configured via Plug opts

### DIFF
--- a/examples/phoenix_app/lib/phoenix_app_web/endpoint.ex
+++ b/examples/phoenix_app/lib/phoenix_app_web/endpoint.ex
@@ -3,6 +3,7 @@ defmodule PhoenixAppWeb.Endpoint do
 
   plug Plug.RequestId
   plug Plug.Logger
+  plug Plug.Static, at: "/", from: {:phoenix_app, "priv/static"}
   plug Plug.Parsers, parsers: [:json], pass: ["*/*"], json_decoder: Jason
   plug PhoenixAppWeb.Router
 end

--- a/examples/phoenix_app/lib/phoenix_app_web/router.ex
+++ b/examples/phoenix_app/lib/phoenix_app_web/router.ex
@@ -12,7 +12,12 @@ defmodule PhoenixAppWeb.Router do
 
   scope "/" do
     pipe_through(:browser)
-    get("/swaggerui", OpenApiSpex.Plug.SwaggerUI, path: "/api/openapi")
+
+    get("/swaggerui", OpenApiSpex.Plug.SwaggerUI,
+      path: "/api/openapi",
+      default_model_expand_depth: 3,
+      display_operation_id: true
+    )
   end
 
   scope "/api" do

--- a/lib/open_api_spex/plug/swagger_ui.ex
+++ b/lib/open_api_spex/plug/swagger_ui.ex
@@ -40,8 +40,7 @@ defmodule OpenApiSpex.Plug.SwaggerUI do
     <head>
       <meta charset="UTF-8">
       <title>Swagger UI</title>
-      <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
-      <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.24.2/swagger-ui.css" >
+      <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.32.4/swagger-ui.css" >
       <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
       <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
       <style>
@@ -65,49 +64,13 @@ defmodule OpenApiSpex.Plug.SwaggerUI do
     </head>
 
     <body>
-
-    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0">
-      <defs>
-        <symbol viewBox="0 0 20 20" id="unlocked">
-              <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V6h2v-.801C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8z"></path>
-        </symbol>
-
-        <symbol viewBox="0 0 20 20" id="locked">
-          <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8zM12 8H8V5.199C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8z"/>
-        </symbol>
-
-        <symbol viewBox="0 0 20 20" id="close">
-          <path d="M14.348 14.849c-.469.469-1.229.469-1.697 0L10 11.819l-2.651 3.029c-.469.469-1.229.469-1.697 0-.469-.469-.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-.469-.469-.469-1.228 0-1.697.469-.469 1.228-.469 1.697 0L10 8.183l2.651-3.031c.469-.469 1.228-.469 1.697 0 .469.469.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c.469.469.469 1.229 0 1.698z"/>
-        </symbol>
-
-        <symbol viewBox="0 0 20 20" id="large-arrow">
-          <path d="M13.25 10L6.109 2.58c-.268-.27-.268-.707 0-.979.268-.27.701-.27.969 0l7.83 7.908c.268.271.268.709 0 .979l-7.83 7.908c-.268.271-.701.27-.969 0-.268-.269-.268-.707 0-.979L13.25 10z"/>
-        </symbol>
-
-        <symbol viewBox="0 0 20 20" id="large-arrow-down">
-          <path d="M17.418 6.109c.272-.268.709-.268.979 0s.271.701 0 .969l-7.908 7.83c-.27.268-.707.268-.979 0l-7.908-7.83c-.27-.268-.27-.701 0-.969.271-.268.709-.268.979 0L10 13.25l7.418-7.141z"/>
-        </symbol>
-
-
-        <symbol viewBox="0 0 24 24" id="jump-to">
-          <path d="M19 7v4H5.83l3.58-3.59L8 6l-6 6 6 6 1.41-1.41L5.83 13H21V7z"/>
-        </symbol>
-
-        <symbol viewBox="0 0 24 24" id="expand">
-          <path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"/>
-        </symbol>
-
-      </defs>
-    </svg>
-
     <div id="swagger-ui"></div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.24.2/swagger-ui-bundle.js"> </script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.24.2/swagger-ui-standalone-preset.js"> </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.32.4/swagger-ui-bundle.js" charset="UTF-8"> </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.32.4/swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
     <script>
     window.onload = function() {
-
-      // Build a system
+      // Begin Swagger UI call region
       const api_spec_url = new URL(window.location);
       api_spec_url.pathname = "<%= config.path %>";
       api_spec_url.hash = "";
@@ -131,11 +94,11 @@ defmodule OpenApiSpex.Plug.SwaggerUI do
         , <%= camelize(k) %>: <%= OpenApiSpex.OpenApi.json_encoder().encode!(v) %>
         <% end %>
       })
+      // End Swagger UI call region
       window.ui = ui
     }
     </script>
     </body>
-
     </html>
   """
 


### PR DESCRIPTION
This PR forwards plug opts from the `SwaggerUI` plug to the `SwaggerUIBundle` constructor.

Usage example:

```elixir
    get "/swaggerui", OpenApiSpex.Plug.SwaggerUI,
      path: "/api/openapi",
      default_model_expand_depth: 3,
      display_operation_id: true
```