### PR TITLE
Avoids overwriting Plug.Conn body_params and params with the cast outcome

### DIFF
--- a/lib/open_api_spex/operation2.ex
+++ b/lib/open_api_spex/operation2.ex
@@ -14,20 +14,47 @@ defmodule OpenApiSpex.Operation2 do
   alias OpenApiSpex.Cast.Error
   alias Plug.Conn
 
-  @spec cast(Operation.t(), Conn.t(), String.t() | nil, Components.t()) ::
+  @spec cast(
+          Operation.t(),
+          Conn.t(),
+          String.t() | nil,
+          Components.t(),
+          opts :: [OpenApiSpex.cast_opt()]
+        ) ::
           {:error, [Error.t()]} | {:ok, Conn.t()}
-  def cast(operation = %Operation{}, conn = %Conn{}, content_type, components = %Components{}) do
-    with {:ok, conn} <- cast_parameters(conn, operation, components),
+  def cast(
+        operation = %Operation{},
+        conn = %Conn{},
+        content_type,
+        components = %Components{},
+        opts \\ []
+      ) do
+    replace_params = Keyword.get(opts, :replace_params, true)
+
+    with {:ok, conn} <- cast_parameters(conn, operation, components, opts),
          {:ok, body} <-
            cast_request_body(operation.requestBody, conn.body_params, content_type, components) do
-      {:ok, %{conn | body_params: body}}
+      {:ok, conn |> cast_conn(body) |> maybe_replace_body(body, replace_params)}
     end
   end
 
   ## Private functions
 
-  defp cast_parameters(conn, operation, components) do
-    CastParameters.cast(conn, operation, components)
+  defp cast_conn(conn, body) do
+    private_data =
+      conn
+      |> Map.get(:private)
+      |> Map.get(:open_api_spex, %{})
+      |> Map.put(:body_params, body)
+
+    Plug.Conn.put_private(conn, :open_api_spex, private_data)
+  end
+
+  defp maybe_replace_body(conn, _body, false), do: conn
+  defp maybe_replace_body(conn, body, true), do: %{conn | body_params: body}
+
+  defp cast_parameters(conn, operation, components, opts) do
+    CastParameters.cast(conn, operation, components, opts)
   end
 
   defp cast_request_body(ref = %Reference{}, body_params, content_type, components) do

--- a/test/plug/cast_test.exs
+++ b/test/plug/cast_test.exs
@@ -13,6 +13,22 @@ defmodule OpenApiSpex.Plug.CastTest do
         |> OpenApiSpexTest.Router.call([])
 
       assert conn.status == 200
+      assert conn.private.open_api_spex.params == conn.params
+
+      assert OpenApiSpex.params(conn) == %{validParam: true}
+    end
+
+    test "Valid Param with replace_params false" do
+      conn =
+        :get
+        |> Plug.Test.conn("/api/users_no_replace?validParam=true")
+        |> OpenApiSpexTest.Router.call([])
+
+      assert conn.status == 200
+      assert conn.private.open_api_spex.params == %{validParam: true}
+      assert conn.params == %{"validParam" => "true"}
+
+      assert OpenApiSpex.params(conn) == %{validParam: true}
     end
 
     @tag :capture_log
@@ -79,6 +95,7 @@ defmodule OpenApiSpex.Plug.CastTest do
         |> OpenApiSpexTest.Router.call([])
 
       assert conn.status == 200
+      assert conn.private.open_api_spex.params == conn.params
     end
   end
 
@@ -90,6 +107,7 @@ defmodule OpenApiSpex.Plug.CastTest do
         |> OpenApiSpexTest.Router.call([])
 
       assert conn.status == 200
+      assert conn.private.open_api_spex.params == conn.params
     end
 
     @tag :capture_log
@@ -126,21 +144,25 @@ defmodule OpenApiSpex.Plug.CastTest do
         }
       }
 
+      casted_body = %OpenApiSpexTest.Schemas.UserRequest{
+        user: %OpenApiSpexTest.Schemas.User{
+          id: 123,
+          name: "asdf",
+          email: "foo@bar.com",
+          password: "0123456789",
+          updated_at: ~N[2017-09-12T14:44:55Z] |> DateTime.from_naive!("Etc/UTC")
+        }
+      }
+
       conn =
         :post
         |> Plug.Test.conn("/api/users", Jason.encode!(request_body))
         |> Plug.Conn.put_req_header("content-type", "application/json; charset=UTF-8")
         |> OpenApiSpexTest.Router.call([])
 
-      assert conn.body_params == %OpenApiSpexTest.Schemas.UserRequest{
-               user: %OpenApiSpexTest.Schemas.User{
-                 id: 123,
-                 name: "asdf",
-                 email: "foo@bar.com",
-                 password: "0123456789",
-                 updated_at: ~N[2017-09-12T14:44:55Z] |> DateTime.from_naive!("Etc/UTC")
-               }
-             }
+      assert conn.body_params == casted_body
+
+      assert conn.private.open_api_spex.body_params == conn.body_params
 
       assert Jason.decode!(conn.resp_body) == %{
                "data" => %{
@@ -151,6 +173,8 @@ defmodule OpenApiSpex.Plug.CastTest do
                  "updated_at" => "2017-09-12T14:44:55Z"
                }
              }
