### PR TITLE
fix: Schema.example/1 for schema module

### DIFF
--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -397,6 +397,7 @@ defmodule OpenApiSpex.Schema do
   def example(%Schema{type: :integer} = s), do: example_for(s, :integer)
   def example(%Schema{type: :number} = s), do: example_for(s, :number)
   def example(%Schema{type: :boolean}), do: false
+  def example(schema_module) when is_atom(schema_module), do: example(schema_module.schema())
   def example(_schema), do: nil
 
   defp default(schema_module) when is_atom(schema_module), do: schema_module.schema().default

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -180,6 +180,36 @@ defmodule OpenApiSpex.SchemaTest do
       schema = %Schema{type: :string, format: :"date-time"}
       assert Schema.example(schema) == "2020-04-20T16:20:00Z"
     end
+
+    test "example for schema module" do
+      defmodule Bar do
+        require OpenApiSpex
+        OpenApiSpex.schema(%{
+          type: :object,
+          properties: %{
+            baz: %Schema{
+              type: :int,
+              example: 2
+            }
+          }
+        })
+      end
+      defmodule Foo do
+        require OpenApiSpex
+        OpenApiSpex.schema(%{
+          type: :object,
+          properties: %{
+            bar: Bar,
+            foo: %Schema{
+              type: :string,
+              example: "1"
+            }
+          }
+        })
+      end
+
+      assert Schema.example(Foo) == %{bar: %{baz: 2}, foo: "1"}
+    end
   end
 
   describe "properties/1" do

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -184,6 +184,7 @@ defmodule OpenApiSpex.SchemaTest do
     test "example for schema module" do
       defmodule Bar do
         require OpenApiSpex
+
         OpenApiSpex.schema(%{
           type: :object,
           properties: %{
@@ -194,8 +195,10 @@ defmodule OpenApiSpex.SchemaTest do
           }
         })
       end
+
       defmodule Foo do
         require OpenApiSpex
+
         OpenApiSpex.schema(%{
           type: :object,
           properties: %{


### PR DESCRIPTION
Hi there,

I think that I found a bug. When we are working with schema modules and try to generate an example with `Schema.example` it returns `nil`. As an example, given the schema module below:

```elixir
  defmodule Bar do
    require OpenApiSpex
    OpenApiSpex.schema(%{
      type: :object,
      properties: %{
        baz: %Schema{
          type: :int,
          example: 2
        }
      }
    })
  end
  defmodule Foo do
    require OpenApiSpex
    OpenApiSpex.schema(%{
      type: :object,
      properties: %{
        bar: Bar,
        foo: %Schema{
          type: :string,
          example: "1"
        }
      }
    })
  end
```

When we try to generate the example we get:

```elixir
> Schema.example(Foo)
> nil
```

but we should expect to get `%{bar: %{baz: 2}, foo: "1"}`.

So, I made a quick fix and put one test :)

Thanks!