### PR TITLE
Fix Application.spec/2 example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ defmodule MyAppWeb.ApiSpec do
 end
 ```
 
-Or you can use application's spec value in `info:` key.
+Or you can use your application's spec values in the `info:` key.
 
 ```elixir
 info: %Info{
-  description: Application.spec(:my_app, :description)
-  version: Application.spec(:my_app, :vsn)
+  title: to_string(Application.spec(:my_app, :description)),
+  version: to_string(Application.spec(:my_app, :vsn))
 }
 ```
 


### PR DESCRIPTION
- `title` is required, fails to generate spec without it
- Missing comma after first value
- Need to call `to_string` on the values from Application.spec or they won't be generated as you expect