### PR TITLE
Stop circular dependency by injecting the schema into list of already…

### DIFF
--- a/lib/open_api_spex/schema_resolver.ex
+++ b/lib/open_api_spex/schema_resolver.ex
@@ -210,7 +210,8 @@ defmodule OpenApiSpex.SchemaResolver do
   end
 
   defp resolve_schema_modules_from_schema(schema = %Schema{title: title}, schemas) do
-    schemas = if is_nil(title) do
+    schemas =
+      if is_nil(title) do
         schemas
       else
         Map.put(schemas, title, schema)

--- a/lib/open_api_spex/schema_resolver.ex
+++ b/lib/open_api_spex/schema_resolver.ex
@@ -209,7 +209,13 @@ defmodule OpenApiSpex.SchemaResolver do
     {%Reference{"$ref": "#/components/schemas/#{title}"}, new_schemas}
   end
 
-  defp resolve_schema_modules_from_schema(schema = %Schema{}, schemas) do
+  defp resolve_schema_modules_from_schema(schema = %Schema{title: title}, schemas) do
+    schemas = if is_nil(title) do
+        schemas
+      else
+        Map.put(schemas, title, schema)
+      end
+
     {all_of, schemas} = resolve_schema_modules_from_schema(schema.allOf, schemas)
     {one_of, schemas} = resolve_schema_modules_from_schema(schema.oneOf, schemas)
     {any_of, schemas} = resolve_schema_modules_from_schema(schema.anyOf, schemas)


### PR DESCRIPTION
Not sure where this would be best to fix.
But this stops the cases where you have properties that have schemas linking back to the same Schema.

```
defmodule Test.Test1 do
  require OpenApiSpex
   alias  OpenApiSpex.Schema

  OpenApiSpex.schema(%{ 
    title: "Test 1",   
    description: "Config Device",   
    type: :object,   
    properties: %{     
      test2:  Test.Test2
    }
  })

defmodule Test.Test2 do
  require OpenApiSpex
   alias OpenApiSpex.Schema

  OpenApiSpex.schema(%{ 
    title: "Test 2",   
    type: :object,   
    properties: %{     
      test1: Test.Test1
    }
  })

```