### PR TITLE
Fix casting Encoding without style field

### DIFF
--- a/lib/open_api_spex/open_api/decode.ex
+++ b/lib/open_api_spex/open_api/decode.ex
@@ -103,8 +103,14 @@ defmodule OpenApiSpex.OpenApi.Decode do
   #
   # This function, ensures that if the map has the key — it'll convert the corresponding value
   # to an atom.
-  defp convert_value_to_atom_if_present(map, key),
-    do: update_map_if_key_present(map, key, &String.to_atom/1)
+  defp convert_value_to_atom_if_present(map, key) do
+    update_fn = fn
+      nil -> nil
+      s -> String.to_atom(s)
+    end
+
+    update_map_if_key_present(map, key, update_fn)
+  end
 
   # In some cases, e.g. Schema type we must convert values that are list of strings to a list atoms,
   #


### PR DESCRIPTION
fixes an issue found when parsing Encodings without the `style` field

example:
```
              "post": {
                "operationId": "TransferMtData",
                "requestBody": {
                  "content": {
                    "multipart/related": {
                      "encoding": {
                        "binaryMtData": {
                          "contentType": "application/vnd.3gpp.5gnas",
                          "headers": {
                            "Content-Id": {
                              "schema": {
                                "type": "string"
                              }
                            }
 ```
produces the following error:

```
** (FunctionClauseError) no function clause matching in String.to_atom/1    
    
    The following arguments were given to String.to_atom/1:
    
        # 1
        nil
    
    Attempted function clauses (showing 1 out of 1):
    
        def to_atom(+string+) when -is_binary(string)-
    
    (elixir 1.13.0-dev) lib/string.ex:2436: String.to_atom/1
    (open_api_spex 3.11.0) lib/open_api_spex/open_api/decode.ex:94: OpenApiSpex.OpenApi.Decode.update_map_if_key_present/3
    (open_api_spex 3.11.0) lib/open_api_spex/open_api/decode.ex:351: anonymous fn/1 in OpenApiSpex.OpenApi.Decode.to_struct/2
    (elixir 1.13.0-dev) lib/enum.ex:1595: anonymous fn/3 in Enum.map/2
    (stdlib 3.15.1) maps.erl:410: :maps.fold_1/3
    (elixir 1.13.0-dev) lib/enum.ex:2406: Enum.map/2
    (elixir 1.13.0-dev) lib/map.ex:219: Map.new/2
    (elixir 1.13.0-dev) lib/map.ex:813: Map.update!/3
```