### PR TITLE
fix decoding of discriminators when `type: object` is present

### DIFF
--- a/lib/open_api_spex/open_api/decode.ex
+++ b/lib/open_api_spex/open_api/decode.ex
@@ -224,22 +224,6 @@ defmodule OpenApiSpex.OpenApi.Decode do
     |> add_extensions(map)
   end
 
-  defp to_struct(%{"type" => "object"} = map, Schema) do
-    map
-    |> Map.update("properties", %{}, fn v ->
-      v
-      |> Map.new(fn {k, v} ->
-        {String.to_atom(k), v}
-      end)
-    end)
-    |> prepare_schema()
-    |> (&struct_from_map(Schema, &1)).()
-    |> prop_to_struct(:properties, Schemas)
-    |> manage_additional_properties()
-    |> prop_to_struct(:externalDocs, ExternalDocumentation)
-    |> add_extensions(map)
-  end
-
   defp to_struct(%{"anyOf" => _valid_schemas} = map, Schema) do
     Schema
     |> struct_from_map(map)
@@ -261,6 +245,22 @@ defmodule OpenApiSpex.OpenApi.Decode do
     |> struct_from_map(map)
     |> prop_to_struct(:allOf, Schemas)
     |> prop_to_struct(:discriminator, Discriminator)
+    |> add_extensions(map)
+  end
+
+  defp to_struct(%{"type" => "object"} = map, Schema) do
+    map
+    |> Map.update("properties", %{}, fn v ->
+      v
+      |> Map.new(fn {k, v} ->
+        {String.to_atom(k), v}
+      end)
+    end)
+    |> prepare_schema()
+    |> (&struct_from_map(Schema, &1)).()
+    |> prop_to_struct(:properties, Schemas)
+    |> manage_additional_properties()
+    |> prop_to_struct(:externalDocs, ExternalDocumentation)
     |> add_extensions(map)
   end
 

--- a/test/open_api/decode_test.exs
+++ b/test/open_api/decode_test.exs
@@ -173,7 +173,8 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
 
       assert %{
                "User" => user_schema,
-               "Admin" => admin_schema
+               "Admin" => admin_schema,
+               "DiscriminatorWithType" => disc_with_type
              } = schemas
 
       assert %OpenApiSpex.Schema{
@@ -190,6 +191,21 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
                  extensions: %{"x-custom-info" => %{"codeowners" => "team-rocker"}}
                }
              } == admin_schema
+
+      assert %OpenApiSpex.Schema{
+               oneOf: [
+                 %OpenApiSpex.Reference{
+                   "$ref": "#/components/schemas/User"
+                 },
+                 %OpenApiSpex.Reference{
+                   "$ref": "#/components/schemas/SpecialUser"
+                 }
+               ],
+               discriminator: %OpenApiSpex.Discriminator{
+                 propertyName: "userType"
+               },
+               type: "object"
+             } == disc_with_type
 
       assert %OpenApiSpex.Schema{
                nullable: false,

--- a/test/support/encoded_schema.json
+++ b/test/support/encoded_schema.json
@@ -230,6 +230,20 @@
           }
         }
       },
+      "DiscriminatorWithType": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "userType"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/User"
+          },
+          {
+            "$ref": "#/components/schemas/SpecialUser"
+          }
+        ]
+      },
       "MetadataObject": {
         "description": "Maximum 3 lines of metadata allowed",
         "type": "object",


### PR DESCRIPTION
This simply change the order of evalutaion during decode phase checking first if a discriminator is present and then decoding it as an object.

Without this fix the new test would have returned:

```elixir
%OpenApiSpex.Schema%{
  discriminator: %{
    "propertyName" => "userType"
  },
  oneOf: [
    %{"$ref" => "#/components/schemas/User"},
    %{"$ref" => "#/components/schemas/SpecialUser"}
  ],
  properties: %{},
  type: :object
}
```

instead of 

```elixir
%OpenApiSpex.Schema%{
  discriminator: %OpenApiSpex.Discriminator{
    extensions: nil,
    mapping: nil,
    propertyName: "userType"
  },
  oneOf: [
    %OpenApiSpex.Reference{"$ref": "#/components/schemas/User"},
    %OpenApiSpex.Reference{"$ref": "#/components/schemas/SpecialUser"}
  ],
  type: "object"
}
```