### PR TITLE
Updates header casting logic to be case-insensitive

### DIFF
--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -31,12 +31,15 @@ defmodule OpenApiSpex.CastParameters do
     Plug.Conn.fetch_cookies(conn).req_cookies
   end
 
+  # Matching is done using the downcase version of the expected_names but the original
+  # version of the expected_names is kept
   defp get_params_by_location(conn, :header, expected_names) do
-    conn.req_headers
-    |> Enum.filter(fn {key, _value} ->
-      Enum.member?(expected_names, String.downcase(key))
-    end)
-    |> Map.new()
+    name_lookup = Map.new(expected_names, &{String.downcase(&1), &1})
+
+    for {key, value} <- conn.req_headers,
+        property_name = name_lookup[String.downcase(key)],
+        into: %{},
+        do: {property_name, value}
   end
 
   defp create_location_schema(parameters) do

--- a/test/cast_parameters_test.exs
+++ b/test/cast_parameters_test.exs
@@ -1,12 +1,12 @@
 defmodule OpenApiSpex.CastParametersTest do
   use ExUnit.Case
-  alias OpenApiSpex.{Operation, Schema, Components, CastParameters}
+  alias OpenApiSpex.{Operation, Schema, Components, CastParameters, Reference}
 
   describe "cast/3" do
     test "fails for not supported additional properties " do
       conn = create_conn_with_unexpected_path_param()
       operation = create_operation()
-      components = create_empty_components()
+      components = create_components()
 
       cast_result = CastParameters.cast(conn, operation, components)
 
@@ -31,9 +31,19 @@ defmodule OpenApiSpex.CastParametersTest do
     test "default parameter values are supplied" do
       conn = create_conn()
       operation = create_operation()
-      components = create_empty_components()
+      components = create_components()
       {:ok, conn} = CastParameters.cast(conn, operation, components)
       assert %{params: %{includeInactive: false}} = conn
+    end
+
+    test "casting of headers is not case sensitive" do
+      conn = create_conn()
+      operation = create_operation()
+      components = create_components()
+
+      {:ok, conn} = CastParameters.cast(conn, operation, components)
+
+      assert %{params: %{"Content-Type": "application/json"}} = conn
     end
   end
 
@@ -60,7 +70,8 @@ defmodule OpenApiSpex.CastParametersTest do
           :query,
           %Schema{type: :boolean, default: false},
           "Include inactive users"
-        )
+        ),
+        %Reference{"$ref": "#/components/parameters/Content-Type"}
       ],
       responses: %{
         200 => %Schema{type: :object}
@@ -68,7 +79,29 @@ defmodule OpenApiSpex.CastParametersTest do
     }
   end
 
-  defp create_empty_components() do
-    %Components{}
+  defp create_components() do
+    %Components{
+      parameters: %{
+        "Content-Type" => %OpenApiSpex.Parameter{
+          allowEmptyValue: nil,
+          allowReserved: nil,
+          content: nil,
+          deprecated: nil,
+          description: "description",
+          example: nil,
+          examples: nil,
+          explode: nil,
+          in: :header,
+          name: :"Content-Type",
+          required: nil,
+          schema: %OpenApiSpex.Schema{
+            enum: ["application/json"],
+            example: "application/json",
+            type: :string
+          },
+          style: nil
+        }
+      }
+    }
   end
 end


### PR DESCRIPTION
HTTP headers are case-insensitive according to:
https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2

This commit updates the OpenApiSpex.CastParameters module to ignore
casing when casting header parameters.

This will allow users to declare header parameters using their upper
case form, like "Content-Type", and still get the parameter casted when
its provided in its downcase form.