### PR TITLE
Remove unnecessary data passing in conn

### DIFF
--- a/lib/open_api_spex/open_api.ex
+++ b/lib/open_api_spex/open_api.ex
@@ -150,4 +150,16 @@ defmodule OpenApiSpex.OpenApi do
   def from_map(map) do
     OpenApi.Decode.decode(map)
   end
+
+  @spec build_operation_lookup(t()) :: %{
+          String.t() => OpenApiSpex.Operation.t()
+        }
+  def build_operation_lookup(%__MODULE__{} = spec) do
+    spec
+    |> Map.get(:paths)
+    |> Stream.flat_map(fn {_name, item} -> Map.values(item) end)
+    |> Stream.filter(fn x -> match?(%OpenApiSpex.Operation{}, x) end)
+    |> Stream.map(fn operation -> {operation.operationId, operation} end)
+    |> Enum.into(%{})
+  end
 end

--- a/lib/open_api_spex/open_api.ex
+++ b/lib/open_api_spex/open_api.ex
@@ -150,16 +150,4 @@ defmodule OpenApiSpex.OpenApi do
   def from_map(map) do
     OpenApi.Decode.decode(map)
   end
-
-  @spec build_operation_lookup(t()) :: %{
-          String.t() => OpenApiSpex.Operation.t()
-        }
-  def build_operation_lookup(%__MODULE__{} = spec) do
-    spec
-    |> Map.get(:paths)
-    |> Stream.flat_map(fn {_name, item} -> Map.values(item) end)
-    |> Stream.filter(fn x -> match?(%OpenApiSpex.Operation{}, x) end)
-    |> Stream.map(fn operation -> {operation.operationId, operation} end)
-    |> Enum.into(%{})
-  end
 end

--- a/lib/open_api_spex/plug/cache.ex
+++ b/lib/open_api_spex/plug/cache.ex
@@ -29,6 +29,7 @@ defmodule OpenApiSpex.Plug.Cache do
     end
 
   @default_adapter default_adapter
+  @missing_oas_key "Missing private.open_api_spex key in conn. Check that PutApiSpec is being called in the Conn pipeline"
 
   @callback get(module) :: {OpenApiSpex.OpenApi.t(), map} | nil
   @callback put(module, {OpenApiSpex.OpenApi.t(), map}) :: :ok
@@ -49,6 +50,24 @@ defmodule OpenApiSpex.Plug.Cache do
   def refresh do
     adapter = adapter()
     adapter.erase()
+  end
+
+  @spec spec_and_operation_lookup(Conn.t()) :: {spec :: term, operation_lookup :: map}
+  def spec_and_operation_lookup(conn) do
+    private_data = Map.get(conn.private, :open_api_spex) || raise @missing_oas_key
+    spec_module = private_data.spec_module
+    adapter().get(spec_module)
+  end
+
+  def get_and_cache_controller_action(conn, operation_id, {controller, action}) do
+    private_data = Map.get(conn.private, :open_api_spex) || raise @missing_oas_key
+    {spec, operation_lookup} = spec_and_operation_lookup(conn)
+    operation = operation_lookup[operation_id]
+    operation_lookup = Map.put(operation_lookup, {controller, action}, operation)
+    spec_module = private_data.spec_module
+    cache_module = OpenApiSpex.Plug.Cache.adapter()
+    cache_module.put(spec_module, {spec, operation_lookup})
+    operation
   end
 end
 

--- a/lib/open_api_spex/plug/cache.ex
+++ b/lib/open_api_spex/plug/cache.ex
@@ -54,20 +54,22 @@ defmodule OpenApiSpex.Plug.Cache do
 
   @spec spec_and_operation_lookup(Conn.t()) :: {spec :: term, operation_lookup :: map}
   def spec_and_operation_lookup(conn) do
-    private_data = Map.get(conn.private, :open_api_spex) || raise @missing_oas_key
-    spec_module = private_data.spec_module
+    spec_module = spec_module(conn)
     adapter().get(spec_module)
   end
 
   def get_and_cache_controller_action(conn, operation_id, {controller, action}) do
-    private_data = Map.get(conn.private, :open_api_spex) || raise @missing_oas_key
+    spec_module = spec_module(conn)
     {spec, operation_lookup} = spec_and_operation_lookup(conn)
     operation = operation_lookup[operation_id]
     operation_lookup = Map.put(operation_lookup, {controller, action}, operation)
