### PR TITLE
Promote ControlerSpecs as the preferred API for controller operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ be defined using moduledoc attributes that are supported in Elixir 1.7 and highe
 
 ```elixir
 defmodule MyAppWeb.UserController do
-  use Phoenix.Controller
+  use MyAppWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
   alias MyAppWeb.Schemas.{UserParams, UserResponse}
@@ -137,15 +137,15 @@ and the HTTP status codes can be replaced with their text equivalents:
 ```elixir
 responses: [
   ok: {"User response", "application/json", MyAppWeb.Schemas.UserResponse},
-  unprocessable_entity: {"Bad request parameters", "application/json", MyAppWeb.Schema.BadRequestParameters},
-  not_found: {"Not found", "application/json", MyAppWeb.Schema.NotFound}
+  unprocessable_entity: {"Bad request parameters", "application/json", MyAppWeb.Schemas.BadRequestParameters},
+  not_found: {"Not found", "application/json", MyAppWeb.Schemas.NotFound}
 ]
 ```
 
 The full set of atom keys are defined in `Plug.Conn.Status.code/1`.
 
-If you need to omit the spec for some action then pass false to the second argument of `operation/2`
-for the action:
+If you need to omit the spec for some action then pass false to the
+second argument of `operation/2` for the action:
 
 ```elixir
 operation :create, false
@@ -160,7 +160,7 @@ The definitions data is cached, so it does not actually extract the definitions 
 Note that the names of the OpenAPI fields follow `snake_case` naming convention instead of
 OpenAPI's (and JSON Schema's) `camelCase` convention.
 
-### Alternatives to ControllerSpecs-based Operation Specs
+### Alternatives to ControllerSpecs-style Operation Specs
 
 #### %Operation{}
 
@@ -370,8 +370,8 @@ defmodule MyAppWeb.UserController do
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
 
   operation :create,
-    summary: "Create user.",
-    description: "Create a user."
+    summary: "Create user",
+    description: "Creates a user from the given params.\nThis is another line of text in the description."
     parameters: [
       id: [in: :query, type: :integer, description: "user ID"]
     ],

--- a/README.md
+++ b/README.md
@@ -91,43 +91,34 @@ For each plug (controller) that will handle API requests, operations need
 to be defined that the plug/controller will handle. The operations can
 be defined using moduledoc attributes that are supported in Elixir 1.7 and higher.
 
