### PR TITLE
Build and publish a hex.pm package automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  release:
+    types:
+      - released
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+
+      - uses: erlef/setup-beam@v1
+        id: beam
+        with:
+          otp-version: 25
+          elixir-version: 1.13
+
+      - id: build
+        name: Build package
+        run: |
+          mix hex.build
+
+      - id: publish
+        name: Publish package to hex.pm
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+        run: |
+          mix hex.publish --yes


### PR DESCRIPTION
The goal of this PR is to have a GH action build and then publish a new hex.pm package version when a tag starting with `v` is pushed.

We'll still need to push a commit like e588b0febf0 to bump the version is mix.exs and update the changelog before cutting a release.

#### Requirements

We have to set `secrets.HEX_API_KEY`.