### PR TITLE
Stop replacing Plug Conn params and body_params

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -12,9 +12,10 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        elixir: [1.9, 1.11]
-        otp: [23.0]
-
+        elixir: ['1.9', '1.11']
+        otp: ['23']
+        exclude:
+          - {otp: '23', elixir: '1.9'}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Elixir

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -12,8 +12,10 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        elixir: [1.9, 1.12]
-        otp: [23.0]
+        elixir: ['1.9', '1.11']
+        otp: ['23']
+        exclude:
+          - {otp: '23', elixir: '1.9'}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Elixir

--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -4,9 +4,9 @@ defmodule OpenApiSpex.CastParameters do
   alias OpenApiSpex.Cast.Error
   alias Plug.Conn
 
-  unless Application.compile_env(:open_api_spex, :do_not_cast_conn_params) do
-    require Logger
+  require Logger
 
+  unless Application.compile_env(:open_api_spex, :do_not_cast_conn_params) do
     Logger.warn("
     Casting of Plug.Conn params by open_api_spex is deprected and will be
     removed in the next major release:

--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -5,7 +5,7 @@ defmodule OpenApiSpex.CastParameters do
   alias Plug.Conn
 
   unless Application.compile_env(:open_api_spex, :do_not_cast_conn_body_params) do
-    import Logger
+    require Logger
 
     Logger.warn("
     Casting of Plug.Conn params by open_api_spex is deprected and will be

--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -17,10 +17,10 @@ defmodule OpenApiSpex.CastParameters do
 
     def function(_conn, params)
 
-    Consider migrating from using the Plug.Conn body_params argument to reading
+    Consider migrating from using the Plug.Conn params argument to reading
     casted parameters from the connection assigns:
 
-    def function(%Conn{assigns: %{casted_params: body_params}}, _params) do ...
+    def function(%Conn{assigns: %{casted_params: params}}, _params) do ...
 
     If you have already migrated to the new behaviour, you can disable the old one:
 

--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -4,7 +4,7 @@ defmodule OpenApiSpex.CastParameters do
   alias OpenApiSpex.Cast.Error
   alias Plug.Conn
 
-  unless Application.compile_env(:open_api_spex, :do_not_cast_conn_body_params) do
+  unless Application.compile_env(:open_api_spex, :do_not_cast_conn_params) do
     require Logger
 
     Logger.warn("

--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -4,9 +4,9 @@ defmodule OpenApiSpex.CastParameters do
   alias OpenApiSpex.Cast.Error
   alias Plug.Conn
 
-  require Logger
-
   unless Application.compile_env(:open_api_spex, :do_not_cast_conn_params) do
+    require Logger
+
     Logger.warn("
     Casting of Plug.Conn params by open_api_spex is deprected and will be
     removed in the next major release:

--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -4,11 +4,39 @@ defmodule OpenApiSpex.CastParameters do
   alias OpenApiSpex.Cast.Error
   alias Plug.Conn
 
+  unless Application.compile_env(:open_api_spex, :do_not_cast_conn_body_params) do
+    import Logger
+
+    Logger.warn("
+    Casting of Plug.Conn params by open_api_spex is deprected and will be
+    removed in the next major release:
+
+    def function(%Conn{params: params}, _params)
+
+    or
+
+    def function(_conn, params)
+
+    Consider migrating from using the Plug.Conn body_params argument to reading
+    casted parameters from the connection assigns:
+
+    def function(%Conn{assigns: %{casted_params: body_params}}, _params) do ...
+
+    If you have already migrated to the new behaviour, you can disable the old one:
+
+    config :open_api_spex, do_not_cast_conn_params: true
+    ")
+  end
+
   @spec cast(Plug.Conn.t(), Operation.t(), Components.t()) ::
           {:error, [Error.t()]} | {:ok, Conn.t()}
   def cast(conn, operation, components) do
     with {:ok, params} <- cast_to_params(conn, operation, components) do
-      {:ok, %{conn | params: params}}
+      if Application.get_env(:open_api_spex, :do_not_cast_conn_params) do
+        {:ok, Conn.assign(conn, :casted_params, params)}
+      else
+        {:ok, %{Conn.assign(conn, :casted_params, params) | params: params}}
+      end
     end
   end
 

--- a/lib/open_api_spex/operation2.ex
+++ b/lib/open_api_spex/operation2.ex
@@ -14,9 +14,9 @@ defmodule OpenApiSpex.Operation2 do
   alias OpenApiSpex.Cast.Error
   alias Plug.Conn
 
-  require Logger
-
   unless Application.compile_env(:open_api_spex, :do_not_cast_conn_body_params) do
+    require Logger
+
     Logger.warn("
     Casting of Plug.Conn body_params by open_api_spex is deprected and will be
     removed in the next major release:

--- a/lib/open_api_spex/operation2.ex
+++ b/lib/open_api_spex/operation2.ex
@@ -14,9 +14,9 @@ defmodule OpenApiSpex.Operation2 do
   alias OpenApiSpex.Cast.Error
   alias Plug.Conn
 
-  unless Application.compile_env(:open_api_spex, :do_not_cast_conn_body_params) do
-    require Logger
+  require Logger
 
+  unless Application.compile_env(:open_api_spex, :do_not_cast_conn_body_params) do
     Logger.warn("
     Casting of Plug.Conn body_params by open_api_spex is deprected and will be
     removed in the next major release:

--- a/lib/open_api_spex/operation2.ex
+++ b/lib/open_api_spex/operation2.ex
@@ -15,7 +15,7 @@ defmodule OpenApiSpex.Operation2 do
   alias Plug.Conn
 
   unless Application.compile_env(:open_api_spex, :do_not_cast_conn_body_params) do
-    import Logger
+    require Logger
 
     Logger.warn("
     Casting of Plug.Conn body_params by open_api_spex is deprected and will be


### PR DESCRIPTION
Hi,

Currently `Plug.Conn` `params` and `body_params` are replaced  when casting via `OpenApiSpex.Plug.CastAndValidate`.
This creates issues with dialyzer (#92) and apparently breaks `Plug.Upload` (#370) too.

Unfortunately this can't be addressed in a backwards compatible way, so what I'm proposing in this PR is:

- Add `casted_body_params` and `casted_params` to conn assigns with the casted version
- Add config flags to disable the old behaviour of modifying `Plug.Conn` `params` and `body_params`.
- Add compilation warnings if the config flag is not set (default) to warn about the breaking change in the next major

This way this change could be immediately merged, and people can start migrating today if they need to.