### PR TITLE
AddFormatToSpecialTratmentValuesWhenDecodingOpenApi

### DIFF
--- a/lib/open_api_spex/open_api/decode.ex
+++ b/lib/open_api_spex/open_api/decode.ex
@@ -120,6 +120,7 @@ defmodule OpenApiSpex.OpenApi.Decode do
   defp prepare_schema(map) do
     map
     |> convert_value_to_atom_if_present("type")
+    |> convert_value_to_atom_if_present("format")
     |> convert_value_to_atom_if_present("x-struct")
     |> convert_value_to_list_of_atoms_if_present("required")
   end


### PR DESCRIPTION
Making sure format remains as an atom so that parameter casting does not fail pattern matching when casting and validating