-    spec_module = private_data.spec_module
-    cache_module = OpenApiSpex.Plug.Cache.adapter()
-    cache_module.put(spec_module, {spec, operation_lookup})
+    adapter().put(spec_module, {spec, operation_lookup})
     operation
+  end
+
+  def spec_module(conn) do
+    private_data = Map.get(conn.private, :open_api_spex) || raise @missing_oas_key
+    private_data.spec_module
   end
 end
 

--- a/lib/open_api_spex/plug/cast.ex
+++ b/lib/open_api_spex/plug/cast.ex
@@ -60,17 +60,16 @@ defmodule OpenApiSpex.Plug.Cast do
         operation_id: operation_id,
         render_error: render_error
       }) do
-    spec = private_data.spec
-    operation = private_data.operation_lookup[operation_id]
+    spec_module = private_data.spec_module
+    cache_module = OpenApiSpex.Plug.Cache.adapter()
+    {spec, operation_lookup} = cache_module.get(spec_module)
+    operation = operation_lookup[operation_id]
 
     content_type =
       Conn.get_req_header(conn, "content-type")
       |> Enum.at(0, "")
       |> String.split(";")
       |> Enum.at(0)
-
-    private_data = Map.put(private_data, :operation_id, operation_id)
-    conn = Conn.put_private(conn, :open_api_spex, private_data)
 
     case apply(OpenApiSpex, :cast, [spec, operation, conn, content_type]) do
       {:ok, conn} ->

--- a/lib/open_api_spex/plug/cast.ex
+++ b/lib/open_api_spex/plug/cast.ex
@@ -56,13 +56,11 @@ defmodule OpenApiSpex.Plug.Cast do
 
   @impl Plug
   @deprecated "Use OpenApiSpex.Plug.CastAndValidate instead"
-  def call(conn = %{private: %{open_api_spex: private_data}}, %{
+  def call(conn = %{private: %{open_api_spex: _private_data}}, %{
         operation_id: operation_id,
         render_error: render_error
       }) do
-    spec_module = private_data.spec_module
-    cache_module = OpenApiSpex.Plug.Cache.adapter()
-    {spec, operation_lookup} = cache_module.get(spec_module)
+    {spec, operation_lookup} = OpenApiSpex.Plug.Cache.get_spec_and_operation_lookup(conn)
     operation = operation_lookup[operation_id]
 
     content_type =

--- a/lib/open_api_spex/plug/cast.ex
+++ b/lib/open_api_spex/plug/cast.ex
@@ -60,7 +60,7 @@ defmodule OpenApiSpex.Plug.Cast do
         operation_id: operation_id,
         render_error: render_error
       }) do
-    {spec, operation_lookup} = OpenApiSpex.Plug.Cache.get_spec_and_operation_lookup(conn)
+    {spec, operation_lookup} = OpenApiSpex.Plug.PutApiSpec.get_spec_and_operation_lookup(conn)
     operation = operation_lookup[operation_id]
 
     content_type =

--- a/lib/open_api_spex/plug/cast_and_validate.ex
+++ b/lib/open_api_spex/plug/cast_and_validate.ex
@@ -61,7 +61,7 @@ defmodule OpenApiSpex.Plug.CastAndValidate do
         operation_id: operation_id,
         render_error: render_error
       }) do
-    {spec, operation_lookup} = OpenApiSpex.Plug.Cache.spec_and_operation_lookup(conn)
+    {spec, operation_lookup} = OpenApiSpex.Plug.Cache.get_spec_and_operation_lookup(conn)
     operation = operation_lookup[operation_id]
 
     content_type =
@@ -97,7 +97,7 @@ defmodule OpenApiSpex.Plug.CastAndValidate do
         },
         opts
       ) do
-    {_spec, operation_lookup} = OpenApiSpex.Plug.Cache.spec_and_operation_lookup(conn)
+    {_spec, operation_lookup} = OpenApiSpex.Plug.Cache.get_spec_and_operation_lookup(conn)
 
     operation =
       case operation_lookup[{controller, action}] do

--- a/lib/open_api_spex/plug/cast_and_validate.ex
+++ b/lib/open_api_spex/plug/cast_and_validate.ex
@@ -42,6 +42,7 @@ defmodule OpenApiSpex.Plug.CastAndValidate do
 
   @behaviour Plug
 