-Note: For projects using Elixir releases, [there is an issue](https://github.com/open-api-spex/open_api_spex/issues/242) that
-potentially breaks OpenApiSpex's integration with your application. See the next section
-for work-arounds to this issue.
-
 ```elixir
 defmodule MyAppWeb.UserController do
-  @moduledoc tags: ["users"]
+  use Phoenix.Controller
+  use OpenApiSpex.ControllerSpecs
 
-  use MyAppWeb, :controller
-  use OpenApiSpex.Controller
+  alias MyAppWeb.Schemas.{UserParams, UserResponse}
 
-  @doc """
-  List users
-  """
-  @doc responses: %{
-    200 => {"Users", "application/json", MyAppWeb.Schema.Users}
-  }
-  def index(conn, _params) do
-    {:ok, users} = MyApp.Users.all()
+  tags ["users"]
+  security [%{}, %{"petstore_auth" => ["write:users", "read:users"]}]
 
-    json(conn, users)
-  end
-
-  @doc """
-  Update user
-  """
-  @doc parameters: [
-      id: [in: :query, schema: %OpenApiSpex.Schema{type: :string}, required: true, description: "User ID"]
+  operation :update,
+    summary: "Update user",
+    parameters: [
+      id: [in: :path, description: "User ID", type: :integer, example: 1001]
     ],
-    request_body: {"Request body to update a User", "application/json", User, required: true},
-    responses: %{
-      200 => {"User", "application/json", MyAppWeb.Schema.User}
-    }
-  def update(conn, %{id: id}) do
-    with {:ok, user} <- MyApp.Users.update(conn.body_params) do
-      json(conn, user)
-    end
+    request_body: {"User params", "application/json", UserParams},
+    responses: [
+      ok: {"User response", "application/json", UserResponse}
+    ]
+
+  def update(conn, %{"id" => id}) do
+    json(conn, %{
+      data: %{
+        id: id,
+        name: "joe user",
+        email: "joe@gmail.com"
+      }
+    })
   end
 end
 ```
@@ -135,8 +126,8 @@ end
 There is a convenient shortcut `:type` for base data types supported by open api
 
 ```elixir
-@doc parameters: [
-  id: [in: :query, type: :string, required: true, description: "User ID"]
+parameters: [
+  id: [in: :query, type: :integer, required: true, description: "User ID", example: 1001]
 ]
 ```
 
@@ -144,19 +135,20 @@ The responses can also be defined using keyword list syntax,
 and the HTTP status codes can be replaced with their text equivalents:
 
 ```elixir
-  @doc responses: [
-    ok: {"User", "application/json", MyAppWeb.Schema.User}
-    unprocessable_entity: {"Bad request parameters", "application/json", MyAppWeb.Schema.BadRequestParameters},
-    not_found: {"Not found", "application/json", MyAppWeb.Schema.NotFound}
-  ]
+responses: [
+  ok: {"User response", "application/json", MyAppWeb.Schemas.UserResponse},
+  unprocessable_entity: {"Bad request parameters", "application/json", MyAppWeb.Schema.BadRequestParameters},
+  not_found: {"Not found", "application/json", MyAppWeb.Schema.NotFound}
+]
 ```
 
 The full set of atom keys are defined in `Plug.Conn.Status.code/1`.
 
-If you need to omit the spec for some action then pass false to the generator:
+If you need to omit the spec for some action then pass false to the second argument of `operation/2`
+for the action:
 
 ```elixir
-@doc false
+operation :create, false
 ```
 
 Each definition in a controller action or plug operation is converted
@@ -165,26 +157,19 @@ by your application's `ApiSpec` module, which in turn is
 called from the `OpenApiSpex.Plug.PutApiSpex` plug on each request.
 The definitions data is cached, so it does not actually extract the definitions on each request.
 
-Note that in the ExDoc-based definitions, the names of the OpenAPI fields follow `snake_case` naming convention instead of
+Note that the names of the OpenAPI fields follow `snake_case` naming convention instead of
 OpenAPI's (and JSON Schema's) `camelCase` convention.
 
-### Alternatives to ExDoc-Based Operation Specs
+### Alternatives to ControllerSpecs-based Operation Specs
 
 #### %Operation{}
 
