### PR TITLE
Adding helpers to OpenApiSpex.TestAssertions

### DIFF
--- a/lib/open_api_spex/cast.ex
+++ b/lib/open_api_spex/cast.ex
@@ -16,7 +16,7 @@ defmodule OpenApiSpex.Cast do
     String
   }
 
-  @type read_write_scope :: nil | :read_only | :write_only
+  @type read_write_scope :: nil | :read | :write
 
   @type schema_or_reference :: Schema.t() | Reference.t()
 

--- a/lib/open_api_spex/cast.ex
+++ b/lib/open_api_spex/cast.ex
@@ -16,6 +16,8 @@ defmodule OpenApiSpex.Cast do
     String
   }
 
+  @type read_write_scope :: nil | :read_only | :write_only
+
   @type schema_or_reference :: Schema.t() | Reference.t()
 
   @type t :: %__MODULE__{
@@ -25,7 +27,8 @@ defmodule OpenApiSpex.Cast do
           path: [atom | Elixir.String.t() | integer],
           key: atom() | nil,
           index: integer,
-          errors: [Error.t()]
+          errors: [Error.t()],
+          read_write_scope: read_write_scope
         }
 
   defstruct value: nil,
@@ -34,7 +37,8 @@ defmodule OpenApiSpex.Cast do
             path: [],
             key: nil,
             index: 0,
