### PR TITLE
fix: Delete duplicated key in struct error

### DIFF
--- a/lib/open_api_spex/schema.ex
+++ b/lib/open_api_spex/schema.ex
@@ -325,8 +325,10 @@ defmodule OpenApiSpex.Schema do
   included in the `allOf` list.
   """
   def properties(schema = %Schema{type: :object, properties: properties = %{}}) do
-    for({name, property} <- properties, do: {name, default(property)}) ++
-      properties(%{schema | properties: nil})
+    properties
+    |> Enum.map(fn {name, property} -> {name, default(property)} end)
+    |> Enum.concat(properties(%{schema | properties: nil}))
+    |> Enum.uniq_by(fn {name, _property} -> name end)
   end
 
   def properties(%Schema{allOf: schemas}) when is_list(schemas) do


### PR DESCRIPTION
I've noticed warnings caused by `OpenApiSpex.schema/1` which indicate that duplicated keys are passed to `defstruct` which makes impossible using `--warnings-as-errors` in CI.

```
warning: duplicate key :state found in struct
  (elixir 1.13.1) lib/kernel/utils.ex:135: Kernel.Utils.warn_on_duplicate_struct_key/1
  (elixir 1.13.1) lib/kernel/utils.ex:105: Kernel.Utils.defstruct/2
  ....:164: (module)
  (elixir 1.13.1) src/elixir_compiler.erl:73: :elixir_compiler.dispatch/4
  (elixir 1.13.1) src/elixir_compiler.erl:58: :elixir_compiler.compile/3
  (elixir 1.13.1) src/elixir_module.erl:369: :elixir_module.eval_form/6
  (elixir 1.13.1) src/elixir_module.erl:105: :elixir_module.compile/5
  ....: (module)
  (elixir 1.13.1) src/elixir_compiler.erl:73: :elixir_compiler.dispatch/4
  (elixir 1.13.1) src/elixir_compiler.erl:58: :elixir_compiler.compile/3
  (elixir 1.13.1) src/elixir_module.erl:369: :elixir_module.eval_form/6
  (elixir 1.13.1) src/elixir_module.erl:105: :elixir_module.compile/5
  (elixir 1.13.1) src/elixir_lexical.erl:15: :elixir_lexical.run/3
  (elixir 1.13.1) src/elixir_compiler.erl:18: :elixir_compiler.quoted/3
  (elixir 1.13.1) lib/kernel/parallel_compiler.ex:346: anonymous fn/5 in Kernel.ParallelCompiler.spawn_workers/7
 ```
 
 The problem occurs when schema and schema defined in allOf have the same property, ex:
 ```elixir
 defmodule AllOfWarning do
    require OpenApiSpex

    OpenApiSpex.schema(%{
      type: :object,
      allOf: [
        %Schema{
          type: :object,
          properties: %{
            state: %Schema{
              type: :string
            }
          }
        }
      ],
      properties: %{
        state: %Schema{
          type: :string
        }
      }
    })
  end
  ```
  
  Proposed changes fix the described issue