### PR TITLE
Fix type of extensions in OpenApiSpex.Info

### DIFF
--- a/lib/open_api_spex/info.ex
+++ b/lib/open_api_spex/info.ex
@@ -27,6 +27,6 @@ defmodule OpenApiSpex.Info do
           contact: Contact.t() | nil,
           license: License.t() | nil,
           version: String.t(),
-          extensions: %{String.t() => String.t()} | nil
+          extensions: %{String.t() => any()} | nil
         }
 end


### PR DESCRIPTION
The value could be other map or list the same way as in
`OpenApiSpex.OpenApi`.