### PR TITLE
Multiple content types

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,36 +137,7 @@ call arguments, add `:open_api_spex` to the `import_deps` list in `.formatter.ex
 ]
 ```
 
-There is a convenient shortcut `:type` for base data types supported by open api
-
-```elixir
-parameters: [
-  id: [in: :query, type: :integer, required: true, description: "User ID", example: 1001]
-]
-```
-
-The responses can also be defined using keyword list syntax,
-and the HTTP status codes can be replaced with their text equivalents:
-
-```elixir
-responses: [
-  ok: {"User response", "application/json", MyAppWeb.Schemas.UserResponse},
-  unprocessable_entity: {"Bad request parameters", "application/json", MyAppWeb.Schemas.BadRequestParameters},
-  not_found: {"Not found", "application/json", MyAppWeb.Schemas.NotFound}
-]
-```
-
-The full set of atom keys are defined in `Plug.Conn.Status.code/1`.
-
-Alternately, the HTTP status codes can be specified directly:
-
-```elixir
-responses: %{
-  200 => {"User response", "application/json", MyAppWeb.Schemas.UserResponse},
-  422 => {"Bad request parameters", "application/json", MyAppWeb.Schemas.BadRequestParameters},
-  404 => {"Not found", "application/json", MyAppWeb.Schemas.NotFound}
-}
-```
+For further information about defining operations, see `OpenApiSpex.ControllerSpecs`.
 
 If you need to omit the spec for some action then pass false to the
 second argument of `operation/2` for the action:

--- a/lib/open_api_spex/controller_specs.ex
+++ b/lib/open_api_spex/controller_specs.ex
@@ -87,11 +87,15 @@ defmodule OpenApiSpex.ControllerSpecs do
   2. The RequestBody `content` field, consisting of a mapping of content types to their `MediaType` objects,
      or a simple content type string (e.g., "application/json").
      ```elixir
-     content: %{"application/json" => [example: "{[]}"]}
+     content: "application/json"
      ```
      Or:
      ```elixir
-     content: "application/json"
+     content: %{"application/text" => [example: "some text!"]}
+     ```
+     Or:
+     ```elixir
+     content: %{"application/text" => [%OpenApiSpex.MediaType{example: "some text!"}]}
      ```
   3. The default schema of the RequestBody.
   4. A keyword list of options.

--- a/lib/open_api_spex/controller_specs.ex
+++ b/lib/open_api_spex/controller_specs.ex
@@ -86,6 +86,13 @@ defmodule OpenApiSpex.ControllerSpecs do
   1. The RequestBody `description` field.
   2. The RequestBody `content` field, consisting of a mapping of content types to their `MediaType` objects,
      or a simple content type string (e.g., "application/json").
+     ```elixir
+     content: %{"application/json" => [example: "{[]}"]}
+     ```
+     Or:
+     ```elixir
+     content: "application/json"
+     ```
   3. The default schema of the RequestBody.
   4. A keyword list of options.
 
@@ -124,6 +131,13 @@ defmodule OpenApiSpex.ControllerSpecs do
   1. The ResponseObject `description` field.
   2. The ResponseObject `content` field, consisting of a mapping of content types to their `MediaType` objects,
      or a simple content type string (e.g., "application/json").
+     ```elixir
+     content: %{"application/json" => [example: "{[]}"]}
+     ```
+     Or:
+     ```elixir
+     content: "application/json"
+     ```
   3. The default schema of the response body.
   4. A keyword list of options to add to the `OpenApiSpex.Response` or `OpenApiSpex.MediaType` structs
      that are generated.

--- a/lib/open_api_spex/controller_specs.ex
+++ b/lib/open_api_spex/controller_specs.ex
@@ -45,6 +45,89 @@ defmodule OpenApiSpex.ControllerSpecs do
   If you use Elixir Formatter, `:open_api_spex` can be added to the `:import_deps`
   list in the `.formatter.exs` file of your project to make parentheses of the
   macros optional.