+  alias OpenApiSpex.Plug.PutApiSpec
   alias Plug.Conn
 
   @impl Plug
@@ -61,7 +62,7 @@ defmodule OpenApiSpex.Plug.CastAndValidate do
         operation_id: operation_id,
         render_error: render_error
       }) do
-    {spec, operation_lookup} = OpenApiSpex.Plug.PutApiSpec.get_spec_and_operation_lookup(conn)
+    {spec, operation_lookup} = PutApiSpec.get_spec_and_operation_lookup(conn)
     operation = operation_lookup[operation_id]
 
     content_type =
@@ -97,7 +98,7 @@ defmodule OpenApiSpex.Plug.CastAndValidate do
         },
         opts
       ) do
-    {_spec, operation_lookup} = OpenApiSpex.Plug.PutApiSpec.get_spec_and_operation_lookup(conn)
+    {_spec, operation_lookup} = PutApiSpec.get_spec_and_operation_lookup(conn)
 
     # This caching is to improve performance of extracting Operation specs
     # at runtime when they're using the @doc-based syntax.
@@ -106,7 +107,7 @@ defmodule OpenApiSpex.Plug.CastAndValidate do
         nil ->
           operation_id = controller.open_api_operation(action).operationId
 
-          OpenApiSpex.Plug.PutApiSpec.get_and_cache_controller_action(
+          PutApiSpec.get_and_cache_controller_action(
             conn,
             operation_id,
             {controller, action}
@@ -128,6 +129,6 @@ defmodule OpenApiSpex.Plug.CastAndValidate do
   end
 
   def call(_conn, _opts) do
-    raise ":open_api_spex was not found under :private. Maybe OpenApiSpex.Plug.PutApiSpec was not called before?"
+    raise ":open_api_spex was not found under :private. Maybe PutApiSpec was not called before?"
   end
 end

--- a/lib/open_api_spex/plug/cast_and_validate.ex
+++ b/lib/open_api_spex/plug/cast_and_validate.ex
@@ -61,7 +61,7 @@ defmodule OpenApiSpex.Plug.CastAndValidate do
         operation_id: operation_id,
         render_error: render_error
       }) do
-    {spec, operation_lookup} = OpenApiSpex.Plug.Cache.get_spec_and_operation_lookup(conn)
+    {spec, operation_lookup} = OpenApiSpex.Plug.PutApiSpec.get_spec_and_operation_lookup(conn)
     operation = operation_lookup[operation_id]
 
     content_type =
@@ -97,7 +97,7 @@ defmodule OpenApiSpex.Plug.CastAndValidate do
         },
         opts
       ) do
-    {_spec, operation_lookup} = OpenApiSpex.Plug.Cache.get_spec_and_operation_lookup(conn)
+    {_spec, operation_lookup} = OpenApiSpex.Plug.PutApiSpec.get_spec_and_operation_lookup(conn)
 
     # This caching is to improve performance of extracting Operation specs
     # at runtime when they're using the @doc-based syntax.
@@ -106,7 +106,7 @@ defmodule OpenApiSpex.Plug.CastAndValidate do
         nil ->
           operation_id = controller.open_api_operation(action).operationId
 
