### PR TITLE
Correctly cast not map bodies (plug puts them under _json key)

### DIFF
--- a/lib/open_api_spex/operation2.ex
+++ b/lib/open_api_spex/operation2.ex
@@ -75,20 +75,14 @@ defmodule OpenApiSpex.Operation2 do
   # Special case to handle strings or arrays in request body that come inside _json
   # https://hexdocs.pm/plug/Plug.Parsers.JSON.html
   defp cast_request_body(
-         %RequestBody{content: content},
-         body = %{"_json" => params},
+         request_body,
+         %{"_json" => body_params},
          content_type,
          components = %Components{}
        ) do
-    case content do
-      %{^content_type => media_type} ->
-        case Cast.cast(media_type.schema, params, components.schemas) do
-          {:ok, _} -> {:ok, body}
-          error -> error
-        end
-
-      _ ->
-        {:error, [Error.new(%{path: [], value: content_type}, {:invalid_header, "content-type"})]}
+    case cast_request_body(request_body, body_params, content_type, components) do
+      {:ok, body_params} -> {:ok, %{"_json" => body_params}}
+      error -> error
     end
   end
 

--- a/test/operation2_test.exs
+++ b/test/operation2_test.exs
@@ -206,6 +206,8 @@ defmodule OpenApiSpex.Operation2Test do
                )
 
       assert %Plug.Conn{} = conn
+
+      assert conn.body_params == %{"_json" => [%{user: %{email: "foo@bar.com"}}]}
     end
 
     test "cast request body - invalid data type" do


### PR DESCRIPTION
At the moment the casted value of not map bodies is simply discarded