### PR TITLE
Generate examples for UUID formatted strings

### DIFF
--- a/lib/open_api_spex/cast/string.ex
+++ b/lib/open_api_spex/cast/string.ex
@@ -30,6 +30,77 @@ defmodule OpenApiSpex.Cast.String do
     end
   end
 
+  @uuid_valid_characters [
+    ?0,
+    ?1,
+    ?2,
+    ?3,
+    ?4,
+    ?5,
+    ?6,
+    ?7,
+    ?8,
+    ?9,
+    ?A,
+    ?B,
+    ?C,
+    ?D,
+    ?E,
+    ?F,
+    ?a,
+    ?b,
+    ?c,
+    ?d,
+    ?e,
+    ?f
+  ]
+  def cast(%{
+        value:
+          <<a1, a2, a3, a4, a5, a6, a7, a8, ?-, b1, b2, b3, b4, ?-, c1, c2, c3, c4, ?-, d1, d2, d3,
+            d4, ?-, e1, e2, e3, e4, e5, e6, e7, e8, e9, e10, e11, e12>> = value,
+        schema: %{format: :uuid}
+      })
+      when is_binary(value) and
+             a1 in @uuid_valid_characters and
+             a2 in @uuid_valid_characters and
+             a3 in @uuid_valid_characters and
+             a4 in @uuid_valid_characters and
+             a5 in @uuid_valid_characters and
+             a6 in @uuid_valid_characters and
+             a7 in @uuid_valid_characters and
+             a8 in @uuid_valid_characters and
+             b1 in @uuid_valid_characters and
+             b2 in @uuid_valid_characters and
+             b3 in @uuid_valid_characters and
+             b4 in @uuid_valid_characters and
+             c1 in @uuid_valid_characters and
+             c2 in @uuid_valid_characters and
+             c3 in @uuid_valid_characters and
+             c3 in @uuid_valid_characters and
+             c4 in @uuid_valid_characters and
+             d1 in @uuid_valid_characters and
+             d2 in @uuid_valid_characters and
+             d3 in @uuid_valid_characters and
+             d4 in @uuid_valid_characters and
+             e1 in @uuid_valid_characters and
+             e2 in @uuid_valid_characters and
+             e3 in @uuid_valid_characters and
+             e4 in @uuid_valid_characters and
+             e5 in @uuid_valid_characters and
+             e6 in @uuid_valid_characters and
+             e7 in @uuid_valid_characters and
+             e8 in @uuid_valid_characters and
+             e9 in @uuid_valid_characters and
+             e10 in @uuid_valid_characters and
+             e11 in @uuid_valid_characters and
+             e12 in @uuid_valid_characters do
+    {:ok, value}
+  end
+
+  def cast(%{value: value, schema: %{format: :uuid}} = ctx) when is_binary(value) do
+    Cast.error(ctx, {:invalid_format, :uuid})
+  end
+
   def cast(%{value: value = %Plug.Upload{}, schema: %{format: :binary}}) do
     {:ok, value}
   end

--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -393,6 +393,7 @@ defmodule OpenApiSpex.Schema do
 
   def example(%Schema{type: :string, format: :date}), do: "2020-04-20"
   def example(%Schema{type: :string, format: :"date-time"}), do: "2020-04-20T16:20:00Z"
+  def example(%Schema{type: :string, format: :uuid}), do: "02ef9c5f-29e6-48fc-9ec3-7ed57ed351f6"
 
   def example(%Schema{type: :string}), do: ""
   def example(%Schema{type: :integer} = s), do: example_for(s, :integer)

--- a/test/cast/string_test.exs
+++ b/test/cast/string_test.exs
@@ -44,6 +44,32 @@ defmodule OpenApiSpex.CastStringTest do
       assert error.format == :date
     end
 
+    test "casts a string with valid uuid format" do
+      schema = %Schema{type: :string, format: :uuid}
+
+      assert {:ok, "02ef9c5f-29e6-48fc-9ec3-7ed57ed351f6"} =
+               cast(value: "02ef9c5f-29e6-48fc-9ec3-7ed57ed351f6", schema: schema)
+
+      assert {:ok, "02EF9C5F-29E6-48FC-9EC3-7ED57ED351F6"} =
+               cast(value: "02EF9C5F-29E6-48FC-9EC3-7ED57ED351F6", schema: schema)
+    end
+
+    test "returns a cast error with an invalid uuid string" do
+      schema = %Schema{type: :string, format: :uuid}
+
+      assert {:error, [%{reason: :invalid_format, value: "string", format: :uuid}]} =
+               cast(value: "string", schema: schema)
+
+      assert {:error,
+              [
+                %{
+                  reason: :invalid_format,
+                  value: "????????-$$$$-@@@@-9ec3-7ed57ed351f6",
+                  format: :uuid
+                }
+              ]} = cast(value: "????????-$$$$-@@@@-9ec3-7ed57ed351f6", schema: schema)
+    end
+
     test "file upload" do
       schema = %Schema{type: :string, format: :binary}
       upload = %Plug.Upload{}

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -181,6 +181,11 @@ defmodule OpenApiSpex.SchemaTest do
       assert Schema.example(schema) == "2020-04-20T16:20:00Z"
     end
 
+    test "string :uuid format" do
+      schema = %Schema{type: :string, format: :uuid}
+      assert Schema.example(schema) == "02ef9c5f-29e6-48fc-9ec3-7ed57ed351f6"
+    end
+
     test "example for schema module" do
       defmodule Bar do
         require OpenApiSpex


### PR DESCRIPTION
This is a continuation of https://github.com/open-api-spex/open_api_spex/pull/266#discussion_r475041706
we should generate valid examples for as many formats as possible.

The current behaviour regarding UUIDs is illustrated in the following example:

```elixir
defmodule SomeSchema do
  require OpenApiSpex

  alias OpenApiSpex.{Schema, Cast}

  OpenApiSpex.schema(%{
    description: "some schema",
    type: :object,
    properties: %{
      id: %Schema{
        type: :string,
        format: :uuid
      }
    }
  })
end

OpenApiSpex.Cast.cast(SomeSchema.schema, OpenApiSpex.Schema.example(SomeSchema))

# => {:ok, %SomeSchema{id: ""}}
```

The generated `example` contains an invalid UUID and `cast/2` doesn't validate it at all returning a success tuple.