-          OpenApiSpex.Plug.Cache.get_and_cache_controller_action(
+          OpenApiSpex.Plug.PutApiSpec.get_and_cache_controller_action(
             conn,
             operation_id,
             {controller, action}

--- a/lib/open_api_spex/plug/cast_and_validate.ex
+++ b/lib/open_api_spex/plug/cast_and_validate.ex
@@ -99,6 +99,8 @@ defmodule OpenApiSpex.Plug.CastAndValidate do
       ) do
     {_spec, operation_lookup} = OpenApiSpex.Plug.Cache.get_spec_and_operation_lookup(conn)
 
+    # This caching is to improve performance of extracting Operation specs
+    # at runtime when they're using the @doc-based syntax.
     operation =
       case operation_lookup[{controller, action}] do
         nil ->

--- a/lib/open_api_spex/plug/put_api_spec.ex
+++ b/lib/open_api_spex/plug/put_api_spec.ex
@@ -16,21 +16,23 @@ defmodule OpenApiSpex.Plug.PutApiSpec do
   @cache OpenApiSpex.Plug.Cache.adapter()
 
   @impl Plug
-  def init([module: _spec_module] = opts) do
-    opts[:module]
+  def init(opts) do
+    opts[:module] ||
+      raise "A :module option is required, but none was given to #{__MODULE__}.init/1"
   end
 
   @impl Plug
   def call(conn, spec_module) do
-    {spec, operation_lookup} =
+    # {spec, operation_lookup} =
+    _ =
       case @cache.get(spec_module) do
         nil ->
-          spec = build_spec(spec_module)
-          @cache.put(spec_module, spec)
-          spec
+          spec_and_lookup = build_spec(spec_module)
+          @cache.put(spec_module, spec_and_lookup)
+          spec_and_lookup
 
-        spec ->
-          spec
+        spec_and_lookup ->
+          spec_and_lookup
       end
 
     private_data =
@@ -38,8 +40,9 @@ defmodule OpenApiSpex.Plug.PutApiSpec do
       |> Map.get(:private)
       |> Map.get(:open_api_spex, %{})
       |> Map.put(:spec_module, spec_module)
-      |> Map.put(:spec, spec)
-      |> Map.put(:operation_lookup, operation_lookup)
+
+    # |> Map.put(:spec, spec)
+    # |> Map.put(:operation_lookup, operation_lookup)
 
     Plug.Conn.put_private(conn, :open_api_spex, private_data)
   end

--- a/lib/open_api_spex/plug/put_api_spec.ex
+++ b/lib/open_api_spex/plug/put_api_spec.ex
@@ -23,7 +23,6 @@ defmodule OpenApiSpex.Plug.PutApiSpec do
 
   @impl Plug
   def call(conn, spec_module) do
-    # {spec, operation_lookup} =
     _ =
       case @cache.get(spec_module) do
         nil ->

--- a/lib/open_api_spex/plug/put_api_spec.ex
+++ b/lib/open_api_spex/plug/put_api_spec.ex
@@ -12,7 +12,12 @@ defmodule OpenApiSpex.Plug.PutApiSpec do
 
       plug OpenApiSpex.Plug.PutApiSpec, module: MyAppWeb.ApiSpec
   """
+  alias OpenApiSpex.OpenApi
+
   @behaviour Plug
+
+  @cache OpenApiSpex.Plug.Cache.adapter()
+  @missing_oas_key "Missing private.open_api_spex key in conn. Check that PutApiSpec is being called in the Conn pipeline"
 
   @impl Plug
   def init(opts) do
@@ -29,5 +34,39 @@ defmodule OpenApiSpex.Plug.PutApiSpec do
       |> Map.put(:spec_module, spec_module)
 
     Plug.Conn.put_private(conn, :open_api_spex, private_data)
+  end
+
+  @spec get_spec_and_operation_lookup(Conn.t()) ::
+          {spec :: OpenApi.t(), operation_lookup :: %{any => Operation.t()}}
+  def get_spec_and_operation_lookup(conn) do
+    spec_module = spec_module(conn)
+    spec_and_lookup = @cache.get(spec_module)
+
+    if spec_and_lookup do
+      spec_and_lookup
+    else
+      spec = spec_module.spec()
+      operation_lookup = OpenApi.build_operation_lookup(spec)
+      spec_and_lookup = {spec, operation_lookup}
+      @cache.put(spec_module, spec_and_lookup)
+      spec_and_lookup
+    end
+  end
+
+  @spec get_and_cache_controller_action(Conn.t(), String.t(), {module, atom}) ::
+          Operation.t()
+  def get_and_cache_controller_action(conn, operation_id, {controller, action}) do
+    spec_module = spec_module(conn)
+    {spec, operation_lookup} = get_spec_and_operation_lookup(conn)
+    operation = operation_lookup[operation_id]
+    operation_lookup = Map.put(operation_lookup, {controller, action}, operation)
+    @cache.put(spec_module, {spec, operation_lookup})
+    operation
+  end
+
+  @spec spec_module(Conn.t()) :: module
+  def spec_module(conn) do
+    private_data = Map.get(conn.private, :open_api_spex) || raise @missing_oas_key
+    private_data.spec_module
   end
 end

--- a/lib/open_api_spex/plug/put_api_spec.ex
+++ b/lib/open_api_spex/plug/put_api_spec.ex
@@ -41,9 +41,6 @@ defmodule OpenApiSpex.Plug.PutApiSpec do
       |> Map.get(:open_api_spex, %{})
       |> Map.put(:spec_module, spec_module)
 
-    # |> Map.put(:spec, spec)
-    # |> Map.put(:operation_lookup, operation_lookup)
-
     Plug.Conn.put_private(conn, :open_api_spex, private_data)
   end
 

--- a/lib/open_api_spex/plug/put_api_spec.ex
+++ b/lib/open_api_spex/plug/put_api_spec.ex
@@ -28,10 +28,6 @@ defmodule OpenApiSpex.Plug.PutApiSpec do
       |> Map.get(:open_api_spex, %{})
       |> Map.put(:spec_module, spec_module)
 
-    conn = Plug.Conn.put_private(conn, :open_api_spex, private_data)
-
-    _ = OpenApiSpex.Plug.Cache.get_spec_and_operation_lookup(conn)
-
-    conn
+    Plug.Conn.put_private(conn, :open_api_spex, private_data)
   end
 end

--- a/lib/open_api_spex/plug/render_spec.ex
+++ b/lib/open_api_spex/plug/render_spec.ex
@@ -23,7 +23,7 @@ defmodule OpenApiSpex.Plug.RenderSpec do
       end
   """
 
-  alias OpenApiSpex.Plug.Cache
+  alias OpenApiSpex.Plug.PutApiSpec
 
   @behaviour Plug
 
@@ -34,7 +34,7 @@ defmodule OpenApiSpex.Plug.RenderSpec do
 
   @impl Plug
   def call(conn, _opts) do
-    {spec, _} = Cache.get_spec_and_operation_lookup(conn)
+    {spec, _} = PutApiSpec.get_spec_and_operation_lookup(conn)
 
     conn
     |> Plug.Conn.put_resp_content_type("application/json")

--- a/lib/open_api_spex/plug/render_spec.ex
+++ b/lib/open_api_spex/plug/render_spec.ex
@@ -22,6 +22,9 @@ defmodule OpenApiSpex.Plug.RenderSpec do
         end
       end
   """
+
+  alias OpenApiSpex.Plug.Cache
+
   @behaviour Plug
 
   @json_encoder Enum.find([Jason, Poison], &Code.ensure_loaded?/1)
@@ -31,8 +34,10 @@ defmodule OpenApiSpex.Plug.RenderSpec do
 
   @impl Plug
   def call(conn, _opts) do
+    {spec, _} = Cache.get_spec_and_operation_lookup(conn)
+
     conn
     |> Plug.Conn.put_resp_content_type("application/json")
-    |> Plug.Conn.send_resp(200, @json_encoder.encode!(conn.private.open_api_spex.spec))
+    |> Plug.Conn.send_resp(200, @json_encoder.encode!(spec))
   end
 end

--- a/test/plug/render_spec_test.exs
+++ b/test/plug/render_spec_test.exs
@@ -5,12 +5,7 @@ defmodule OpenApiSpex.Plug.RenderSpecTest do
   alias OpenApiSpex.Plug.{PutApiSpec, RenderSpec}
 
   defmodule ApiSpec do
-    def spec do
-      %OpenApi{
-        info: %{},
-        paths: %{}
-      }
-    end
+    def spec, do: %OpenApi{info: %{}, paths: %{}}
   end
 
   test "call/2" do

--- a/test/plug/render_spec_test.exs
+++ b/test/plug/render_spec_test.exs
@@ -1,0 +1,25 @@
+defmodule OpenApiSpex.Plug.RenderSpecTest do
+  use ExUnit.Case, async: true
+
+  alias OpenApiSpex.OpenApi
+  alias OpenApiSpex.Plug.{PutApiSpec, RenderSpec}
+
+  defmodule ApiSpec do
+    def spec do
+      %OpenApi{
+        info: %{},
+        paths: %{}
+      }
+    end
+  end
+
+  test "call/2" do
+    conn =
+      Plug.Test.conn(:get, "/openapi")
+      |> PutApiSpec.call(ApiSpec)
+      |> RenderSpec.call([])
+
+    resp_body = Jason.decode!(conn.resp_body)
+    assert %{"openapi" => "3.0.0"} = resp_body
+  end
+end


### PR DESCRIPTION
When a request fails to pattern match on a controller action, the resulting error report can be overwhelmingly large. In a recent test, the error report was 83k characters.

There doesn't seem to be a good reason to pass the Open API spec and the Operations lookup into the Conn. That data is already in the in-memory cache.

By removing the data from the Conn, the same error report is only 2k characters in size. It becomes much easier to figure out the bad pattern match.