### PR TITLE
Return error tuple when discriminator cast fails

### DIFF
--- a/lib/open_api_spex/cast/discriminator.ex
+++ b/lib/open_api_spex/cast/discriminator.ex
@@ -58,13 +58,13 @@ defmodule OpenApiSpex.Cast.Discriminator do
   end
 
   defp cast_composition(composite_ctx, ctx, discriminator_value, mappings) do
-    with {composite_schemas, {:ok, _}} <- cast_composition(composite_ctx),
-         %{} = schema <-
-           find_discriminator_schema(discriminator_value, mappings, composite_schemas) do
+    with {composite_schemas, cast_composition_result} <- cast_composition(composite_ctx),
+         {:ok, _} <- cast_composition_result,
+         %{} = schema <- find_discriminator_schema(discriminator_value, mappings, composite_schemas) do
       Cast.cast(%{composite_ctx | schema: schema})
     else
       nil -> error(:invalid_discriminator_value, ctx)
-      other -> other
+      {:error, _} = error -> error
     end
   end
 

--- a/test/cast/one_of_test.exs
+++ b/test/cast/one_of_test.exs
@@ -44,7 +44,32 @@ defmodule OpenApiSpex.CastOneOfTest do
 
     test "objects, using discriminator" do
       dog = %{"bark" => "woof", "pet_type" => "Dog"}
-      TestAssertions.assert_schema(dog, "CatOrDog", OpenApiSpexTest.ApiSpec.spec())
+      TestAssertions.assert_schema(dog, "Pet", OpenApiSpexTest.ApiSpec.spec())
+    end
+
+    test "error when value invalid against all schemas, using discriminator" do
+      dog = %{"fur" => "grey", "pet_type" => "Wolf"}
+      api_spec = OpenApiSpexTest.ApiSpec.spec()
+      pet_schema = api_spec.components.schemas["Pet"]
+      assert {:error, [error]} = OpenApiSpex.cast_value(dog, pet_schema, api_spec)
+
+      assert error == %OpenApiSpex.Cast.Error{
+               format: nil,
+               length: 0,
+               meta: %{
+                 failed_schemas: [
+                   "Schema(title: \"Dog\", type: :object)",
+                   "Schema(title: \"Cat\", type: :object)"
+                 ],
+                 message: "no schemas validate",
+                 valid_schemas: []
+               },
+               name: nil,
+               path: ["pet_type"],
+               reason: :one_of,
+               type: nil,
+               value: %{"fur" => "grey", "pet_type" => "Wolf"}
+             }
     end
   end
 


### PR DESCRIPTION
Fixes #302 

`Discriminator.cast` would return the error tuple wrapped in another tuple containing the schemas it tried to validate against - coming from the `cast_composition` private function.

Now returns only the inner error tuple.

