### PR TITLE
fix: support RequestBody passed to operation macro

### DIFF
--- a/lib/open_api_spex/operation_builder.ex
+++ b/lib/open_api_spex/operation_builder.ex
@@ -1,7 +1,7 @@
 defmodule OpenApiSpex.OperationBuilder do
   @moduledoc false
 
-  alias OpenApiSpex.{ExternalDocumentation, Operation, Parameter, Reference, Response}
+  alias OpenApiSpex.{ExternalDocumentation, Operation, Parameter, Reference, RequestBody, Response}
   alias Plug.Conn.Status
 
   def ensure_type_and_schema_exclusive!(name, type, schema) do
@@ -113,6 +113,8 @@ defmodule OpenApiSpex.OperationBuilder do
   def build_request_body(%{body: {description, media_type, schema}}) do
     Operation.request_body(description, media_type, schema)
   end
+
+  def build_request_body(%{request_body: %RequestBody{} = request_body}), do: request_body
 
   def build_request_body(%{request_body: {description, media_type, schema}}) do
     Operation.request_body(description, media_type, schema)

--- a/test/controller_specs_test.exs
+++ b/test/controller_specs_test.exs
@@ -5,6 +5,7 @@ defmodule OpenApiSpex.ControllerSpecsTest do
 
   alias OpenApiSpex.{MediaType, RequestBody, Response}
   alias OpenApiSpexTest.DslController
+  alias OpenApiSpexTest.DslControllerOperationStructs
 
   describe "operation/1" do
     test "supports :parameters" do
@@ -64,6 +65,47 @@ defmodule OpenApiSpex.ControllerSpecsTest do
 
       assert %{"application/text" => media_type} = content
       assert media_type.example == "text example"
+    end
+
+    test "supports Parameter, RequestBody and Response structs" do
+      assert %OpenApiSpex.Operation{
+               summary: "Update user",
+               requestBody: request_body,
+               responses: responses
+             } = DslControllerOperationStructs.open_api_operation(:update)
+
+      assert %{200 => response} = responses
+
+      assert %Response{
+               content: content,
+               description: "User response",
+               headers: %{"content-type" => %OpenApiSpex.Header{}}
+             } = response
+
+      assert %{
+               "application/json" => %MediaType{
+                 schema: OpenApiSpexTest.DslController.UserResponse,
+                 example: "json example response"
+               },
+               "application/text" => %MediaType{
+                 schema: OpenApiSpexTest.DslController.UserResponse,
+                 example: "text example response"
+               }
+             } = content
+
+      assert %RequestBody{
+               content: %{
+                 "application/json" => %MediaType{
+                   schema: OpenApiSpexTest.DslController.UserParams,
+                   example: "json example request"
+                 },
+                 "application/text" => %MediaType{
+                   schema: OpenApiSpexTest.DslController.UserParams,
+                   example: "text example request"
+                 }
+               },
+               description: "User params"
+             } = request_body
     end
 
     test ":deprecated" do

--- a/test/support/dsl_controller_operation_structs.ex
+++ b/test/support/dsl_controller_operation_structs.ex
@@ -1,0 +1,58 @@
+defmodule OpenApiSpexTest.DslControllerOperationStructs do
+  use Phoenix.Controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias OpenApiSpex.Operation
+
+  alias OpenApiSpexTest.DslController
+
+  tags ["users"]
+
+  security [%{"api_key" => ["mySecurityScheme"]}]
+
+  operation :update,
+    summary: "Update user",
+    parameters: [
+      Operation.parameter(:id, :path, :integer, "User ID", example: 1001)
+    ],
+    request_body:
+      Operation.request_body(
+        "User params",
+        %{
+          "application/json" => [example: "json example request"],
+          "application/text" => [example: "text example request"]
+        },
+        DslController.UserParams
+      ),
+    responses: [
+      ok:
+        Operation.response(
+          "User response",
+          %{
+            "application/json" => [example: "json example response"],
+            "application/text" => [example: "text example response"]
+          },
+          DslController.UserResponse,
+          headers: %{
+            "content-type" => %OpenApiSpex.Header{
+              description: "Type of the content for the response",
+              example: "content-type: application/json; charset=utf-8"
+            }
+          }
+        )
+    ],
+    tags: ["custom"],
+    security: [%{"two" => ["another"]}]
+
+  def update(conn, %{"id" => id}) do
+    conn
+    |> put_resp_header("content-type", "application/json; charset=utf-8")
+    |> json(%{
+      data: %{
+        id: id,
+        name: "joe user",
+        email: "joe@gmail.com"
+      }
+    })
+  end
+end


### PR DESCRIPTION
The operation macro currently supports passing arguments for url params, request body and response schemas in a "simplified" way (as tuples/keyword lists).

It also supports passing operation structs like `%Parameter{}` and `%Response{}`.

However, it didn't support passing `%RequestBody{}`, for example this:

```elixir
operation :update
  summary: "Update user",
  request_body: %RequestBody{
    #...
  }
  # ...
```

would result in `%Operation{requestBody: nil}`.

This changeset fixes it so that we get the expected behaviour of
`%Operation{requestBody: %RequestBody{}}`.

Fixes: https://github.com/open-api-spex/open_api_spex/issues/457