### PR TITLE
Fix/response object default

### DIFF
--- a/lib/open_api_spex/operation_builder.ex
+++ b/lib/open_api_spex/operation_builder.ex
@@ -96,7 +96,6 @@ defmodule OpenApiSpex.OperationBuilder do
 
   def build_responses(_), do: []
 
-  @spec status_to_code(integer | atom) :: integer | :default
   defp status_to_code(:default), do: :default
   defp status_to_code(status), do: Plug.Conn.Status.code(status)
 

--- a/lib/open_api_spex/operation_builder.ex
+++ b/lib/open_api_spex/operation_builder.ex
@@ -96,8 +96,8 @@ defmodule OpenApiSpex.OperationBuilder do
 
   def build_responses(_), do: []
 
-  @spec status_to_code(integer | :default) :: integer
-  defp status_to_code(:default), do: "default"
+  @spec status_to_code(integer | atom) :: integer | :default
+  defp status_to_code(:default), do: :default
   defp status_to_code(status), do: Plug.Conn.Status.code(status)
 
   def build_request_body(%{body: {name, mime, schema}}) do

--- a/lib/open_api_spex/operation_builder.ex
+++ b/lib/open_api_spex/operation_builder.ex
@@ -69,16 +69,16 @@ defmodule OpenApiSpex.OperationBuilder do
   def build_responses(%{responses: responses}) when is_list(responses) or is_map(responses) do
     Map.new(responses, fn
       {status, {description, mime, schema}} ->
-        {Plug.Conn.Status.code(status), Operation.response(description, mime, schema)}
+        {status_to_code(status), Operation.response(description, mime, schema)}
 
       {status, {description, mime, schema, opts}} ->
-        {Plug.Conn.Status.code(status), Operation.response(description, mime, schema, opts)}
+        {status_to_code(status), Operation.response(description, mime, schema, opts)}
 
       {status, %Response{} = response} ->
-        {Plug.Conn.Status.code(status), response}
+        {status_to_code(status), response}
 
       {status, description} when is_binary(description) ->
-        {Plug.Conn.Status.code(status), %Response{description: description}}
+        {status_to_code(status), %Response{description: description}}
     end)
   end
 
@@ -95,6 +95,10 @@ defmodule OpenApiSpex.OperationBuilder do
   end
 
   def build_responses(_), do: []
+
+  @spec status_to_code(integer | :default) :: integer
+  defp status_to_code(:default), do: "default"
+  defp status_to_code(status), do: Plug.Conn.Status.code(status)
 
   def build_request_body(%{body: {name, mime, schema}}) do
     IO.warn("Using :body key for requestBody is deprecated. Please use :request_body instead.")

--- a/test/controller_test.exs
+++ b/test/controller_test.exs
@@ -43,7 +43,7 @@ defmodule OpenApiSpex.ControllerTest do
     end
 
     test "has default response" do
-      assert %{responses: %{"default" => _}} = @controller.open_api_operation(:update)
+      assert %{responses: %{:default => _}} = @controller.open_api_operation(:update)
     end
 
     test "has parameter `:id`" do

--- a/test/controller_test.exs
+++ b/test/controller_test.exs
@@ -42,6 +42,10 @@ defmodule OpenApiSpex.ControllerTest do
       assert %{responses: %{404 => _}} = @controller.open_api_operation(:update)
     end
 
+    test "has default response" do
+      assert %{responses: %{"default" => _}} = @controller.open_api_operation(:update)
+    end
+
     test "has parameter `:id`" do
       assert %{parameters: [param]} = @controller.open_api_operation(:update)
       assert param.name == :id

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -131,11 +131,11 @@ defmodule OpenApiSpexTest.Schemas do
     })
 
     @doc """
-    Unauthorized object, as a whole response.
+    GenericError object, as a whole response.
     """
     def response do
       Operation.response(
-        "Authorization Required",
+        "Error",
         "application/json",
         __MODULE__
       )

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -102,6 +102,46 @@ defmodule OpenApiSpexTest.Schemas do
     end
   end
 
+  defmodule GenericError do
+    @moduledoc """
+    Generic error
+    """
+    require OpenApiSpex
+    alias OpenApiSpex.Operation
+
+    # OpenApiSpex.schema/1 macro can be optionally used to reduce boilerplate code
+    OpenApiSpex.schema(%{
+      title: "Error",
+      type: :object,
+      properties: %{
+        errors: %Schema{
+          type: :array,
+          items: %Schema{
+            type: :object,
+            properties: %{
+              detail: %Schema{
+                type: :string,
+                example: "An error occured."
+              },
+              title: %Schema{type: :string, example: "Error"}
+            }
+          }
+        }
+      }
+    })
+
+    @doc """
+    Unauthorized object, as a whole response.
+    """
+    def response do
+      Operation.response(
+        "Authorization Required",
+        "application/json",
+        __MODULE__
+      )
+    end
+  end
+
   defmodule NoContent do
     require OpenApiSpex
     alias OpenApiSpex.Operation

--- a/test/support/user_controller_annotated.ex
+++ b/test/support/user_controller_annotated.ex
@@ -3,7 +3,7 @@ defmodule OpenApiSpexTest.UserControllerAnnotated do
 
   use OpenApiSpex.Controller
   alias OpenApiSpex.Header
-  alias OpenApiSpexTest.Schemas.{NotFound, Unauthorized, User}
+  alias OpenApiSpexTest.Schemas.{GenericError, NotFound, Unauthorized, User}
 
   @doc """
   Update a user
@@ -22,7 +22,8 @@ defmodule OpenApiSpexTest.UserControllerAnnotated do
            headers: %{"token" => %Header{description: "Access token"}}
          },
          unauthorized: Unauthorized.response(),
-         not_found: NotFound.response()
+         not_found: NotFound.response(),
+         default: GenericError.response()
        ]
   @doc security: [%{"authorization" => []}]
   def update(_conn, _params), do: :ok


### PR DESCRIPTION
#300 

Fixes error when attempting to use the key `:default` for a response in the responses map.