### PR TITLE
Allow specifying x-struct directive when using the schema/1 macro

### DIFF
--- a/lib/open_api_spex.ex
+++ b/lib/open_api_spex.ex
@@ -178,7 +178,9 @@ defmodule OpenApiSpex do
                 OpenApiSpex.Schema,
                 unquote(body)
                 |> Map.delete(:__struct__)
-                |> Map.put(:"x-struct", __MODULE__)
+                |> update_in([:"x-struct"], fn struct_module ->
+                  struct_module || __MODULE__
+                end)
                 |> update_in([:title], fn title ->
                   title || __MODULE__ |> Module.split() |> List.last()
                 end)

--- a/lib/open_api_spex.ex
+++ b/lib/open_api_spex.ex
@@ -188,9 +188,11 @@ defmodule OpenApiSpex do
 
       def schema, do: @schema
 
-      @derive Enum.filter([Poison.Encoder, Jason.Encoder], &Code.ensure_loaded?/1)
-      defstruct Schema.properties(@schema)
-      @type t :: %__MODULE__{}
+      if Map.get(@schema, :"x-struct") == __MODULE__ do
+        @derive Enum.filter([Poison.Encoder, Jason.Encoder], &Code.ensure_loaded?/1)
+        defstruct Schema.properties(@schema)
+        @type t :: %__MODULE__{}
+      end
 
       Map.from_struct(@schema) |> OpenApiSpex.validate_compiled_schema()
 


### PR DESCRIPTION
Closes #303 .

This change enables specifying an `x-struct` value in the `%Schema{}` struct when using the `OpenApiSpex.schema/1` macro.

Previously, the value for this field would be overridden with the module where the schema is defined.

Now, the logic will check to see if an `x-struct` value is specified. If not, it will fall back to the prior logic.

@mbuhot let me know if this is satisfactory as per our discussion on #303 . Thanks!