### PR TITLE
Require Elixir 1.9

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
@@ -23,6 +23,4 @@ use Mix.Config
 
 config :phoenix, json_library: Jason
 
-if Mix.env() == :test do
-  import_config "test.exs"
-end
+import_config "#{Mix.env()}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,3 @@
-use Mix.Config
+import Config
 
 config :logger, level: :info

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule OpenApiSpex.Mixfile do
     [
       app: :open_api_spex,
       version: @version,
-      elixir: "~> 1.7",
+      elixir: "~> 1.9",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       consolidate_protocols: Mix.env() != :test,


### PR DESCRIPTION
Previous Elixir versions [no longer receive](https://hexdocs.pm/elixir/compatibility-and-deprecations.html) security updates. In addition, this removes the deprecation warnings that come from instances of `use Mix.Config` within the code.