-            errors: []
+            errors: [],
+            read_write_scope: nil
 
   @doc ~S"""
   Cast and validate a value against the given schema.

--- a/lib/open_api_spex/cast/error.ex
+++ b/lib/open_api_spex/cast/error.ex
@@ -201,8 +201,8 @@ defmodule OpenApiSpex.Cast.Error do
     |> add_context_fields(ctx)
   end
 
-  def new(ctx, {:missing_field, name}) do
-    %__MODULE__{reason: :missing_field, name: name}
+  def new(ctx, {:missing_field, name, property}) do
+    %__MODULE__{reason: :missing_field, name: name, meta: %{property: property}}
     |> add_context_fields(ctx)
   end
 

--- a/lib/open_api_spex/cast/error.ex
+++ b/lib/open_api_spex/cast/error.ex
@@ -201,8 +201,8 @@ defmodule OpenApiSpex.Cast.Error do
     |> add_context_fields(ctx)
   end
 
-  def new(ctx, {:missing_field, name, property}) do
-    %__MODULE__{reason: :missing_field, name: name, meta: %{property: property}}
+  def new(ctx, {:missing_field, name}) do
+    %__MODULE__{reason: :missing_field, name: name}
     |> add_context_fields(ctx)
   end
 

--- a/lib/open_api_spex/cast/object.ex
+++ b/lib/open_api_spex/cast/object.ex
@@ -51,6 +51,17 @@ defmodule OpenApiSpex.Cast.Object do
 
   defp check_required_fields(%{value: input_map} = ctx, schema) do
     required = schema.required || []
+
+    # Adjust required fields list, based on read_write_scope
+    required =
+      Enum.filter(required, fn key ->
+        case {ctx.read_write_scope, schema.properties[key]} do
+          {:read_only, %{readOnly: true}} -> false
+          {:write_only, %{writeOnly: true}} -> false
+          _ -> true
+        end
+      end)
+
     input_keys = Map.keys(input_map)
     missing_keys = required -- input_keys
 

--- a/lib/open_api_spex/cast/object.ex
+++ b/lib/open_api_spex/cast/object.ex
@@ -60,7 +60,7 @@ defmodule OpenApiSpex.Cast.Object do
       errors =
         Enum.map(missing_keys, fn key ->
           ctx = %{ctx | path: [key | ctx.path]}
-          Error.new(ctx, {:missing_field, key, schema.properties[key]})
+          Error.new(ctx, {:missing_field, key})
         end)
 
       {:error, ctx.errors ++ errors}

--- a/lib/open_api_spex/cast/object.ex
+++ b/lib/open_api_spex/cast/object.ex
@@ -56,8 +56,8 @@ defmodule OpenApiSpex.Cast.Object do
     required =
       Enum.filter(required, fn key ->
         case {ctx.read_write_scope, schema.properties[key]} do
-          {:read_only, %{readOnly: true}} -> false
-          {:write_only, %{writeOnly: true}} -> false
+          {:read, %{writeOnly: true}} -> false
+          {:write, %{readOnly: true}} -> false
           _ -> true
         end
       end)

--- a/lib/open_api_spex/cast/object.ex
+++ b/lib/open_api_spex/cast/object.ex
@@ -60,7 +60,7 @@ defmodule OpenApiSpex.Cast.Object do
       errors =
         Enum.map(missing_keys, fn key ->
           ctx = %{ctx | path: [key | ctx.path]}
-          Error.new(ctx, {:missing_field, key})
+          Error.new(ctx, {:missing_field, key, schema.properties[key]})
         end)
 
       {:error, ctx.errors ++ errors}

--- a/lib/open_api_spex/test/test_assertions.ex
+++ b/lib/open_api_spex/test/test_assertions.ex
@@ -5,14 +5,17 @@ defmodule OpenApiSpex.TestAssertions do
   import ExUnit.Assertions
   alias OpenApiSpex.OpenApi
   alias OpenApiSpex.Cast.Error
+  alias OpenApiSpex.Schema
 
   @dialyzer {:no_match, assert_schema: 3}
+
+  @type assert_operation :: :request | :response | nil
 
   @doc """
   Asserts that `value` conforms to the schema with title `schema_title` in `api_spec`.
   """
-  @spec assert_schema(term, String.t(), OpenApi.t()) :: term | no_return
-  def assert_schema(value, schema_title, api_spec = %OpenApi{}) do
+  @spec assert_schema(term, String.t(), OpenApi.t(), assert_operation) :: term | no_return
+  def assert_schema(value, schema_title, api_spec = %OpenApi{}, assert_operation \\ nil) do
     schemas = api_spec.components.schemas
     schema = schemas[schema_title]
 
@@ -26,17 +29,43 @@ defmodule OpenApiSpex.TestAssertions do
 
       {:error, errors} ->
         errors =
-          Enum.map(errors, fn error ->
+          errors
+          |> Enum.reject(&ignore_error?(&1, assert_operation))
+          |> Enum.map(fn error ->
             message = Error.message(error)
             path = Error.path_to_string(error)
             "#{message} at #{path}"
           end)
 
-        flunk(
-          "Value does not conform to schema #{schema_title}: #{Enum.join(errors, "\n")}\n#{
-            inspect(value)
-          }"
-        )
+        if length(errors) > 0 do
+          flunk(
+            "Value does not conform to schema #{schema_title}: #{Enum.join(errors, "\n")}\n#{
+              inspect(value)
+            }"
+          )
+        end
     end
   end
+
+  @doc """
+  Asserts that `value` is a valid **response** schema with title `schema_title` in `api_spec`. In this case,
+  the presence of required `writeOnly` fields is not validated.
+  """
+  @spec assert_response_schema(term, String.t(), OpenApi.t()) :: term | no_return
+  def assert_response_schema(value, schema_title, api_spec = %OpenApi{}) do
+    assert_schema(value, schema_title, api_spec, :response)
+  end
+
+  @doc """
+  Asserts that `value` is a valid **request** schema with title `schema_title` in `api_spec`. In this case,
+  the presence of required `readOnly` fields is not validated.
+  """
+  @spec assert_request_schema(term, String.t(), OpenApi.t()) :: term | no_return
+  def assert_request_schema(value, schema_title, api_spec = %OpenApi{}) do
+    assert_schema(value, schema_title, api_spec, :request)
+  end
+
+  defp ignore_error?(%Error{reason: :missing_field, meta: %{property: %Schema{readOnly: true}}}, :request), do: true
+  defp ignore_error?(%Error{reason: :missing_field, meta: %{property: %Schema{writeOnly: true}}}, :response), do: true
+  defp ignore_error?(_error, _assert_operation), do: false
 end

--- a/test/cast/object_test.exs
+++ b/test/cast/object_test.exs
@@ -93,8 +93,8 @@ defmodule OpenApiSpex.ObjectTest do
     end
 
     @test_cases [
-      %{schema: [readOnly: true], read_write_scope: :read_only, result: :ok},
-      %{schema: [writeOnly: true], read_write_scope: :write_only, result: :ok},
+      %{schema: [readOnly: true], read_write_scope: :write, result: :ok},
+      %{schema: [writeOnly: true], read_write_scope: :read, result: :ok},
       %{schema: [readOnly: true], read_write_scope: nil, result: :error},
       %{schema: [writeOnly: true], read_write_scope: nil, result: :error}
     ]

--- a/test/cast/object_test.exs
+++ b/test/cast/object_test.exs
@@ -3,6 +3,7 @@ defmodule OpenApiSpex.ObjectTest do
   alias OpenApiSpex.{Cast, Schema}
   alias OpenApiSpex.Cast.{Object, Error}
 
+  defp cast(%Cast{} = ctx), do: Object.cast(ctx)
   defp cast(ctx), do: Object.cast(struct(Cast, ctx))
 
   describe "cast/3" do
@@ -76,7 +77,7 @@ defmodule OpenApiSpex.ObjectTest do
     test "required fields" do
       schema = %Schema{
         type: :object,
-        properties: %{age: nil, name: nil},
+        properties: %{age: %Schema{type: :integer}, name: %Schema{type: :string}},
         required: [:age, :name]
       }
 
@@ -89,6 +90,39 @@ defmodule OpenApiSpex.ObjectTest do
       assert error2.reason == :missing_field
       assert error2.name == :name
       assert error2.path == [:name]
+    end
+
+    @test_cases [
+      %{schema: [readOnly: true], read_write_scope: :read_only, result: :ok},
+      %{schema: [writeOnly: true], read_write_scope: :write_only, result: :ok},
+      %{schema: [readOnly: true], read_write_scope: nil, result: :error},
+      %{schema: [writeOnly: true], read_write_scope: nil, result: :error}
+    ]
+
+    for test_case <- @test_cases do
+      @schema_attrs test_case.schema
+      @read_write_scope test_case.read_write_scope
+      @expected_result test_case.result
+
+      test "required, schema:#{inspect(@schema_attrs)}, read_write_scope:#{
+             inspect(@read_write_scope)
+           }" do
+        object_schema = %Schema{
+          type: :object,
+          properties: %{name: struct!(Schema, @schema_attrs)},
+          required: [:name]
+        }
+
+        cast_ctx = %Cast{
+          value: %{},
+          schema: object_schema,
+          read_write_scope: @read_write_scope
+        }
+
+        assert {result, _} = cast(cast_ctx)
+
+        assert result == @expected_result
+      end
     end
 
     test "fields with default values" do

--- a/test/plug/cast_test.exs
+++ b/test/plug/cast_test.exs
@@ -105,6 +105,7 @@ defmodule OpenApiSpex.Plug.CastTest do
           "id" => 123,
           "name" => "asdf",
           "email" => "foo@bar.com",
+          "password" => "0123456789",
           "updated_at" => "2017-09-12T14:44:55Z"
         }
       }
@@ -120,6 +121,7 @@ defmodule OpenApiSpex.Plug.CastTest do
                  id: 123,
                  name: "asdf",
                  email: "foo@bar.com",
+                 password: "0123456789",
                  updated_at: ~N[2017-09-12T14:44:55Z] |> DateTime.from_naive!("Etc/UTC")
                }
              }
@@ -142,6 +144,7 @@ defmodule OpenApiSpex.Plug.CastTest do
           "id" => 123,
           "name" => "*1234",
           "email" => "foo@bar.com",
+          "password" => "0123456789",
           "updated_at" => "2017-09-12T14:44:55Z"
         }
       }

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -16,9 +16,9 @@ defmodule OpenApiSpex.SchemaTest do
       spec = ApiSpec.spec()
 
       assert_schema(Schemas.User.schema().example, "User", spec)
-      assert_schema(Schemas.UserRequest.schema().example, "UserRequest", spec, :request)
-      assert_schema(Schemas.UserResponse.schema().example, "UserResponse", spec, :response)
-      assert_schema(Schemas.UsersResponse.schema().example, "UsersResponse", spec, :response)
+      assert_schema(Schemas.UserRequest.schema().example, "UserRequest", spec, :write)
+      assert_schema(Schemas.UserResponse.schema().example, "UserResponse", spec, :read)
+      assert_schema(Schemas.UsersResponse.schema().example, "UsersResponse", spec, :read)
     end
 
     test "Array Schema example matches schema" do

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -16,9 +16,9 @@ defmodule OpenApiSpex.SchemaTest do
       spec = ApiSpec.spec()
 
       assert_schema(Schemas.User.schema().example, "User", spec)
-      assert_schema(Schemas.UserRequest.schema().example, "UserRequest", spec)
-      assert_schema(Schemas.UserResponse.schema().example, "UserResponse", spec)
-      assert_schema(Schemas.UsersResponse.schema().example, "UsersResponse", spec)
+      assert_schema(Schemas.UserRequest.schema().example, "UserRequest", spec, :request)
+      assert_schema(Schemas.UserResponse.schema().example, "UserResponse", spec, :response)
+      assert_schema(Schemas.UsersResponse.schema().example, "UsersResponse", spec, :response)
     end
 
     test "Array Schema example matches schema" do

--- a/test/support/api_spec.ex
+++ b/test/support/api_spec.ex
@@ -1,18 +1,45 @@
 defmodule OpenApiSpexTest.ApiSpec do
   alias OpenApiSpex.{
-    OpenApi,
-    Contact,
-    License,
-    Paths,
-    Server,
-    Info,
     Components,
+    Components,
+    Contact,
+    Info,
+    License,
+    OpenApi,
     Parameter,
-    Schema
+    Paths,
+    Schema,
+    Server
   }
 
   alias OpenApiSpexTest.{Router, Schemas}
   @behaviour OpenApi
+
+  @info %Info{
+    title: "A",
+    version: "3.0",
+    contact: %Contact{
+      name: "joe",
+      email: "Joe@gmail.com",
+      url: "https://help.joe.com"
+    },
+    license: %License{
+      name: "MIT",
+      url: "http://mit.edu/license"
+    }
+  }
+
+  def info, do: @info
+
+  def empty_spec do
+    %OpenApi{
+      paths: %{},
+      info: @info,
+      components: %Components{
+        schemas: %{}
+      }
+    }
+  end
 
   @impl OpenApi
   def spec() do
@@ -20,19 +47,7 @@ defmodule OpenApiSpexTest.ApiSpec do
       servers: [
         %Server{url: "http://example.com"}
       ],
-      info: %Info{
-        title: "A",
-        version: "3.0",
-        contact: %Contact{
-          name: "joe",
-          email: "Joe@gmail.com",
-          url: "https://help.joe.com"
-        },
-        license: %License{
-          name: "MIT",
-          url: "http://mit.edu/license"
-        }
-      },
+      info: @info,
       components: %Components{
         schemas:
           for schemaMod <- [

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -179,6 +179,7 @@ defmodule OpenApiSpexTest.Schemas do
         id: %Schema{type: :integer, description: "User ID"},
         name: %Schema{type: :string, description: "User name", pattern: ~r/[a-zA-Z][a-zA-Z0-9_]+/},
         email: %Schema{type: :string, description: "Email address", format: :email},
+        password: %Schema{type: :string, description: "Login password", writeOnly: true},
         inserted_at: %Schema{
           type: :string,
           description: "Creation timestamp",
@@ -186,12 +187,13 @@ defmodule OpenApiSpexTest.Schemas do
         },
         updated_at: %Schema{type: :string, description: "Update timestamp", format: :"date-time"}
       },
-      required: [:name, :email],
+      required: [:name, :email, :password],
       additionalProperties: false,
       example: %{
         "id" => 123,
         "name" => "Joe User",
         "email" => "joe@gmail.com",
+        "password" => "12345678",
         "inserted_at" => "2017-09-12T12:34:55Z",
         "updated_at" => "2017-09-13T10:11:12Z"
       }
@@ -277,7 +279,8 @@ defmodule OpenApiSpexTest.Schemas do
       example: %{
         "user" => %{
           "name" => "Joe User",
-          "email" => "joe@gmail.com"
+          "email" => "joe@gmail.com",
+          "password" => "0123456789"
         }
       }
     })

--- a/test/support/user_controller.ex
+++ b/test/support/user_controller.ex
@@ -68,8 +68,14 @@ defmodule OpenApiSpexTest.UserController do
          created: {"User", "application/json", Schemas.UserResponse}
        ]
   def create(conn = %{body_params: %Schemas.UserRequest{user: user = %Schemas.User{}}}, _) do
+    user =
+      user
+      |> Map.from_struct()
+      |> Map.put(:id, 1234)
+      |> Map.delete(:password)
+
     json(conn, %Schemas.UserResponse{
-      data: %{user | id: 1234}
+      data: user
     })
   end
 

--- a/test/test_assertions_test.exs
+++ b/test/test_assertions_test.exs
@@ -1,0 +1,67 @@
+defmodule OpenApiSpex.TestAssertionsTest do
+  use ExUnit.Case, async: true
+
+  alias OpenApiSpex.{Cast, Schema, TestAssertions}
+  alias OpenApiSpexTest.ApiSpec
+
+  describe "assert_schema/1" do
+    test "success" do
+      schema = %Schema{type: :string}
+      cast_context = %Cast{value: "hello", schema: schema}
+      TestAssertions.assert_schema(cast_context)
+    end
+
+    test "failure" do
+      schema = %Schema{type: :string}
+      cast_context = %Cast{value: :nope, schema: schema}
+
+      try do
+        TestAssertions.assert_schema(cast_context)
+        raise RuntimeError, "Should flunk"
+      rescue
+        e in ExUnit.AssertionError ->
+          assert e.message =~ "Value does not conform to schema"
+      end
+    end
+
+    test "required object property, but different read_write_scope" do
+      schema = %Schema{
+        type: :object,
+        properties: %{publish: %Schema{type: :boolean, writeOnly: true}},
+        required: [:publish]
+      }
+
+      value = %{}
+      cast_context = %Cast{value: value, schema: schema, read_write_scope: :read}
+
+      TestAssertions.assert_schema(cast_context)
+    end
+  end
+
+  describe "assert_response_schema/3" do
+    test "ignore required field when read_write_scope is different" do
+      schema = %Schema{
+        type: :object,
+        title: "MySchema",
+        properties: %{publish: %Schema{type: :boolean, writeOnly: true}},
+        required: [:publish]
+      }
+
+      value = %{}
+      api_spec = ApiSpec.empty_spec()
+      api_spec = put_in(api_spec.components.schemas, %{schema.title => schema})
+
+      TestAssertions.assert_response_schema(value, schema.title, api_spec)
+    end
+  end
+
+  describe "assert_request_schema/3" do
+    test "success" do
+      schema = %Schema{type: :string}
+      value = "hello"
+      api_spec = ApiSpec.empty_spec()
+      api_spec = put_in(api_spec.components.schemas, %{schema.title => schema})
+      TestAssertions.assert_request_schema(value, schema.title, api_spec)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the helpers `assert_request_schema` and `assert_response_schema` to OpenApiSpex.TestAssertions. They can be useful to validate request and response schemas, respectively, when there are required `writeOnly` or `readOnly` properties being used. Fixes #335 

Relevant changes
- Creates new helpers `assert_request_schema` and `assert_response_schema`
- The original `assert_schema` helper has a new optional argument `assert_operation`, to indicate the operation being validated. If it's not provided (or is `nil`), it fallbacks to the current behavior.
- Adds a property `password` to the example `User` schema, to serve as an example (and test case) for a `writeOnly` required field