### PR TITLE
Always fetch and compile dependencies when publishing to Hex

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,11 @@ jobs:
           otp-version: 25
           elixir-version: 1.13
 
+      - id: deps
+        name: Fetch and compile dependencies
+        run: |
+          mix do deps.get, deps.compile
+
       - id: build
         name: Build package
         run: |


### PR DESCRIPTION
This is a follow-up for https://github.com/open-api-spex/open_api_spex/pull/474 fixing [this error](https://github.com/open-api-spex/open_api_spex/runs/7436105904?check_suite_focus=true)