+
+      assert OpenApiSpex.body_params(conn) == casted_body
     end
 
     @tag :capture_log
@@ -182,6 +206,50 @@ defmodule OpenApiSpex.Plug.CastTest do
                "title" => "Invalid value"
              }
     end
+
+    test "Valid Request with replace_params false" do
+      request_body = %{
+        "user" => %{
+          "id" => 123,
+          "name" => "asdf",
+          "email" => "foo@bar.com",
+          "password" => "0123456789",
+          "updated_at" => "2017-09-12T14:44:55Z"
+        }
+      }
+
+      casted_body = %OpenApiSpexTest.Schemas.UserRequest{
+        user: %OpenApiSpexTest.Schemas.User{
+          id: 123,
+          name: "asdf",
+          email: "foo@bar.com",
+          password: "0123456789",
+          updated_at: ~N[2017-09-12T14:44:55Z] |> DateTime.from_naive!("Etc/UTC")
+        }
+      }
+
+      conn =
+        :post
+        |> Plug.Test.conn("/api/users_no_replace", Jason.encode!(request_body))
+        |> Plug.Conn.put_req_header("content-type", "application/json; charset=UTF-8")
+        |> OpenApiSpexTest.Router.call([])
+
+      assert conn.private.open_api_spex.body_params == casted_body
+
+      assert conn.body_params == request_body
+
+      assert Jason.decode!(conn.resp_body) == %{
+               "data" => %{
+                 "email" => "foo@bar.com",
+                 "id" => 1234,
+                 "inserted_at" => nil,
+                 "name" => "asdf",
+                 "updated_at" => "2017-09-12T14:44:55Z"
+               }
+             }
+
+      assert OpenApiSpex.body_params(conn) == casted_body
+    end
   end
 
   describe "oneOf body params" do
@@ -205,6 +273,8 @@ defmodule OpenApiSpex.Plug.CastTest do
                  bark: "woof"
                }
              }
+
+      assert conn.private.open_api_spex.body_params == conn.body_params
 
       assert Jason.decode!(conn.resp_body) == %{
                "data" => %{

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -13,6 +13,8 @@ defmodule OpenApiSpexTest.Router do
     pipe_through :api
     resources "/users", OpenApiSpexTest.UserController, only: [:create, :index, :show]
 
+    resources "/users_no_replace", OpenApiSpexTest.UserNoRepalceController, only: [:create, :index]
+
     # Used by ParamsTest
     resources "/custom_error_users", OpenApiSpexTest.CustomErrorUserController, only: [:index]
 

--- a/test/support/user_no_replace_controller.ex
+++ b/test/support/user_no_replace_controller.ex
@@ -1,0 +1,62 @@
+defmodule OpenApiSpexTest.UserNoRepalceController do
+  @moduledoc tags: ["users_no_replace"]
+
+  use Phoenix.Controller
+  use OpenApiSpex.Controller
+
+  alias OpenApiSpexTest.Schemas
+
+  plug OpenApiSpex.Plug.CastAndValidate,
+    json_render_error_v2: true,
+    replace_params: false
+
+  @doc """
+  List users
+
+  List all users
+  """
+  @doc parameters: [
+         validParam: [in: :query, type: :boolean, description: "Valid Param", example: true]
+       ],
+       responses: [
+         ok: {"User List Response", "application/json", Schemas.UsersResponse}
+       ]
+  def index(conn, _params) do
+    json(conn, %Schemas.UsersResponse{
+      data: [
+        %Schemas.User{
+          id: 123,
+          name: "joe user",
+          email: "joe@gmail.com"
+        }
+      ]
+    })
+  end
+
+  @doc """
+  Create user.
+
+  Create a user.
+  """
+  @doc request_body: {"The user attributes", "application/json", Schemas.UserRequest},
+       responses: [
+         created: {"User", "application/json", Schemas.UserResponse},
+         unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
+       ]
+  def create(
+        conn = %{
+          private: %{
+            open_api_spex: %{body_params: %Schemas.UserRequest{user: user = %Schemas.User{}}}
+          }
+        },
+        _
+      ) do
+    user =
+      user
+      |> Map.from_struct()
+      |> Map.put(:id, 1234)
+      |> Map.delete(:password)
+
+    json(conn, %Schemas.UserResponse{data: user})
+  end
+end


### PR DESCRIPTION
See #398 and #376

As aked in [this comment](https://github.com/open-api-spex/open_api_spex/pull/376#issuecomment-1009472277) the flag for moving cast result to `conn.private` is now an option to `CastAndValidate` plug.

Credits to @riccardomanfrin and @lucacorti 