### PR TITLE
ControllerSpecs add support for deprecated

### DIFF
--- a/lib/open_api_spex/controller_specs.ex
+++ b/lib/open_api_spex/controller_specs.ex
@@ -262,6 +262,7 @@ defmodule OpenApiSpex.ControllerSpecs do
 
     %Operation{
       description: Map.get(spec, :description),
+      deprecated: Map.get(spec, :deprecated),
       operationId: OperationBuilder.build_operation_id(spec, module, action),
       parameters: OperationBuilder.build_parameters(spec),
       requestBody: OperationBuilder.build_request_body(spec),

--- a/test/controller_specs_test.exs
+++ b/test/controller_specs_test.exs
@@ -56,6 +56,13 @@ defmodule OpenApiSpex.ControllerSpecsTest do
       assert %MediaType{schema: OpenApiSpexTest.DslController.UserResponse} = media_type
     end
 
+    test ":deprecated" do
+      assert %OpenApiSpex.Operation{
+               summary: "User destroy",
+               deprecated: true
+             } = DslController.open_api_operation(:destroy)
+    end
+
     test "outputs warning when action not defined for called open_api_operation" do
       output = capture_io(:stderr, fn -> DslController.open_api_operation(:undefined) end)
 

--- a/test/support/dsl_controller.ex
+++ b/test/support/dsl_controller.ex
@@ -46,6 +46,15 @@ defmodule OpenApiSpexTest.DslController do
     })
   end
 
+  defmodule UsersDestroyResponse do
+    alias OpenApiSpex.Schema
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      type: :string
+    })
+  end
+
   tags ["users"]
 
   security [%{"api_key" => ["mySecurityScheme"]}]
@@ -88,6 +97,24 @@ defmodule OpenApiSpexTest.DslController do
     ],
     responses: [
       ok: {"Users index response", "application/json", UsersIndexResponse}
+    ]
+
+  def index(conn, _) do
+    json(conn, [])
+  end
+
+  operation :destroy,
+    deprecated: true,
+    summary: "User destroy",
+    parameters: [
+      username: [
+        in: :query,
+        description: "Username to destroy",
+        type: :string
+      ]
+    ],
+    responses: [
+      no_content: {"Users destroy response", "application/json", UsersDestroyResponse}
     ]
 
   def index(conn, _) do


### PR DESCRIPTION
Hi there!

Thanks for the library, the thing is that we wanted to add the `deprecated` flag to the operation used @doc based API and it collisions with Elixir deprecated flag, later we found the new `operation` API and it misses the flag so we just added it.

Do I need to do anything else for this to be accepted?

Thanks in advance