### PR TITLE
Add support for multiple specs for the same Phoenix router

### DIFF
--- a/lib/open_api_spex/paths.ex
+++ b/lib/open_api_spex/paths.ex
@@ -26,7 +26,7 @@ defmodule OpenApiSpex.Paths do
   @doc """
   Create a Paths map from a list of routes.
   """
-  @spec from_routes([Phoenix.Route.t]) :: t
+  @spec from_routes([Phoenix.Route.t()]) :: t
   def from_routes(routes) do
     paths =
       routes

--- a/lib/open_api_spex/paths.ex
+++ b/lib/open_api_spex/paths.ex
@@ -26,7 +26,7 @@ defmodule OpenApiSpex.Paths do
   @doc """
   Create a Paths map from a list of routes.
   """
-  @spec from_routes(Phoenix.Route.t) :: t
+  @spec from_routes([Phoenix.Route.t]) :: t
   def from_routes(routes) do
     paths =
       routes

--- a/lib/open_api_spex/paths.ex
+++ b/lib/open_api_spex/paths.ex
@@ -21,9 +21,15 @@ defmodule OpenApiSpex.Paths do
   Create a Paths map from the routes in the given router module.
   """
   @spec from_router(module) :: t
-  def from_router(router) do
+  def from_router(router), do: from_routes(router.__routes__())
+
+  @doc """
+  Create a Paths map from a list of routes.
+  """
+  @spec from_routes(Phoenix.Route.t) :: t
+  def from_routes(routes) do
     paths =
-      router.__routes__()
+      routes
       |> Enum.group_by(fn route -> route.path end)
       |> Enum.map(fn {k, v} -> {open_api_path(k), PathItem.from_routes(v)} end)
       |> Enum.filter(fn {_k, v} -> !is_nil(v) end)


### PR DESCRIPTION
In phoenix you can define the endpoint `host` as nil and then use host prefixes to define host specific routes in the router. 

```
  scope "/", TestappWeb, host: "api." do
    pipe_through :browser

    get "/", PageController, :index
  end
```

This is helpful if you want for instance serve different sets of apis and describe them with separate specs from the same phoenix instance:

```
     paths: Paths.from_router(router, host: "api.")
```

This simply adds the ability to filter phoenix routes when calling `Paths.from_router`, so that one can easily generate a spec only for routes having a specific attribute value. This covers not only the `host` use case, but filtering on any phoenix route attribute.

