### PR TITLE
feat(ui): dont json encode swagger-ui methods

### DIFF
--- a/lib/open_api_spex/plug/swagger_ui.ex
+++ b/lib/open_api_spex/plug/swagger_ui.ex
@@ -182,7 +182,6 @@ defmodule OpenApiSpex.Plug.SwaggerUI do
       true -> value
       false -> OpenApiSpex.OpenApi.json_encoder().encode!(value)
     end
-    |> IO.inspect()
   end
 
   defp supplement_config(%{oauth2_redirect_url: {:endpoint_url, path}} = config, conn) do

--- a/lib/open_api_spex/plug/swagger_ui.ex
+++ b/lib/open_api_spex/plug/swagger_ui.ex
@@ -96,7 +96,7 @@ defmodule OpenApiSpex.Plug.SwaggerUI do
           return request;
         }
         <%= for {k, v} <- Map.drop(config, [:path, :oauth]) do %>
-        , <%= camelize(k) %>: <%= OpenApiSpex.OpenApi.json_encoder().encode!(v) %>
+        , <%= camelize(k) %>: <%= encode_config(k, v) %>
         <% end %>
       })
       // End Swagger UI call region
@@ -114,6 +114,19 @@ defmodule OpenApiSpex.Plug.SwaggerUI do
     </body>
     </html>
   """
+
+  @ui_config_methods [
+    "operationsSorter",
+    "tagsSorter",
+    "onComplete",
+    "requestInterceptor",
+    "responseInterceptor",
+    "modelPropertyMacro",
+    "parameterMacro",
+    "initOAuth",
+    "preauthorizeBasic",
+    "preauthorizeApiKey"
+  ]
 
   @doc """
   Initializes the plug.
@@ -162,6 +175,14 @@ defmodule OpenApiSpex.Plug.SwaggerUI do
       [first] -> first
       [first, rest] -> first <> Macro.camelize(rest)
     end
+  end
+
+  defp encode_config(key, value) do
+    case Enum.member?(@ui_config_methods, camelize(key)) do
+      true -> value
+      false -> OpenApiSpex.OpenApi.json_encoder().encode!(value)
+    end
+    |> IO.inspect()
   end
 
   defp supplement_config(%{oauth2_redirect_url: {:endpoint_url, path}} = config, conn) do


### PR DESCRIPTION
Dont encode functions for swagger UI, now you are able to set authentication by initiating the SwaggerUi plug like so:

```elixir
get "/", OpenApiSpex.Plug.SwaggerUI,
      path: "/v1/openapi",
      onComplete: "function(){ ui.preauthorizeApiKey(\"brand\", \"ad\"); }"
```

solution for: https://github.com/open-api-spex/open_api_spex/issues/324