### PR TITLE
Fix typo in result of JsonErrorResponse.response()

### DIFF
--- a/lib/open_api_spex/json_error_response.ex
+++ b/lib/open_api_spex/json_error_response.ex
@@ -49,7 +49,7 @@ defmodule OpenApiSpex.JsonErrorResponse do
   """
   def response do
     Operation.response(
-      "Unprocessible Entity",
+      "Unprocessable Entity",
       "application/json",
       __MODULE__
     )


### PR DESCRIPTION
Like #248 fixed the same typo in the README, this PR fixes it in the result of the function mentioned in the title (which shows up in the responses section of Swagger UI when calling it as shown in the example in the `@doc` above).