### PR TITLE
Version 3.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+# 3.10.0
+
+Thanks to the contributions of the community ❤️💙💛💜🧡
+
+- [noozo](https://github.com/noozo)
+- [sernajoto](https://github.com/sernajoto)
+- [pacoguzman](https://github.com/pacoguzman)
+- [vitorleal](https://github.com/vitorleal)
+- [zlarsen](https://github.com/zlarsen)
+- [surik](https://github.com/surik)
+- [brentjr](https://github.com/brentjr)
+- [dwmcc](https://github.com/dwmcc)
+- [wingyplus](https://github.com/wingyplus)
+
+- Feature: Support OAuth2 for swagger-ui (#217)
+- Feature: Support `default` response type in responses (#301)
+- Feature: Allow overriding `x-struct` in `OpenApiSpex.shcmea/1` (#304)
+- Feature: Ability to specify `deprecated` in ControllerSpec operation (#296)
+- Feature: `:struct?` and `:derive?` options in `OpenApiSpex.schema/1` (#312)
+- Feature: `OpenApiSpex.add_schemas/2` (#314)
+- Enhancement: Remove api_spec data from Conn (#286)
+- Enhancement: More informative errors for bad schema (#288, #284, #287) 
+- Fix: Convert `:format` value to atom when decoding schema file (#293)
+- Fix: Type spec in OpenApiSpex.Info
+- Fix: Elixir Formatter rules in published package (#306)
+- Docs: Fix spelling error in example code (#295)
+- Docs: Fix type in README (#297)
+- Docs: Fix links and punctuation in README (#298)
+- Docs: Promote ControlerSpecs as the preferred API for controller operations (#311)
+
 # 3.9.0
 
 Thanks to the contributions of the community ❤️💙💛💜🧡

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The package can be installed by adding `open_api_spex` to your list of dependenc
 ```elixir
 def deps do
   [
-    {:open_api_spex, "~> 3.9"}
+    {:open_api_spex, "~> 3.10"}
   ]
 end
 ```
@@ -88,8 +88,7 @@ To learn more about the different security schemes please the check the [officia
 ### Operations
 
 For each plug (controller) that will handle API requests, operations need
-to be defined that the plug/controller will handle. The operations can
-be defined using moduledoc attributes that are supported in Elixir 1.7 and higher.
+to be defined that the plug/controller will handle.
 
 ```elixir
 defmodule MyAppWeb.UserController do
@@ -123,6 +122,16 @@ defmodule MyAppWeb.UserController do
 end
 ```
 
+Note: In order to prevent Elixir Formatter from automatically adding parentheses to the `ControllerSpecs` macro
+call arguments, add `:open_api_spex` to the `import_deps` list in `.formatter.exs`:
+
+.formatter.exs:
+```elixir
+[
+  import_deps: [:open_api_spex]
+]
+```
+
 There is a convenient shortcut `:type` for base data types supported by open api
 
 ```elixir
@@ -143,6 +152,16 @@ responses: [
 ```
 
 The full set of atom keys are defined in `Plug.Conn.Status.code/1`.
+
+Alternately, the HTTP status codes can be specified directly:
+
+```elixir
+responses: %{
+  200 => {"User response", "application/json", MyAppWeb.Schemas.UserResponse},
+  422 => {"Bad request parameters", "application/json", MyAppWeb.Schemas.BadRequestParameters},
+  404 => {"Not found", "application/json", MyAppWeb.Schemas.NotFound}
+}
+```
 
 If you need to omit the spec for some action then pass false to the
 second argument of `operation/2` for the action:
@@ -454,8 +473,7 @@ end
 
 OpenApiSpex can generate example data from specs. This has a similar result as
 SwaggerUI when it generates example requests or responses for an endpoint.
-Generated examples are a convenient way to come up with test data for
-controller/plug tests.
+This is a convenient way to generate test data for controller/plug tests.
 
 ```elixir
 use MyAppWeb.ConnCase

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule OpenApiSpex.Mixfile do
   use Mix.Project
 
-  @version "3.9.0"
+  @version "3.10.0"
 
   def project do
     [


### PR DESCRIPTION
Thanks to the contributions of the community ❤️💙💛💜🧡

- [noozo](https://github.com/noozo)
- [sernajoto](https://github.com/sernajoto)
- [pacoguzman](https://github.com/pacoguzman)
- [vitorleal](https://github.com/vitorleal)
- [zlarsen](https://github.com/zlarsen)
- [surik](https://github.com/surik)
- [brentjr](https://github.com/brentjr)
- [dwmcc](https://github.com/dwmcc)
- [wingyplus](https://github.com/wingyplus)

- Feature: Support OAuth2 for swagger-ui (#217)
- Feature: Support `default` response type in responses (#301)
- Feature: Allow overriding `x-struct` in `OpenApiSpex.shcmea/1` (#304)
- Feature: Ability to specify `deprecated` in ControllerSpec operation (#296)
- Feature: `:struct?` and `:derive?` options in `OpenApiSpex.schema/1` (#312)
- Feature: `OpenApiSpex.add_schemas/2` (#314)
- Enhancement: Remove api_spec data from Conn (#286)
- Enhancement: More informative errors for bad schema (#288, #284, #287) 
- Fix: Convert `:format` value to atom when decoding schema file (#293)
- Fix: Type spec in OpenApiSpex.Info
- Fix: Elixir Formatter rules in published package (#306)
- Docs: Fix spelling error in example code (#295)
- Docs: Fix type in README (#297)
- Docs: Fix links and punctuation in README (#298)
- Docs: Promote ControlerSpecs as the preferred API for controller operations (#311)