### PR TITLE
Fix JsonErrorResponse schema definition

### DIFF
--- a/lib/open_api_spex/json_error_response.ex
+++ b/lib/open_api_spex/json_error_response.ex
@@ -6,7 +6,7 @@ defmodule OpenApiSpex.JsonErrorResponse do
 
       @doc responses: %{
              201 => {"User", "application/json", UserResponse}
-             422 => {"Unprocessable Entity"], "application/json", OpenApiSpex.JsonApiErrorResponse}
+             422 => {"Unprocessable Entity", "application/json", OpenApiSpex.JsonErrorResponse}
            }
   """
   require OpenApiSpex
@@ -18,6 +18,7 @@ defmodule OpenApiSpex.JsonErrorResponse do
       errors: %Schema{
         type: :array,
         items: %Schema{
+          type: :object,
           properties: %{
             title: %Schema{type: :string, example: "Invalid value"},
             source: %Schema{

--- a/test/plug/cast_test.exs
+++ b/test/plug/cast_test.exs
@@ -43,7 +43,7 @@ defmodule OpenApiSpex.Plug.CastTest do
              }
     end
 
-    test "matches JsonErrorResponse" do
+    test "error response matches JsonErrorResponse" do
       api_spec = ApiSpec.spec()
 
       conn =

--- a/test/plug/cast_test.exs
+++ b/test/plug/cast_test.exs
@@ -1,6 +1,10 @@
 defmodule OpenApiSpex.Plug.CastTest do
   use ExUnit.Case
 
+  import OpenApiSpex.TestAssertions
+
+  alias OpenApiSpexTest.ApiSpec
+
   describe "query params - basics" do
     test "Valid Param" do
       conn =
@@ -37,6 +41,18 @@ defmodule OpenApiSpex.Plug.CastTest do
                "source" => %{"pointer" => "/validParam"},
                "title" => "Invalid value"
              }
+    end
+
+    test "matches JsonErrorResponse" do
+      api_spec = ApiSpec.spec()
+
+      conn =
+        :get
+        |> Plug.Test.conn("/api/users?validParam=123")
+        |> OpenApiSpexTest.Router.call([])
+
+      error_resp = Jason.decode!(conn.resp_body)
+      assert_schema(error_resp, "JsonErrorResponse", api_spec)
     end
 
     test "with requestBody" do

--- a/test/support/user_controller.ex
+++ b/test/support/user_controller.ex
@@ -65,7 +65,8 @@ defmodule OpenApiSpexTest.UserController do
   """
   @doc request_body: {"The user attributes", "application/json", Schemas.UserRequest},
        responses: [
-         created: {"User", "application/json", Schemas.UserResponse}
+         created: {"User", "application/json", Schemas.UserResponse},
+         unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
        ]
   def create(conn = %{body_params: %Schemas.UserRequest{user: user = %Schemas.User{}}}, _) do
     user =


### PR DESCRIPTION
Fixes: #384

The `OpenApiSpex.JsonErrorResponse` schema did not
contain a type for its error items, this caused
generated responses from `OpenApiSpex.Plug.CastAndValidate`
to not match JsonErrorResponse with errors like:

```
Value does not conform to schema JsonErrorResponse: Invalid schema.type. Got: nil at /errors/0
     %{"errors" => [%{"detail" => "Invalid value for enum", "source" => %{"pointer" => "/type"}, "title" => "Invalid value"}]}

```