### PR TITLE
Allow to configure casting to not automatically populate default values

### DIFF
--- a/lib/open_api_spex.ex
+++ b/lib/open_api_spex.ex
@@ -77,7 +77,7 @@ defmodule OpenApiSpex do
     OpenApiSpex.Cast.cast(schema, value, spec.components.schemas)
   end
 
-  @type cast_opt :: {:replace_params, boolean()}
+  @type cast_opt :: {:replace_params, boolean()} | {:apply_defaults, boolean()}
 
   @spec cast_and_validate(
           OpenApi.t(),

--- a/lib/open_api_spex/cast.ex
+++ b/lib/open_api_spex/cast.ex
@@ -22,6 +22,8 @@ defmodule OpenApiSpex.Cast do
 
   @type schema_or_reference :: Schema.t() | Reference.t()
 
+  @type cast_opt :: {:apply_defaults, boolean()}
+
   @type t :: %__MODULE__{
           value: term(),
           schema: schema_or_reference | nil,
@@ -30,7 +32,8 @@ defmodule OpenApiSpex.Cast do
           key: atom() | nil,
           index: integer,
           errors: [Error.t()],
-          read_write_scope: read_write_scope
+          read_write_scope: read_write_scope,
+          opts: [cast_opt()]
         }
 
   defstruct value: nil,
@@ -40,7 +43,8 @@ defmodule OpenApiSpex.Cast do
             key: nil,
             index: 0,
             errors: [],
-            read_write_scope: nil
+            read_write_scope: nil,
+            opts: []
 
   @doc ~S"""
   Cast and validate a value against the given schema.
@@ -96,9 +100,10 @@ defmodule OpenApiSpex.Cast do
 
   """
 
-  @spec cast(schema_or_reference | nil, term(), map()) :: {:ok, term()} | {:error, [Error.t()]}
-  def cast(schema, value, schemas \\ %{}) do
-    ctx = %__MODULE__{schema: schema, value: value, schemas: schemas}
+  @spec cast(schema_or_reference | nil, term(), map(), [cast_opt()]) ::
+          {:ok, term()} | {:error, [Error.t()]}
+  def cast(schema, value, schemas \\ %{}, opts \\ []) do
+    ctx = %__MODULE__{schema: schema, value: value, schemas: schemas, opts: opts}
     cast(ctx)
   end
 

--- a/lib/open_api_spex/cast/object.ex
+++ b/lib/open_api_spex/cast/object.ex
@@ -26,7 +26,13 @@ defmodule OpenApiSpex.Cast.Object do
          :ok <- check_max_properties(ctx),
          :ok <- check_min_properties(ctx),
          {:ok, value} <- cast_properties(%{ctx | schema: resolved_schema_properties}) do
-      value_with_defaults = apply_defaults(value, resolved_schema_properties)
+      value_with_defaults =
+        if Keyword.get(ctx.opts, :apply_defaults, true) do
+          apply_defaults(value, resolved_schema_properties)
+        else
+          value
+        end
+
       ctx = to_struct(%{ctx | value: value_with_defaults})
       {:ok, ctx}
     end

--- a/test/cast/object_test.exs
+++ b/test/cast/object_test.exs
@@ -134,6 +134,18 @@ defmodule OpenApiSpex.ObjectTest do
       assert cast(value: %{name: "Robin"}, schema: schema) == {:ok, %{name: "Robin"}}
     end
 
+    test "fields with default values and apply_defaults config" do
+      schema = %Schema{
+        type: :object,
+        properties: %{name: %Schema{type: :string, default: "Rubi"}}
+      }
+
+      assert cast(value: %{}, schema: schema, opts: [apply_defaults: true]) ==
+               {:ok, %{name: "Rubi"}}
+
+      assert cast(value: %{}, schema: schema, opts: [apply_defaults: false]) == {:ok, %{}}
+    end
+
     test "explicitly passing nil for fields with default values (not nullable)" do
       schema = %Schema{
         type: :object,

--- a/test/cast_test.exs
+++ b/test/cast_test.exs
@@ -221,6 +221,25 @@ defmodule OpenApiSpec.CastTest do
       assert error.path == [:age]
       assert Error.message_with_path(error) == "#/age: Invalid strict_integer. Got: string"
     end
+
+    test "apply defaults configuration" do
+      schema = %Schema{
+        type: :object,
+        properties: %{
+          data: %Schema{
+            type: :string,
+            default: "default"
+          }
+        }
+      }
+
+      assert {:ok, %{}} == cast(value: %{}, schema: schema, opts: [apply_defaults: false])
+
+      assert {:ok, %{data: "default"}} ==
+               cast(value: %{}, schema: schema, opts: [apply_defaults: true])
+
+      assert {:ok, %{data: "default"}} == cast(value: %{}, schema: schema)
+    end
   end
 
   describe "ok/1" do


### PR DESCRIPTION
Added an option to disable the auto-population of default values in casted parameters.
The configuration is optional and by default the old behaviour (populate the default values) is preserved