### PR TITLE
Add missing argument to `erase/1`

### DIFF
--- a/lib/open_api_spex/plug/cache.ex
+++ b/lib/open_api_spex/plug/cache.ex
@@ -50,7 +50,7 @@ defmodule OpenApiSpex.Plug.Cache do
   @spec refresh() :: :ok
   def refresh do
     adapter = adapter()
-    adapter.erase()
+    adapter.erase(adapter)
   end
 end
 


### PR DESCRIPTION
It fixes the error on calling `OpenApiSpex.Plug.Cache.reload()`