### PR TITLE
Validate :integer type format

### DIFF
--- a/lib/open_api_spex/cast/integer.ex
+++ b/lib/open_api_spex/cast/integer.ex
@@ -2,6 +2,11 @@ defmodule OpenApiSpex.Cast.Integer do
   @moduledoc false
   alias OpenApiSpex.Cast
 
+  @min_int32 -2_147_483_647
+  @max_int32 2_147_483_647
+  @min_int64 -9_223_372_036_854_775_807
+  @max_int64 9_223_372_036_854_775_807
+
   def cast(%{value: value} = ctx) when is_integer(value) do
     case cast_integer(ctx) do
       {:cast, ctx} -> cast(ctx)
@@ -25,6 +30,16 @@ defmodule OpenApiSpex.Cast.Integer do
   end
 
   ## Private functions
+
+  defp cast_integer(%{value: value, schema: %{format: :int32}} = ctx)
+       when value < @min_int32 or value > @max_int32 do
+    Cast.error(ctx, {:invalid_format, :int32})
+  end
+
+  defp cast_integer(%{value: value, schema: %{format: :int64}} = ctx)
+       when value < @min_int64 or value > @max_int64 do
+    Cast.error(ctx, {:invalid_format, :int64})
+  end
 
   defp cast_integer(%{value: value, schema: %{minimum: minimum, exclusiveMinimum: true}} = ctx)
        when is_integer(value) and is_integer(minimum) do

--- a/test/cast/integer_test.exs
+++ b/test/cast/integer_test.exs
@@ -72,5 +72,29 @@ defmodule OpenApiSpex.CastIntegerTest do
       assert error.length == 2
       assert Error.message(error) =~ "larger than exclusive maximum"
     end
+
+    test "format int32" do
+      schema = %Schema{type: :integer, format: :int32}
+      # less than max int32
+      assert {:error, [error]} = cast(value: -2_147_483_648, schema: schema)
+      assert error.reason == :invalid_format
+      assert error.format == :int32
+      # over max int32
+      assert {:error, [error]} = cast(value: 2_147_483_648, schema: schema)
+      assert error.reason == :invalid_format
+      assert error.format == :int32
+    end
+
+    test "format int64" do
+      schema = %Schema{type: :integer, format: :int64}
+      # less than max int64
+      assert {:error, [error]} = cast(value: -9_223_372_036_854_775_808, schema: schema)
+      assert error.reason == :invalid_format
+      assert error.format == :int64
+      # over max int64
+      assert {:error, [error]} = cast(value: 9_223_372_036_854_775_808, schema: schema)
+      assert error.reason == :invalid_format
+      assert error.format == :int64
+    end
   end
 end


### PR DESCRIPTION
Validate min/max for both `:int32` and `:int64` format. It'll returns
`:invalid_format` when the value is outside of their range.

Fixes #402