### PR TITLE
fix: allow empty content for Response

### DIFF
--- a/lib/open_api_spex/operation.ex
+++ b/lib/open_api_spex/operation.ex
@@ -139,8 +139,8 @@ defmodule OpenApiSpex.Operation do
   """
   @spec response(
           description :: String.t(),
-          media_type :: String.t() | %{String.t() => Keyword.t() | MediaType.t()},
-          schema_ref :: Schema.t() | Reference.t() | module,
+          media_type :: String.t() | %{String.t() => Keyword.t() | MediaType.t()} | nil,
+          schema_ref :: Schema.t() | Reference.t() | module | nil,
           opts :: keyword
         ) :: Response.t()
   def response(description, media_type, schema_ref, opts \\ []) do
@@ -158,7 +158,7 @@ defmodule OpenApiSpex.Operation do
     %Response{
       description: description,
       headers: opts[:headers],
-      content: build_content_map(media_type, content_opts)
+      content: build_response_content_map(media_type, content_opts)
     }
   end
 
@@ -303,6 +303,11 @@ defmodule OpenApiSpex.Operation do
     |> Schema.validate(params, schemas)
   end
 
+  defp build_response_content_map(nil, _media_type_opts), do: nil
+
+  defp build_response_content_map(media_type, media_type_opts),
+    do: build_content_map(media_type, media_type_opts)
+
   defp build_content_map(media_type, media_type_opts) when is_binary(media_type) do
     %{
       media_type => struct!(MediaType, media_type_opts)
@@ -317,6 +322,6 @@ defmodule OpenApiSpex.Operation do
   end
 
   defp build_content_map(media_types, _shared_opts) do
-    raise "Expected string or map for request_body: #{inspect(media_types)}"
+    raise "Expected string or map as a media type. Got: #{inspect(media_types)}"
   end
 end


### PR DESCRIPTION
#451 introduced a change that doesn't meet OpenAPI specification. https://spec.openapis.org/oas/v3.1.0#fixed-fields-14 - content can be empty. 

The mentioned change caused errors in following example
```
  operation(:operation,
    summary: "summary",
    description: "description",
    request_body: {nil, "application/json", SchemaRequest},
    responses: %{
      201 => {"Operation succeed", nil, nil}
    }
  )
```

```
** (RuntimeError) Expected string or map for request_body: nil
    (open_api_spex 3.11.0) lib/open_api_spex/operation.ex:320: OpenApiSpex.Operation.build_content_map/2
    (open_api_spex 3.11.0) lib/open_api_spex/operation.ex:161: OpenApiSpex.Operation.response/4
    (open_api_spex 3.11.0) lib/open_api_spex/operation_builder.ex:82: anonymous fn/1 in OpenApiSpex.OperationBuilder.build_responses/1
    (elixir 1.13.1) lib/enum.ex:1597: anonymous fn/3 in Enum.map/2
    (stdlib 3.17) maps.erl:410: :maps.fold_1/3
    (elixir 1.13.1) lib/enum.ex:2408: Enum.map/2
    (elixir 1.13.1) lib/map.ex:219: Map.new/2
    (open_api_spex 3.11.0) lib/open_api_spex/controller_specs.ex:393: OpenApiSpex.ControllerSpecs.operation_spec/3
    ...: (module)
```

This PR allows back to define empty response content 