### PR TITLE
Handle the same operation occurring at different routes

### DIFF
--- a/examples/phoenix_app/lib/phoenix_app/accounts/accounts.ex
+++ b/examples/phoenix_app/lib/phoenix_app/accounts/accounts.ex
@@ -14,4 +14,12 @@ defmodule PhoenixApp.Accounts do
     user = Repo.insert!(%User{name: name, email: email})
     {:ok, user}
   end
+
+  def update_user(id, params) do
+    original = get_user!(id)
+
+    original
+    |> User.changeset(params)
+    |> Repo.update!()
+  end
 end

--- a/examples/phoenix_app/lib/phoenix_app/accounts/user.ex
+++ b/examples/phoenix_app/lib/phoenix_app/accounts/user.ex
@@ -1,9 +1,16 @@
 defmodule PhoenixApp.Accounts.User do
   use Ecto.Schema
+  alias __MODULE__
 
   schema "users" do
     field :name, :string
     field :email, :string
     timestamps()
+  end
+
+  def changeset(data \\ %User{}, params) do
+    data
+    |> Ecto.Changeset.cast(params, [:name, :email])
+    |> Ecto.Changeset.validate_required([:name, :email])
   end
 end

--- a/examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller.ex
+++ b/examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller.ex
@@ -76,4 +76,28 @@ defmodule PhoenixAppWeb.UserController do
     user = Accounts.get_user!(id)
     render(conn, "show.json", user: user)
   end
+
+  @doc """
+  Update user.
+
+  Update a user by ID.
+  """
+  @doc parameters: [
+         id: [
+           in: :path,
+           type: %Schema{type: :integer, minimum: 1},
+           description: "User ID",
+           example: 123,
+           required: true
+         ]
+       ],
+       request_body:
+         {"The user attributes", "application/json", Schemas.UserRequest, required: true},
+       responses: [
+         ok: {"User", "application/json", Schemas.UserResponse}
+       ]
+  def update(conn = %{body_params: %Schemas.UserRequest{user: user}}, %{id: id}) do
+    updated = Accounts.update_user(id, Map.take(user, [:name, :email]))
+    render(conn, "show.json", user: updated)
+  end
 end

--- a/examples/phoenix_app/lib/phoenix_app_web/router.ex
+++ b/examples/phoenix_app/lib/phoenix_app_web/router.ex
@@ -17,7 +17,7 @@ defmodule PhoenixAppWeb.Router do
 
   scope "/api" do
     pipe_through(:api)
-    resources("/users", PhoenixAppWeb.UserController, only: [:index, :show])
+    resources("/users", PhoenixAppWeb.UserController, only: [:index, :show, :update])
     post("/users/:group_id", PhoenixAppWeb.UserController, :create)
     get("/openapi", OpenApiSpex.Plug.RenderSpec, :show)
   end

--- a/lib/open_api_spex/paths.ex
+++ b/lib/open_api_spex/paths.ex
@@ -2,7 +2,7 @@ defmodule OpenApiSpex.Paths do
   @moduledoc """
   Defines the `OpenApiSpex.Paths.t` type.
   """
-  alias OpenApiSpex.PathItem
+  alias OpenApiSpex.{PathItem, Operation}
 
   @typedoc """
   [Paths Object](https://swagger.io/specification/#pathsObject)
@@ -11,25 +11,70 @@ defmodule OpenApiSpex.Paths do
   The path is appended to the URL from the Server Object in order to construct the full URL.
   The Paths MAY be empty, due to ACL constraints.
   """
-  @type t :: %{String.t => PathItem.t}
+  @type path :: String.t()
+  @type t :: %{path => PathItem.t()}
+
+  @typep operation_id :: String.t()
+  @typep verb :: atom
 
   @doc """
   Create a Paths map from the routes in the given router module.
   """
   @spec from_router(module) :: t
   def from_router(router) do
-    router.__routes__()
-    |> Enum.group_by(fn route -> route.path end)
-    |> Enum.map(fn {k, v} -> {open_api_path(k), PathItem.from_routes(v)} end)
-    |> Enum.filter(fn {_k, v} -> !is_nil(v) end)
-    |> Map.new()
+    paths =
+      router.__routes__()
+      |> Enum.group_by(fn route -> route.path end)
+      |> Enum.map(fn {k, v} -> {open_api_path(k), PathItem.from_routes(v)} end)
+      |> Enum.filter(fn {_k, v} -> !is_nil(v) end)
+      |> Map.new()
+
+    paths
+    |> find_duplicate_operations()
+    |> make_operation_ids_unique()
+    |> Enum.reduce(paths, fn {path, verb, operation}, paths ->
+      Map.update!(paths, path, fn path_item ->
+        %{path_item | verb => operation}
+      end)
+    end)
   end
 
