### PR TITLE
JsonApiErrorResponse vs JsonErrorResponse

### DIFF
--- a/lib/open_api_spex/json_error_response.ex
+++ b/lib/open_api_spex/json_error_response.ex
@@ -38,13 +38,13 @@ defmodule OpenApiSpex.JsonErrorResponse do
   })
 
   @doc """
-  Convenience function to return that wraps JsonApiErrorResponse in an Operation response.
+  Convenience function to return that wraps JsonErrorResponse in an Operation response.
 
   ## Examples
 
       @doc responses: %{
              201 => {"User", "application/json", UserResponse}
-             422 => OpenApiSpex.JsonApiErrorResponse.response()
+             422 => OpenApiSpex.JsonErrorResponse.response()
            }
   """
   def response do


### PR DESCRIPTION
Fixed naming mismatch in comments of the `json_error_response.ex` file.