-If the ExDoc-based operation specs don't provide the flexibiliy you need, the `%Operation{}` struct
+If ControllerSpecs-style operation specs don't provide the flexibiliy you need, the `%Operation{}` struct
 and related structs can be used instead. See the
 [example user controller that uses `%Operation{}` structs](https://github.com/open-api-spex/open_api_spex/blob/master/examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller_with_struct_specs.ex).
 
 For examples of other action operations, see the
 [example web app](https://github.com/open-api-spex/open_api_spex/blob/master/examples/phoenix_app/lib/phoenix_app_web/controllers/user_controller.ex).
-
-#### Experimental API
-
-There is a new, experimental Operation spec API that has the same lightweight syntax
-as the ExDoc-based API, but without the potentially breaking issue described in
-[issue #242](https://github.com/open-api-spex/open_api_spex/issues/242).
-This new API is described in the `OpenApiSpex.ControllerSpecs` docs.
 
 ### Schemas
 
@@ -378,24 +363,23 @@ Example usage of `CastAndValidate` in a Phoenix controller:
 ```elixir
 defmodule MyAppWeb.UserController do
   use MyAppWeb, :controller
-  alias OpenApiSpex.Operation
+  use OpenApiSpex.ControllerSpecs
+
   alias MyAppWeb.Schemas.{User, UserRequest, UserResponse}
 
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
 
-  @doc """
-  Create user.
-
-  Create a user.
-  """
-  @doc parameters: [
-         id: [in: :query, type: :integer, description: "user ID"]
-       ],
-       request_body: {"The user attributes", "application/json", UserRequest},
-       responses: %{
-         201 => {"User", "application/json", UserResponse}
-         422 => OpenApiSpex.JsonErrorResponse.response()
-       }
+  operation :create,
+    summary: "Create user.",
+    description: "Create a user."
+    parameters: [
+      id: [in: :query, type: :integer, description: "user ID"]
+    ],
+    request_body: {"The user attributes", "application/json", UserRequest},
+    responses: %{
+      201 => {"User", "application/json", UserResponse}
+      422 => OpenApiSpex.JsonErrorResponse.response()
+    }
   def create(
         conn = %{
           body_params: %UserRequest{
@@ -406,6 +390,12 @@ defmodule MyAppWeb.UserController do
       ) do
     # conn.body_params cast to UserRequest struct
     # conn.params.id cast to integer
+
+    # Note: Using pattern-matching in the action function's arguments can
+    # cause Dialyzer to complain. This is because Dialyzer expects the
+    # `conn` and `params` arguments to have string keys, not atom keys.
+    # To resolve this, fetch the `:body_params` with
+    # `body_params = Map.get(conn, :body_params)`.
   end
 end
 ```

--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -2,6 +2,10 @@ defmodule OpenApiSpex.Controller do
   @moduledoc ~S'''
   Generation of OpenAPI documentation via ExDoc documentation and tags.
 
+  Note: For projects using Elixir releases, [there is an issue](https://github.com/open-api-spex/open_api_spex/issues/242) that
+  potentially breaks OpenApiSpex's integration with your application. Please use `OpenApiSpex.ControllerSpecs` instead.
+
+
   ## Supported OpenAPI fields
 
   ### `description` and `summary`

--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -5,7 +5,6 @@ defmodule OpenApiSpex.Controller do
   Note: For projects using Elixir releases, [there is an issue](https://github.com/open-api-spex/open_api_spex/issues/242) that
   potentially breaks OpenApiSpex's integration with your application. Please use `OpenApiSpex.ControllerSpecs` instead.
 
-
   ## Supported OpenAPI fields
 
   ### `description` and `summary`

--- a/lib/open_api_spex/controller_specs.ex
+++ b/lib/open_api_spex/controller_specs.ex
@@ -254,7 +254,13 @@ defmodule OpenApiSpex.ControllerSpecs do
     end
   end
 
-  @doc false
+  @doc """
+  Define an Operation for a controller action.
+
+  See `OpenApiSpex.ControllerSpecs` for usage and examples.
+  """
+  def operation_spec(_module, _action, nil = _spec), do: nil
+
   def operation_spec(module, action, spec) do
     spec = Map.new(spec)
     shared_tags = Module.get_attribute(module, :shared_tags, []) |> List.flatten()

--- a/test/open_api/decode_test.exs
+++ b/test/open_api/decode_test.exs
@@ -218,7 +218,7 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
              } == link
 
       assert %{
-               "api_key" => api_key_security_scheme,
+               "api_key" => _api_key_security_scheme,
                "petstore_auth" => petstore_auth_security_scheme
              } = securitySchemes
 
@@ -387,7 +387,7 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
 
       test_conn = fetch_query_params(test_conn)
 
-      assert {:ok, validation_result} =
+      assert {:ok, _validation_result} =
                OpenApiSpex.cast_and_validate(
                  spec,
                  spec.paths["/example"].post,


### PR DESCRIPTION
Because of #242, ExDoc-based operation specs is not a reliable API across different versions of Elixir. `ControllerSpecs`, introduced in version 3.9, offers a similar lightweight syntax as the ExDoc API without the same limitation. This PR updates the README to promote `ControllerSpecs` as the preferred API for defining operations specs.