### PR TITLE
Preserves body_params *and params resolved by Plug.Parsers

### DIFF
--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -8,7 +8,12 @@ defmodule OpenApiSpex.CastParameters do
           {:error, [Error.t()]} | {:ok, Conn.t()}
   def cast(conn, operation, components) do
     with {:ok, params} <- cast_to_params(conn, operation, components) do
-      {:ok, %{conn | params: params}}
+      conn = case Application.get_env(:open_api_spex, :conn_private_decode, false) do
+        false -> %{conn | params: params}
+        true -> Plug.Conn.put_private(conn, :params, params)
+      end
+
+      {:ok, conn}
     end
   end
 

--- a/lib/open_api_spex/operation2.ex
+++ b/lib/open_api_spex/operation2.ex
@@ -20,7 +20,11 @@ defmodule OpenApiSpex.Operation2 do
     with {:ok, conn} <- cast_parameters(conn, operation, components),
          {:ok, body} <-
            cast_request_body(operation.requestBody, conn.body_params, content_type, components) do
-      conn = Map.put(conn, :private, Map.put(conn.private, :body_params, body))
+      conn = case Application.get_env(:open_api_spex, :conn_private_body_decode, false) do
+        false -> %{conn | body_params: body}
+        true -> Map.put(conn, :private, Map.put(conn.private, :body_params, body))
+      end
+
       {:ok, conn}
     end
   end

--- a/lib/open_api_spex/operation2.ex
+++ b/lib/open_api_spex/operation2.ex
@@ -20,7 +20,8 @@ defmodule OpenApiSpex.Operation2 do
     with {:ok, conn} <- cast_parameters(conn, operation, components),
          {:ok, body} <-
            cast_request_body(operation.requestBody, conn.body_params, content_type, components) do
-      {:ok, %{conn | body_params: body}}
+      conn = Map.put(conn, :private, Map.put(conn.private, :body_params, body))
+      {:ok, conn}
     end
   end
 

--- a/lib/open_api_spex/operation2.ex
+++ b/lib/open_api_spex/operation2.ex
@@ -20,9 +20,9 @@ defmodule OpenApiSpex.Operation2 do
     with {:ok, conn} <- cast_parameters(conn, operation, components),
          {:ok, body} <-
            cast_request_body(operation.requestBody, conn.body_params, content_type, components) do
-      conn = case Application.get_env(:open_api_spex, :conn_private_body_decode, false) do
+      conn = case Application.get_env(:open_api_spex, :conn_private_decode, false) do
         false -> %{conn | body_params: body}
-        true -> Map.put(conn, :private, Map.put(conn.private, :body_params, body))
+        true -> Plug.Conn.put_private(conn, :body_params, body)
       end
 
       {:ok, conn}


### PR DESCRIPTION
I'm proposing the use of an additional config key (defaulted to false)
```elixir
config :open_api_spex, conn_private_body_decode: true
```
to move the casted body result into the `:private` fields of the `Plug.Conn`.

While preserving the backward compat, it feels more inline with [Plug.Conn doc](https://github.com/elixir-plug/plug/blob/master/lib/plug/conn.ex#L310) and preserves the parsers result for inspection

Thanks