+
+  `.formatter.exs`:
+
+  ```elixir
+  [
+    import_deps: [:open_api_spex]
+  ]
+  ```
+
+  ## `parameters`
+
+  `parameters` is a keyword list (or map) of request parameters (not body parameters). They each represent the
+  OpenAPI [Parameter Object](https://spec.openapis.org/oas/v3.1.0#parameter-object).
+
+  There is a convenient shortcut `:type` for base data types supported by open api
+
+  ```elixir
+  parameters: [
+    id: [in: :query, type: :integer, required: true, description: "User ID", example: 1001]
+  ]
+  ```
+
+  This is equivalent to:
+
+  ```elixir
+  parameters: [
+    id: [in: :query, schema: %OpenApiSpex.Schema{type: :integer}, required: true, description: "User ID", example: 1001]
+  ]
+  ```
+
+  The keyword value is the parameter name. Each value in the keyword list correlates to a field in the OpenAPI ParameterObject.
+
+  ## `request_body`
+
+  The `request_body` defines the OpenAPI [RequestBodyObject](https://spec.openapis.org/oas/v3.1.0#request-body-object).
+
+  The `request_body` takes a tuple that is 2-4 elements in length. The elements of the tuple are:
+
+  1. The RequestBody `description` field.
+  2. The RequestBody `content` field, consisting of a mapping of content types to their `MediaType` objects,
+     or a simple content type string (e.g., "application/json").
+  3. The default schema of the RequestBody.
+  4. A keyword list of options.
+
+  ## `responses`
+
+  The `responses` key defines the OpenAPI [Responses Object](https://spec.openapis.org/oas/v3.1.0#fixed-fields-7)
+
+  The `responses` value is a keyword list or map that maps the HTTP status to a
+  [ResponseObject](https://spec.openapis.org/oas/v3.1.0#response-object).
+
+  If the the responses is defined using keyword list syntax,
+  the HTTP status codes can be replaced with their text equivalents:
+
+  ```elixir
+  responses: [
+    ok: {"User response", "application/json", MyAppWeb.Schemas.UserResponse},
+    unprocessable_entity: {"Bad request parameters", "application/json", MyAppWeb.Schemas.BadRequestParameters},
+    not_found: {"Not found", "application/json", MyAppWeb.Schemas.NotFound}
+  ]
+  ```
+
+  The full set of atom keys are defined in `Plug.Conn.Status.code/1`.
+
+  Alternately, the HTTP status codes can be specified directly:
+
+  ```elixir
+  responses: %{
+    200 => {"User response", "application/json", MyAppWeb.Schemas.UserResponse},
+    422 => {"Bad request parameters", "application/json", MyAppWeb.Schemas.BadRequestParameters},
+    404 => {"Not found", "application/json", MyAppWeb.Schemas.NotFound}
+  }
+  ```
+
+  The ResponseObject is represented as a tuple that is 2-4 elements in length. The elements of the tuple are:
+
+  1. The ResponseObject `description` field.
+  2. The ResponseObject `content` field, consisting of a mapping of content types to their `MediaType` objects,
+     or a simple content type string (e.g., "application/json").
+  3. The default schema of the response body.
+  4. A keyword list of options to add to the `OpenApiSpex.Response` or `OpenApiSpex.MediaType` structs
+     that are generated.
+
   """
   alias OpenApiSpex.{Operation, OperationBuilder}
 

--- a/lib/open_api_spex/operation.ex
+++ b/lib/open_api_spex/operation.ex
@@ -111,17 +111,21 @@ defmodule OpenApiSpex.Operation do
   """
   @spec request_body(
           description :: String.t(),
-          media_type :: String.t() | %{String.t() => Keyword.t() | map | MediaType.t()},
+          media_type :: String.t() | %{String.t() => Keyword.t() | MediaType.t()},
           schema_ref :: Schema.t() | Reference.t() | module,
           opts :: keyword
         ) :: RequestBody.t()
   def request_body(description, media_type, schema_ref, opts \\ []) do
-    opts = Keyword.new(opts)
-
     content_opts =
-      opts
-      |> Keyword.take([:example, :examples])
-      |> Keyword.put(:schema, schema_ref)
+      case opts do
+        %MediaType{} = media_type ->
+          %MediaType{media_type | schema: schema_ref}
+
+        opts when is_list(opts) ->
+          opts
+          |> Keyword.take([:example, :examples])
+          |> Keyword.put(:schema, schema_ref)
+      end
 
     %RequestBody{
       description: description,
@@ -135,15 +139,21 @@ defmodule OpenApiSpex.Operation do
   """
   @spec response(
           description :: String.t(),
-          media_type :: String.t() | %{String.t() => Keyword.t() | map | MediaType.t()},
+          media_type :: String.t() | %{String.t() => Keyword.t() | MediaType.t()},
           schema_ref :: Schema.t() | Reference.t() | module,
           opts :: keyword
         ) :: Response.t()
   def response(description, media_type, schema_ref, opts \\ []) do
     content_opts =
-      opts
-      |> Keyword.take([:example, :examples])
-      |> Keyword.put(:schema, schema_ref)
+      case opts do
+        %MediaType{} = media_type ->
+          %MediaType{media_type | schema: schema_ref}
+
+        opts when is_list(opts) ->
+          opts
+          |> Keyword.take([:example, :examples])
+          |> Keyword.put(:schema, schema_ref)
+      end
 
     %Response{
       description: description,

--- a/lib/open_api_spex/operation_builder.ex
+++ b/lib/open_api_spex/operation_builder.ex
@@ -109,17 +109,16 @@ defmodule OpenApiSpex.OperationBuilder do
   defp status_to_code(:default), do: :default
   defp status_to_code(status), do: Plug.Conn.Status.code(status)
 
-  def build_request_body(%{body: {name, mime, schema}}) do
-    IO.warn("Using :body key for requestBody is deprecated. Please use :request_body instead.")
-    Operation.request_body(name, mime, schema)
+  def build_request_body(%{body: {description, media_type, schema}}) do
+    Operation.request_body(description, media_type, schema)
   end
 
-  def build_request_body(%{request_body: {name, mime, schema}}) do
-    Operation.request_body(name, mime, schema)
+  def build_request_body(%{request_body: {description, media_type, schema}}) do
+    Operation.request_body(description, media_type, schema)
   end
 
-  def build_request_body(%{request_body: {name, mime, schema, opts}}) do
-    Operation.request_body(name, mime, schema, opts)
+  def build_request_body(%{request_body: {description, media_type, schema, opts}}) do
+    Operation.request_body(description, media_type, schema, opts)
   end
 
   def build_request_body(_), do: nil

--- a/test/controller_specs_test.exs
+++ b/test/controller_specs_test.exs
@@ -38,6 +38,10 @@ defmodule OpenApiSpex.ControllerSpecsTest do
              } = request_body
 
       assert %MediaType{schema: OpenApiSpexTest.DslController.UserParams} = media_type
+      assert media_type.example == "json example"
+
+      assert text_media_type = request_body.content["application/text"]
+      assert text_media_type.example == "text example"
     end
 
     test ":responses" do
@@ -49,12 +53,17 @@ defmodule OpenApiSpex.ControllerSpecsTest do
       assert %{200 => response} = responses
 
       assert %Response{
-               content: %{"application/json" => media_type},
+               content: content,
                description: "User response",
                headers: %{"content-type" => %OpenApiSpex.Header{}}
              } = response
 
+      assert %{"application/json" => media_type} = content
       assert %MediaType{schema: OpenApiSpexTest.DslController.UserResponse} = media_type
+      assert media_type.example == "json example"
+
+      assert %{"application/text" => media_type} = content
+      assert media_type.example == "text example"
     end
 
     test ":deprecated" do

--- a/test/support/dsl_controller.ex
+++ b/test/support/dsl_controller.ex
@@ -93,16 +93,29 @@ defmodule OpenApiSpexTest.DslController do
         }
       }
     },
-    request_body: {"User params", "application/json", UserParams},
+    request_body: {
+      "User params",
+      %{
+        "application/json" => [example: "json example"],
+        "application/text" => [example: "text example"]
+      },
+      UserParams
+    },
     responses: [
-      ok:
-        {"User response", "application/json", UserResponse,
-         headers: %{
-           "content-type" => %OpenApiSpex.Header{
-             description: "Type of the content for the response",
-             example: "content-type: application/json; charset=utf-8"
-           }
-         }}
+      ok: {
+        "User response",
+        %{
+          "application/json" => [example: "json example"],
+          "application/text" => [example: "text example"]
+        },
+        UserResponse,
+        headers: %{
+          "content-type" => %OpenApiSpex.Header{
+            description: "Type of the content for the response",
+            example: "content-type: application/json; charset=utf-8"
+          }
+        }
+      }
     ],
     tags: ["custom"],
     security: [%{"two" => ["another"]}]


### PR DESCRIPTION
Adds support for multiple content types for request bodies and response bodies in the ControllerSpecs DSL.

Resolves #450.