### PR TITLE
Clarify controller example

### DIFF
--- a/lib/open_api_spex/controller.ex
+++ b/lib/open_api_spex/controller.ex
@@ -137,7 +137,7 @@ defmodule OpenApiSpex.Controller do
     @moduledoc tags: ["Users"]
 
     use MyAppWeb, :controller
-    use #{inspect(__MODULE__)}
+    use OpenApiSpex.Controller
 
     @doc """
     Endpoint summary


### PR DESCRIPTION
I think the intention was to interpolate the inspected controller name but the code block shows the original source which makes it, IMO, unnecessarily confusing as an example, since if you copy this code it fails to compile, but if you omit that line it silently fails to load the docs, which was frustrating as a beginner.