### PR TITLE
external_docs via controller @doc and @moduledoc or ControllerSpecs DSL

### DIFF
--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -179,6 +179,7 @@ defmodule OpenApiSpex.Controller do
     with {:ok, {mod_meta, summary, description, meta}} <- get_docs(mod, name) do
       %Operation{
         summary: summary,
+        externalDocs: OperationBuilder.build_external_docs(meta, mod_meta),
         description: description,
         operationId: OperationBuilder.build_operation_id(meta, mod, name),
         parameters: OperationBuilder.build_parameters(meta),

--- a/lib/open_api_spex/controller_specs.ex
+++ b/lib/open_api_spex/controller_specs.ex
@@ -278,9 +278,9 @@ defmodule OpenApiSpex.ControllerSpecs do
 
     %Operation{
       callbacks: Map.get(spec, :callbacks, %{}),
-      externalDocs: OperationBuilder.build_external_docs(spec),
       description: Map.get(spec, :description),
       deprecated: Map.get(spec, :deprecated),
+      externalDocs: OperationBuilder.build_external_docs(spec),
       operationId: OperationBuilder.build_operation_id(spec, module, action),
       parameters: OperationBuilder.build_parameters(spec),
       requestBody: OperationBuilder.build_request_body(spec),

--- a/lib/open_api_spex/controller_specs.ex
+++ b/lib/open_api_spex/controller_specs.ex
@@ -278,6 +278,7 @@ defmodule OpenApiSpex.ControllerSpecs do
 
     %Operation{
       callbacks: Map.get(spec, :callbacks, %{}),
+      externalDocs: OperationBuilder.build_external_docs(spec),
       description: Map.get(spec, :description),
       deprecated: Map.get(spec, :deprecated),
       operationId: OperationBuilder.build_operation_id(spec, module, action),

--- a/lib/open_api_spex/operation_builder.ex
+++ b/lib/open_api_spex/operation_builder.ex
@@ -17,9 +17,15 @@ defmodule OpenApiSpex.OperationBuilder do
     end
   end
 
-  def build_external_docs(%{external_docs: external_docs}, _module_spec), do: struct(ExternalDocumentation, external_docs)
-  def build_external_docs(_operation_spec, %{external_docs: external_docs}), do: struct(ExternalDocumentation, external_docs)
-  def build_external_docs(_operation_spec, _module_spec), do: nil
+  def build_external_docs(%{external_docs: _external_docs} = operation_spec, _module_spec),
+    do: build_external_docs(operation_spec)
+
+  def build_external_docs(_operation_spec, module_spec), do: build_external_docs(module_spec)
+
+  def build_external_docs(%{external_docs: external_docs}),
+    do: struct(ExternalDocumentation, external_docs)
+
+  def build_external_docs(_spec), do: nil
 
   def build_operation_id(meta, mod, name) do
     Map.get(meta, :operation_id, "#{inspect(mod)}.#{name}")

--- a/lib/open_api_spex/operation_builder.ex
+++ b/lib/open_api_spex/operation_builder.ex
@@ -1,7 +1,7 @@
 defmodule OpenApiSpex.OperationBuilder do
   @moduledoc false
 
-  alias OpenApiSpex.{Operation, Parameter, Response, Reference}
+  alias OpenApiSpex.{ExternalDocumentation, Operation, Parameter, Response, Reference}
 
   def ensure_type_and_schema_exclusive!(name, type, schema) do
     if type != nil && schema != nil do
@@ -16,6 +16,10 @@ defmodule OpenApiSpex.OperationBuilder do
         """
     end
   end
+
+  def build_external_docs(%{external_docs: external_docs}, _module_spec), do: struct(ExternalDocumentation, external_docs)
+  def build_external_docs(_operation_spec, %{external_docs: external_docs}), do: struct(ExternalDocumentation, external_docs)
+  def build_external_docs(_operation_spec, _module_spec), do: nil
 
   def build_operation_id(meta, mod, name) do
     Map.get(meta, :operation_id, "#{inspect(mod)}.#{name}")

--- a/test/controller_specs_test.exs
+++ b/test/controller_specs_test.exs
@@ -64,6 +64,16 @@ defmodule OpenApiSpex.ControllerSpecsTest do
              } = DslController.open_api_operation(:destroy)
     end
 
+    test ":external_docs" do
+      assert %OpenApiSpex.Operation{
+               summary: "User destroy",
+               externalDocs: %OpenApiSpex.ExternalDocumentation{
+                 description: "User destroy docs",
+                 url: "https://example.com/"
+               }
+             } = DslController.open_api_operation(:destroy)
+    end
+
     test "outputs warning when action not defined for called open_api_operation" do
       output = capture_io(:stderr, fn -> DslController.open_api_operation(:undefined) end)
 

--- a/test/controller_test.exs
+++ b/test/controller_test.exs
@@ -67,7 +67,10 @@ defmodule OpenApiSpex.ControllerTest do
 
     test "has externalDocs" do
       %{externalDocs: external_docs} = @controller.open_api_operation(:update)
-      assert %OpenApiSpex.ExternalDocumentation{description: description, url: url} = external_docs
+
+      assert %OpenApiSpex.ExternalDocumentation{description: description, url: url} =
+               external_docs
+
       assert description == "Check out these docs"
       assert url == "https://example.com/"
     end

--- a/test/controller_test.exs
+++ b/test/controller_test.exs
@@ -65,6 +65,13 @@ defmodule OpenApiSpex.ControllerTest do
       assert schema == OpenApiSpexTest.Schemas.User
     end
 
+    test "has externalDocs" do
+      %{externalDocs: external_docs} = @controller.open_api_operation(:update)
+      assert %OpenApiSpex.ExternalDocumentation{description: description, url: url} = external_docs
+      assert description == "Check out these docs"
+      assert url == "https://example.com/"
+    end
+
     test "sets the operation_id" do
       op = @controller.open_api_operation(:show)
       assert op.operationId == "show_user"

--- a/test/support/dsl_controller.ex
+++ b/test/support/dsl_controller.ex
@@ -137,6 +137,10 @@ defmodule OpenApiSpexTest.DslController do
   end
 
   operation :destroy,
+    external_docs: %{
+      description: "User destroy docs",
+      url: "https://example.com/"
+    },
     deprecated: true,
     summary: "User destroy",
     parameters: [

--- a/test/support/user_controller_annotated.ex
+++ b/test/support/user_controller_annotated.ex
@@ -10,6 +10,10 @@ defmodule OpenApiSpexTest.UserControllerAnnotated do
 
   Full description for this endpoint...
   """
+  @doc external_docs: %{
+    description: "Check out these docs",
+    url: "https://example.com/"
+  }
   @doc parameters: [
          id: [in: :path, type: :string, required: true]
        ]

--- a/test/support/user_controller_annotated.ex
+++ b/test/support/user_controller_annotated.ex
@@ -11,9 +11,9 @@ defmodule OpenApiSpexTest.UserControllerAnnotated do
   Full description for this endpoint...
   """
   @doc external_docs: %{
-    description: "Check out these docs",
-    url: "https://example.com/"
-  }
+         description: "Check out these docs",
+         url: "https://example.com/"
+       }
   @doc parameters: [
          id: [in: :path, type: :string, required: true]
        ]


### PR DESCRIPTION
Fixes #328

This allows you to do either:

```elixir
defmodule MyApp.SomeController do
  @moduledoc external_docs %{
    description: "My description",
    url: "http://example.com/"
  }

  ...
end
```

or:

```elixir
defmodule MyApp.SomeController do
  @doc external_docs %{
    description: "My description",
    url: "http://example.com/"
  }
  def create, do: ...

  ...
end
```

or:

```elixir
defmodule MyApp.SomeController do
   use OpenApiSpex.ControllerSpecs

  operation :create,
    external_docs %{
      description: "My description",
      url: "http://example.com/"
    }
  def create, do: ...

  ...
end
```

... and the map referenced by `external_docs` will end up as the `externalDocs` property of the relevant operation(s) - if used from the `@moduledoc`, it will be added to all operations.

This is a draft PR to motivate the conversation in #328.
