### PR TITLE
Infer content type from headers when not provided to cast_and_validate/4

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,14 +343,13 @@ open_api_spec_from_yaml = "encoded_schema.yaml"
   |> OpenApiSpex.OpenApi.Decode.decode()
 ```
 
-You can then use the loaded spec to with `OpenApiSpex.cast_and_validate/4`, like:
+You can then use the loaded spec to with `OpenApiSpex.cast_and_validate/3`, like:
 
 ```elixir
 {:ok, _} = OpenApiSpex.cast_and_validate(
   open_api_spec_from_json, # or open_api_spec_from_yaml
   spec.paths["/some_path"].post,
-  test_conn,
-  "application/json"
+  test_conn
 )
 ```
 

--- a/lib/open_api_spex.ex
+++ b/lib/open_api_spex.ex
@@ -83,7 +83,20 @@ defmodule OpenApiSpex do
         conn = %Plug.Conn{},
         content_type \\ nil
       ) do
+    content_type = content_type || content_type_from_header(conn)
     Operation2.cast(operation, conn, content_type, spec.components)
+  end
+
+  defp content_type_from_header(conn = %Plug.Conn{}) do
+    case Plug.Conn.get_req_header(conn, "content-type") do
+      [header_value | _] ->
+        header_value
+        |> String.split(";")
+        |> List.first()
+
+      _ ->
+        nil
+    end
   end
 
   @doc """

--- a/lib/open_api_spex/plug/cast_and_validate.ex
+++ b/lib/open_api_spex/plug/cast_and_validate.ex
@@ -43,7 +43,6 @@ defmodule OpenApiSpex.Plug.CastAndValidate do
   @behaviour Plug
 
   alias OpenApiSpex.Plug.PutApiSpec
-  alias Plug.Conn
 
   @impl Plug
   def init(opts) do
@@ -65,18 +64,7 @@ defmodule OpenApiSpex.Plug.CastAndValidate do
     {spec, operation_lookup} = PutApiSpec.get_spec_and_operation_lookup(conn)
     operation = operation_lookup[operation_id]
 
-    content_type =
-      case Conn.get_req_header(conn, "content-type") do
-        [header_value | _] ->
-          header_value
-          |> String.split(";")
-          |> Enum.at(0)
-
-        _ ->
-          nil
-      end
-
-    with {:ok, conn} <- OpenApiSpex.cast_and_validate(spec, operation, conn, content_type) do
+    with {:ok, conn} <- OpenApiSpex.cast_and_validate(spec, operation, conn) do
       conn
     else
       {:error, errors} ->

--- a/test/open_api/decode_test.exs
+++ b/test/open_api/decode_test.exs
@@ -400,8 +400,7 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
                OpenApiSpex.cast_and_validate(
                  spec,
                  spec.paths["/example"].post,
-                 test_conn,
-                 "application/json"
+                 test_conn
                )
     end
   end


### PR DESCRIPTION
This PR moves the logic to determine the content type from the `CastAndValidate` plug into `OpenApiSpex`. 

This prevents the mistake where a value isn't provided for callers other than the `CastAndValidate` plug.

Fixes #220