### PR TITLE
Function for adding additional schemas to an OpenApi spec struct

### DIFF
--- a/lib/open_api_spex.ex
+++ b/lib/open_api_spex.ex
@@ -37,6 +37,15 @@ defmodule OpenApiSpex do
   end
 
   @doc """
+  Add more schemas to an existing OpenApi struct.
+
+  This is useful when the schemas are not used by a Plug or Controller.
+  Perhaps they're used by a Phoenix Channel.
+  """
+  @spec add_schemas(OpenApi.t(), list(module)) :: OpenApi.t()
+  defdelegate add_schemas(spec, schema_modules), to: SchemaResolver
+
+  @doc """
   Cast and validate a value against a given Schema.
   """
   def cast_value(value, schema = %schema_mod{}) when schema_mod in [Schema, Reference] do

--- a/lib/open_api_spex.ex
+++ b/lib/open_api_spex.ex
@@ -41,6 +41,23 @@ defmodule OpenApiSpex do
 
   This is useful when the schemas are not used by a Plug or Controller.
   Perhaps they're used by a Phoenix Channel.
+
+  ## Example
+
+      defmodule MyAppWeb.ApiSpec do
+        def spec do
+          %OpenApiSpex.OpenApi{
+            # ...
+            paths: OpenApiSpex.Paths.from_router(MyAppWeb.Router)
+            # ...
+          }
+          |> OpenApiSpex.resolve_schema_modules()
+          |> OpenApiSpex.add_schemas([
+            MyAppWeb.Schemas.Message,
+            MyAppWeb.Schemas.Channel
+          ])
+        end
+      end
   """
   @spec add_schemas(OpenApi.t(), list(module)) :: OpenApi.t()
   defdelegate add_schemas(spec, schema_modules), to: SchemaResolver

--- a/lib/open_api_spex/schema_resolver.ex
+++ b/lib/open_api_spex/schema_resolver.ex
@@ -40,6 +40,12 @@ defmodule OpenApiSpex.SchemaResolver do
     %{spec | paths: paths, components: %{components | schemas: schemas, responses: responses}}
   end
 
+  @doc false
+  def add_schemas(spec = %OpenApi{}, schemas) do
+    {_, schemas} = resolve_schema_modules_from_schema(schemas, spec.components.schemas)
+    put_in(spec.components.schemas, schemas)
+  end
+
   defp resolve_schema_modules_from_paths(paths = %{}, schemas = %{}) do
     Enum.reduce(paths, {paths, schemas}, fn {path, path_item}, {paths, schemas} ->
       {new_path_item, schemas} = resolve_schema_modules_from_path_item(path_item, schemas)


### PR DESCRIPTION
Sometimes it is desired to define a schema that isn't referenced by a Plug or Controller. For example, a Phoenix Channel communicates in JSON, and that JSON can be specified with OpenApiSpex. This PR adds a function `OpenApiSpex.add_schemas/2` that resolves the given functions and adds them to the `OpenApi` struct as component schemas.