### PR TITLE
Add optional header in `opts` to Operation.response

### DIFF
--- a/lib/open_api_spex/controller_specs.ex
+++ b/lib/open_api_spex/controller_specs.ex
@@ -181,6 +181,11 @@ defmodule OpenApiSpex.ControllerSpecs do
       3. An Open API schema. This can be a schema module that implements the
          `OpenApiSpex.Schema` [behaviour](https://hexdocs.pm/elixir/Module.html#module-behaviour),
          or an `OpenApiSpex.Schema` struct.
+      4. An optional `Keyword` list with the following optional key/values:
+        a. example: an example string
+        b. examples: a list of example strings
+        c. headers: a `Map` with string keys defining the header name and
+           an `OpenApiSpex.Header` struct as a value.
 
     - If the response represents an empty response, the definition value can
       be a single string representing the response description. For example:

--- a/lib/open_api_spex/operation.ex
+++ b/lib/open_api_spex/operation.ex
@@ -128,7 +128,7 @@ defmodule OpenApiSpex.Operation do
   end
 
   @doc """
-  Shorthand for constructing a Response with description, media_type, schema and optional examples
+  Shorthand for constructing a Response with description, media_type, schema and optional headers or examples
   """
   @spec response(
           description :: String.t(),
@@ -139,6 +139,7 @@ defmodule OpenApiSpex.Operation do
   def response(description, media_type, schema_ref, opts \\ []) do
     %Response{
       description: description,
+      headers: opts[:headers],
       content: %{
         media_type => %MediaType{
           schema: schema_ref,

--- a/test/controller_specs_test.exs
+++ b/test/controller_specs_test.exs
@@ -50,7 +50,8 @@ defmodule OpenApiSpex.ControllerSpecsTest do
 
       assert %Response{
                content: %{"application/json" => media_type},
-               description: "User response"
+               description: "User response",
+               headers: %{"content-type" => %OpenApiSpex.Header{}}
              } = response
 
       assert %MediaType{schema: OpenApiSpexTest.DslController.UserResponse} = media_type

--- a/test/operation_test.exs
+++ b/test/operation_test.exs
@@ -1,5 +1,6 @@
 defmodule OpenApiSpex.OperationTest do
   use ExUnit.Case
+  alias OpenApiSpexTest.Schemas
   alias OpenApiSpex.Operation
   alias OpenApiSpexTest.UserController
 
@@ -39,6 +40,28 @@ defmodule OpenApiSpex.OperationTest do
     test "from_plug" do
       assert Operation.from_plug(UserController, :show) ==
                UserController.open_api_operation(:show)
+    end
+
+    test "response" do
+      assert %OpenApiSpex.Response{} =
+        Operation.response(
+          "A description for the response",
+          "application/json",
+          Schemas.User.schema().example
+        )
+
+      assert %OpenApiSpex.Response{} =
+        Operation.response(
+          "A description for the response",
+          "application/json",
+          Schemas.User.schema().example,
+          headers: %{
+            "content-length" => %OpenApiSpex.Header{
+              description: "The length of response",
+              example: "content-length: 42"
+            }
+          }
+        )
     end
   end
 end

--- a/test/support/dsl_controller.ex
+++ b/test/support/dsl_controller.ex
@@ -70,13 +70,22 @@ defmodule OpenApiSpexTest.DslController do
     ],
     request_body: {"User params", "application/json", UserParams},
     responses: [
-      ok: {"User response", "application/json", UserResponse}
+      ok: { "User response", "application/json", UserResponse,
+        headers: %{
+          "content-type" => %OpenApiSpex.Header{
+            description: "Type of the content for the response",
+            example: "content-type: application/json; charset=utf-8"
+          }
+        }
+      }
     ],
     tags: ["custom"],
     security: [%{"two" => ["another"]}]
 
   def update(conn, %{"id" => id}) do
-    json(conn, %{
+    conn
+    |> put_resp_header("content-type", "application/json; charset=utf-8")
+    |> json(%{
       data: %{
         id: id,
         name: "joe user",


### PR DESCRIPTION
This commit adds the `:headers` to the list of opts that `Operation.response` can receive.
Additionally, it describes how for the `operation` macro these optional values can assigned to the inside the `responses:` key.
Fixes #331 