### PR TITLE
Do not repeat the summary in the description

### DIFF
--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -7,8 +7,8 @@ defmodule OpenApiSpex.Controller do
   ### `description` and `summary`
 
   Description of endpoint will be filled with documentation string in the same
-  manner as ExDocs, so first line will be used as a `summary` and whole
-  documentation will be used as `description` field.
+  manner as ExDocs, so first line will be used as a `summary` and the rest of it
+  will be used as `description` field.
 
   ### `operation_id`
 
@@ -215,9 +215,9 @@ defmodule OpenApiSpex.Controller do
           true ->
             {summary, description} =
               if is_map(docs) do
-                description = Map.get(docs, "en", "")
-                [summary | _] = String.split(description, ~r/\n\s*\n/, parts: 2)
-                {summary, description}
+                contents = Map.get(docs, "en", "")
+                [summary | description] = String.split(contents, ~r/\n\s*\n/, parts: 2)
+                {summary, List.first(description)}
               else
                 {"", ""}
               end

--- a/test/controller_test.exs
+++ b/test/controller_test.exs
@@ -22,7 +22,7 @@ defmodule OpenApiSpex.ControllerTest do
     test "summary matches 'Endpoint summary'" do
       op = @controller.open_api_operation(:update)
       assert op.summary == "Update a user"
-      assert op.description == "Update a user\n\nFull description for this endpoint...\n"
+      assert op.description == "Full description for this endpoint...\n"
     end
 
     test "security matches 'foo'" do


### PR DESCRIPTION
When documenting an operation from the @doc tag, use the first line as
summary and the rest of it as description, without repeating the summary
in the description.

This changes current behaviour, but I feel it's better to not repeat the
summary in the description, which usually appears shortly after.

Feedback is welcome :)