-  @spec open_api_path(String.t) :: String.t
+  @spec open_api_path(String.t()) :: String.t()
   defp open_api_path(path) do
     path
     |> String.split("/")
-    |> Enum.map(fn ":"<>segment -> "{#{segment}}"; segment -> segment end)
+    |> Enum.map(fn
+      ":" <> segment -> "{#{segment}}"
+      segment -> segment
+    end)
     |> Enum.join("/")
+  end
+
+  @spec find_duplicate_operations(paths :: t) :: [{operation_id, [{path, verb, Operation.t()}]}]
+  defp find_duplicate_operations(paths) do
+    all_operations =
+      for {path, path_item} <- paths,
+          {verb, operation = %Operation{}} <- Map.from_struct(path_item),
+          do: {path, verb, operation}
+
+    all_operations
+    |> Enum.group_by(fn {_path, _verb, operation} -> operation.operationId end)
+    |> Enum.filter(fn
+      {_operationId, [_item]} -> false
+      _ -> true
+    end)
+  end
+
+  @spec make_operation_ids_unique([{operation_id, [{path, verb, Operation.t()}]}]) ::
+          [{path, verb, Operation.t()}]
+  defp make_operation_ids_unique(duplicate_operations) do
+    duplicate_operations
+    |> Enum.flat_map(fn {operation_id, [_first | rest]} ->
+      rest
+      |> Enum.with_index(2)
+      |> Enum.map(fn {{path, verb, operation}, occurrence} ->
+        {path, verb, %{operation | operationId: "#{operation_id} (#{occurrence})"}}
+      end)
+    end)
   end
 end

--- a/test/paths_test.exs
+++ b/test/paths_test.exs
@@ -6,9 +6,14 @@ defmodule OpenApiSpex.PathsTest do
   describe "Paths" do
     test "from_router" do
       paths = Paths.from_router(Router)
+
       assert %{
-        "/api/users" => %PathItem{},
-      } = paths
+               "/api/users" => %PathItem{},
+               "/api/pets/{id}" => pets_path_item
+             } = paths
+
+      assert pets_path_item.patch.operationId == "OpenApiSpexTest.PetController.update"
+      assert pets_path_item.put.operationId == "OpenApiSpexTest.PetController.update (2)"
     end
   end
 end

--- a/test/support/pet_controller.ex
+++ b/test/support/pet_controller.ex
@@ -111,16 +111,33 @@ defmodule OpenApiSpexTest.PetController do
   end
 
   @doc """
-  Create pet.
+  Create appointment.
 
-  Create a pet.
+  Create an appointment.
   """
   @doc request_body:
-         {"The pet attributes", "application/json", Schemas.PetAppointmentRequest, required: true},
+         {"The appointment attributes", "application/json", Schemas.PetAppointmentRequest,
+          required: true},
        responses: [
          created: {"Pet", "application/json", Schemas.PetResponse}
        ]
   def appointment(conn, _) do
+    json(conn, %Schemas.PetResponse{
+      data: [%{pet_type: "Dog", bark: "bow wow"}]
+    })
+  end
+
+  @doc """
+  Update pet.
+
+  This action is available as a PUT or a PATCH.
+  """
+  @doc request_body:
+         {"The pet attributes", "application/json", Schemas.PetRequest, required: true},
+       responses: [
+         created: {"Pet", "application/json", Schemas.PetResponse}
+       ]
+  def update(conn, _) do
     json(conn, %Schemas.PetResponse{
       data: [%{pet_type: "Dog", bark: "bow wow"}]
     })

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -21,7 +21,7 @@ defmodule OpenApiSpexTest.Router do
     post "/users/create_entity", UserController, :create_entity
     get "/openapi", RenderSpec, []
 
-    resources "/pets", PetController, only: [:create, :index, :show]
+    resources "/pets", PetController, only: [:create, :index, :show, :update]
     post "/pets/:id/adopt", PetController, :adopt
     post "/pets/appointment", PetController, :appointment
 


### PR DESCRIPTION
Fixes #123 

When two (or more) routes map to the same operation, the first is left unchanged,
while the rest will have an index in parens appended to the `operationId`.

Example:

<img width="1098" alt="image" src="https://user-images.githubusercontent.com/336840/90975683-d8d71800-e579-11ea-8fd8-30f8048cd8dc.png">
