### PR TITLE
fix: any_of cast for multiple schemas

### DIFF
--- a/lib/open_api_spex/cast/any_of.ex
+++ b/lib/open_api_spex/cast/any_of.ex
@@ -10,10 +10,10 @@ defmodule OpenApiSpex.Cast.AnyOf do
   end
 
   defp cast_any_of(
-        %{schema: %{anyOf: [%Schema{} = schema | remaining]}} = ctx,
-        failed_schemas,
-        acc
-      ) do
+         %{schema: %{anyOf: [%Schema{} = schema | remaining]}} = ctx,
+         failed_schemas,
+         acc
+       ) do
     relaxed_schema = %{schema | additionalProperties: true, "x-struct": nil}
     new_ctx = put_in(ctx.schema.anyOf, remaining)
 
@@ -40,7 +40,9 @@ defmodule OpenApiSpex.Cast.AnyOf do
     cast_any_of(%{ctx | schema: %{anyOf: [schema | remaining]}}, failed_schemas, acc)
   end
 
-  defp cast_any_of(%_{schema: %{anyOf: [], "x-struct": module}}, _failed_schemas, acc) when not is_nil(module), do: {:ok, struct(module, acc)}
+  defp cast_any_of(%_{schema: %{anyOf: [], "x-struct": module}}, _failed_schemas, acc)
+       when not is_nil(module),
+       do: {:ok, struct(module, acc)}
 
   defp cast_any_of(%_{schema: %{anyOf: []}}, _failed_schemas, acc), do: {:ok, acc}
 

--- a/lib/open_api_spex/cast/any_of.ex
+++ b/lib/open_api_spex/cast/any_of.ex
@@ -2,24 +2,39 @@ defmodule OpenApiSpex.Cast.AnyOf do
   @moduledoc false
   alias OpenApiSpex.Cast
 
-  def cast(ctx, failed_schemas \\ [])
+  def cast(ctx, failed_schemas \\ [], acc \\ nil)
 
-  def cast(%_{schema: %{type: _, anyOf: []}} = ctx, failed_schemas) do
+  def cast(%_{schema: %{type: _, anyOf: []}} = ctx, failed_schemas, nil) do
     Cast.error(ctx, {:any_of, error_message(failed_schemas, ctx.schemas)})
   end
 
   def cast(
-        %{schema: %{type: _, anyOf: [schema | schemas]}} = ctx,
-        failed_schemas
+        %{schema: %{type: _, anyOf: [schema | remaining]}} = ctx,
+        failed_schemas,
+        acc
       ) do
-    with {:ok, value} <- Cast.cast(%{ctx | schema: schema}) do
-      {:ok, value}
-    else
-      _ ->
-        new_schema = %{ctx.schema | anyOf: schemas}
-        cast(%{ctx | schema: new_schema}, [schema | failed_schemas])
+    relaxed_schema = %{schema | additionalProperties: true, "x-struct": nil}
+    new_ctx = put_in(ctx.schema.anyOf, remaining)
+
+    case Cast.cast(%{ctx | schema: relaxed_schema}) do
+      {:ok, value} when is_map(value) ->
+        acc =
+          value
+          |> Enum.reject(fn {k, _} -> is_binary(k) end)
+          |> Enum.concat(acc || %{})
+          |> Map.new()
+
+        cast(new_ctx, failed_schemas, acc)
+
+      {:ok, value} ->
+        cast(new_ctx, failed_schemas, acc || value)
+
+      {:error, _} ->
+        cast(new_ctx, [schema | failed_schemas], acc)
     end
   end
+
+  def cast(%_{schema: %{type: _, anyOf: []}}, _failed_schemas, acc), do: {:ok, acc}
 
   ## Private functions
 

--- a/test/cast/any_of_test.exs
+++ b/test/cast/any_of_test.exs
@@ -35,6 +35,55 @@ defmodule OpenApiSpex.CastAnyOfTest do
       assert {:ok, %{breed: "Corgi", age: 3}} = cast(value: value, schema: schema)
     end
 
+    test "should cast multiple schemas" do
+      dog_schema = %Schema{
+        title: "Dog",
+        type: :object,
+        properties: %{
+          breed: %Schema{type: :string},
+          age: %Schema{type: :integer}
+        }
+      }
+
+      food_schema = %Schema{
+        title: "Food",
+        type: :object,
+        properties: %{
+          food: %Schema{type: :string},
+          amount: %Schema{type: :integer}
+        }
+      }
+
+      schema = %Schema{anyOf: [dog_schema, food_schema], title: "MyCoolSchema"}
+      value = %{"breed" => "Corgi", "age" => 3, "food" => "meat"}
+      assert {:ok, %{breed: "Corgi", age: 3, food: "meat"}} = cast(value: value, schema: schema)
+    end
+
+    test "should cast multiple schemas with conflicting properties" do
+      dog_schema = %Schema{
+        title: "Dog",
+        type: :object,
+        properties: %{
+          breed: %Schema{type: :string},
+          age: %Schema{type: :integer}
+        }
+      }
+
+      food_schema = %Schema{
+        title: "Food",
+        type: :object,
+        properties: %{
+          food: %Schema{type: :string},
+          amount: %Schema{type: :integer},
+          age: %Schema{type: :integer}
+        }
+      }
+
+      schema = %Schema{anyOf: [dog_schema, food_schema], title: "MyCoolSchema"}
+      value = %{"breed" => "Corgi", "age" => 3, "food" => "meat"}
+      assert {:ok, %{breed: "Corgi", age: 3, food: "meat"}} = cast(value: value, schema: schema)
+    end
+
     test "no castable schema" do
       schema = %Schema{anyOf: [%Schema{type: :integer}, %Schema{type: :string}]}
       assert {:error, [error]} = cast(value: [:whoops], schema: schema)


### PR DESCRIPTION
`anyOf` casting is validating just against the first schema.

Accordingly the json schema definition: 

> To validate against anyOf, the given data must be valid against any (one or more) of the given subschemas.

The following code returns an error:

```elixir
test "should cast multiple schemas" do
      dog_schema = %Schema{
        title: "Dog",
        type: :object,
        properties: %{
          breed: %Schema{type: :string},
          age: %Schema{type: :integer}
        }
      }

      food_schema = %Schema{
        title: "Food",
        type: :object,
        properties: %{
          food: %Schema{type: :string},
          amount: %Schema{type: :integer}
        }
      }

      schema = %Schema{anyOf: [dog_schema, food_schema], title: "MyCoolSchema"}
      value = %{"breed" => "Corgi", "age" => 3, "food" => "meat"}
      assert {:ok, %{breed: "Corgi", age: 3, food: "meat"}} = cast(value: value, schema: schema)
    end
```

This PR adds this test case and fix this problem.