### PR TITLE
Encode obj properties and query param keys as strings instead of atoms

### DIFF
--- a/lib/open_api_spex/cast/object.ex
+++ b/lib/open_api_spex/cast/object.ex
@@ -122,10 +122,15 @@ defmodule OpenApiSpex.Cast.Object do
   defp cast_atom_keys(input_map, properties) do
     Enum.reduce(properties, %{}, fn {key, _}, output ->
       string_key = to_string(key)
+      keyout = case Application.get_env(:open_api_spex, :keys, :atoms) do
+        :strings -> string_key
+        _ -> key
+      end
+
 
       case input_map do
-        %{^key => value} -> Map.put(output, string_key, value)
-        %{^string_key => value} -> Map.put(output, string_key, value)
+        %{^key => value} -> Map.put(output, keyout, value)
+        %{^string_key => value} -> Map.put(output, keyout, value)
         _ -> output
       end
     end)

--- a/lib/open_api_spex/cast/object.ex
+++ b/lib/open_api_spex/cast/object.ex
@@ -124,8 +124,8 @@ defmodule OpenApiSpex.Cast.Object do
       string_key = to_string(key)
 
       case input_map do
-        %{^key => value} -> Map.put(output, key, value)
-        %{^string_key => value} -> Map.put(output, key, value)
+        %{^key => value} -> Map.put(output, string_key, value)
+        %{^string_key => value} -> Map.put(output, string_key, value)
         _ -> output
       end
     end)

--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -78,12 +78,20 @@ defmodule OpenApiSpex.CastParameters do
   end
 
   defp cast_location(location, schema, components, conn) do
-    params =
-      get_params_by_location(
-        conn,
-        location,
-        schema.properties |> Map.keys() |> Enum.map(&Atom.to_string/1)
-      )
+    params = case Application.get_env(:open_api_spex, :keys, :atoms) do
+      :strings ->
+        get_params_by_location(
+          conn,
+          location,
+          schema.properties |> Map.keys()
+        )
+      _ ->
+        get_params_by_location(
+          conn,
+          location,
+          schema.properties |> Map.keys() |> Enum.map(&Atom.to_string/1)
+        )
+      end
 
     Cast.cast(schema, params, components.schemas)
   end

--- a/lib/open_api_spex/open_api/decode.ex
+++ b/lib/open_api_spex/open_api/decode.ex
@@ -291,8 +291,12 @@ defmodule OpenApiSpex.OpenApi.Decode do
   defp to_struct(map, RequestBodies), do: embedded_ref_or_struct(map, RequestBody)
 
   defp to_struct(map, Parameter) do
+    map = case Application.get_env(:open_api_spex, :keys, :atoms) do
+      :strings -> map
+      _ -> map
+        |> convert_value_to_atom_if_present("name")
+    end
     map
-    |> convert_value_to_atom_if_present("name")
     |> convert_value_to_atom_if_present("in")
     |> convert_value_to_atom_if_present("style")
     |> (&struct_from_map(Parameter, &1)).()

--- a/lib/open_api_spex/open_api/decode.ex
+++ b/lib/open_api_spex/open_api/decode.ex
@@ -122,7 +122,6 @@ defmodule OpenApiSpex.OpenApi.Decode do
     |> convert_value_to_atom_if_present("type")
     |> convert_value_to_atom_if_present("format")
     |> convert_value_to_atom_if_present("x-struct")
-    |> convert_value_to_list_of_atoms_if_present("required")
   end
 
   defp to_struct(nil, _mod), do: nil
@@ -208,7 +207,7 @@ defmodule OpenApiSpex.OpenApi.Decode do
     |> Map.update("properties", %{}, fn v ->
       v
       |> Map.new(fn {k, v} ->
-        {String.to_atom(k), v}
+        {k, v}
       end)
     end)
     |> prepare_schema()


### PR DESCRIPTION
According to [here](https://hexdocs.pm/plug/Plug.Conn.html#t:params/0)
`body_params` are `params()` which should be `%{optional(binary()) => term()}`

I guess it's probably wise to opt the choice (as Jason `keys: :strings` allows), but as a total newbie I don't even know how.