### PR TITLE
fix: cast discriminator when value has atom keys

### DIFF
--- a/lib/open_api_spex/cast/discriminator.ex
+++ b/lib/open_api_spex/cast/discriminator.ex
@@ -40,11 +40,11 @@ defmodule OpenApiSpex.Cast.Discriminator do
   defp cast_discriminator(%_{value: value, schema: schema} = ctx) do
     {discriminator_property, mappings} = discriminator_details(schema)
 
-    case Map.pop(value, "#{discriminator_property}") do
-      {"", _} ->
+    case value["#{discriminator_property}"] || value[:"#{discriminator_property}"] do
+      v when v in ["", nil] ->
         error(:no_value_for_discriminator, ctx)
 
-      {discriminator_value, _castable_value} ->
+      discriminator_value ->
         # The cast specified by the composite key (allOf, anyOf, oneOf) MUST succeed
         # or return an error according to the Open API Spec.
         composite_ctx = %{

--- a/lib/open_api_spex/cast/discriminator.ex
+++ b/lib/open_api_spex/cast/discriminator.ex
@@ -40,7 +40,7 @@ defmodule OpenApiSpex.Cast.Discriminator do
   defp cast_discriminator(%_{value: value, schema: schema} = ctx) do
     {discriminator_property, mappings} = discriminator_details(schema)
 
-    case value["#{discriminator_property}"] || value[:"#{discriminator_property}"] do
+    case value["#{discriminator_property}"] || value[discriminator_property] do
       v when v in ["", nil] ->
         error(:no_value_for_discriminator, ctx)
 

--- a/test/cast/discriminator_test.exs
+++ b/test/cast/discriminator_test.exs
@@ -195,6 +195,25 @@ defmodule OpenApiSpex.CastDiscriminatorTest do
       assert expected == cast_cast(value: input_value, schema: discriminator_schema)
     end
 
+    test "nested, atom map success", %{schemas: %{dog: dog, cat: cat}} do
+      # "animal_type" is the discriminator and the keys need to be strings.
+      input_value = %{data: %{"#{@discriminator}": "Dog", breed: "Corgi", age: 1}}
+      # Nested schema to better simulate use with JSON API (real world)
+      discriminator_schema = %Schema{
+        title: "Nested Skemuh",
+        type: :object,
+        properties: %{
+          data:
+            build_discriminator_schema([dog, cat], :anyOf, String.to_atom(@discriminator), nil)
+        }
+      }
+
+      # Note: We're expecting to getting atoms back, not strings
+      expected = {:ok, %{data: %{age: 1, breed: "Corgi", animal_type: "Dog"}}}
+
+      assert expected == cast_cast(value: input_value, schema: discriminator_schema)
+    end
+
     test "nested, with invalid property on discriminator schema", %{
       schemas: %{dog: dog, wolf: wolf}
     } do


### PR DESCRIPTION
Discriminator silently fails when the input map is build with atom keys (e.g. when using the schema example)