### PR TITLE
Fix compilation warnings

### DIFF
--- a/lib/open_api_spex/open_api.ex
+++ b/lib/open_api_spex/open_api.ex
@@ -71,6 +71,7 @@ defmodule OpenApiSpex.OpenApi do
   @callback spec() :: t
 
   @json_encoder Enum.find([Jason, Poison], &Code.ensure_loaded?/1)
+  @yaml_encoder nil
   @vendor_extensions ~w(
     x-struct
     x-validate

--- a/lib/open_api_spex/plug/render_spec.ex
+++ b/lib/open_api_spex/plug/render_spec.ex
@@ -23,8 +23,6 @@ defmodule OpenApiSpex.Plug.RenderSpec do
       end
   """
 
-  alias OpenApiSpex.Plug.PutApiSpec
-
   @behaviour Plug
 
   @json_encoder Enum.find([Jason, Poison], &Code.ensure_loaded?/1)
@@ -35,18 +33,16 @@ defmodule OpenApiSpex.Plug.RenderSpec do
   if @json_encoder do
     @impl Plug
     def call(conn, _opts) do
-      {spec, _} = PutApiSpec.get_spec_and_operation_lookup(conn)
+      {spec, _} = OpenApiSpex.Plug.PutApiSpec.get_spec_and_operation_lookup(conn)
 
       conn
       |> Plug.Conn.put_resp_content_type("application/json")
       |> Plug.Conn.send_resp(200, @json_encoder.encode!(spec))
     end
   else
-    @impl Plug
-    def call(conn, _opts) do
-      IO.warn("No JSON encoder found. Please add :json or :poison in your mix dependencies.")
+    IO.warn("No JSON encoder found. Please add :json or :poison in your mix dependencies.")
 
-      conn
-    end
+    @impl Plug
+    def call(conn, _opts), do: conn
   end
 end

--- a/lib/open_api_spex/plug/render_spec.ex
+++ b/lib/open_api_spex/plug/render_spec.ex
@@ -32,12 +32,21 @@ defmodule OpenApiSpex.Plug.RenderSpec do
   @impl Plug
   def init(opts), do: opts
 
-  @impl Plug
-  def call(conn, _opts) do
-    {spec, _} = PutApiSpec.get_spec_and_operation_lookup(conn)
+  if @json_encoder do
+    @impl Plug
+    def call(conn, _opts) do
+      {spec, _} = PutApiSpec.get_spec_and_operation_lookup(conn)
 
-    conn
-    |> Plug.Conn.put_resp_content_type("application/json")
-    |> Plug.Conn.send_resp(200, @json_encoder.encode!(spec))
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(200, @json_encoder.encode!(spec))
+    end
+  else
+    @impl Plug
+    def call(conn, _opts) do
+      IO.warn("No JSON encoder found. Please add :json or :poison in your mix dependencies.")
+
+      conn
+    end
   end
 end

--- a/lib/open_api_spex/plug/render_spec.ex
+++ b/lib/open_api_spex/plug/render_spec.ex
@@ -33,6 +33,7 @@ defmodule OpenApiSpex.Plug.RenderSpec do
   if @json_encoder do
     @impl Plug
     def call(conn, _opts) do
+      # credo:disable-for-this-file Credo.Check.Design.AliasUsage
       {spec, _} = OpenApiSpex.Plug.PutApiSpec.get_spec_and_operation_lookup(conn)
 
       conn

--- a/lib/open_api_spex/plug/swagger_ui.ex
+++ b/lib/open_api_spex/plug/swagger_ui.ex
@@ -192,10 +192,12 @@ defmodule OpenApiSpex.Plug.SwaggerUI do
     end
   end
 
-  defp supplement_config(%{oauth2_redirect_url: {:endpoint_url, path}} = config, conn) do
-    endpoint_module = Phoenix.Controller.endpoint_module(conn)
-    url = Path.join(endpoint_module.url(), path)
-    Map.put(config, :oauth2_redirect_url, url)
+  if Code.ensure_loaded?(Phoenix.Controller) do
+    defp supplement_config(%{oauth2_redirect_url: {:endpoint_url, path}} = config, conn) do
+      endpoint_module = Phoenix.Controller.endpoint_module(conn)
+      url = Path.join(endpoint_module.url(), path)
+      Map.put(config, :oauth2_redirect_url, url)
+    end
   end
 
   defp supplement_config(config, _conn) do


### PR DESCRIPTION
Fixes the following compilation warnings:

```
warning: undefined module attribute @yaml_encoder, please remove access to @yaml_encoder or explicitly set it
before access
  lib/open_api_spex/open_api.ex:108: OpenApiSpex.OpenApi (module)

warning: Phoenix.Controller.endpoint_module/1 is undefined (module Phoenix.Controller is not available or is y
et to be defined)
  lib/open_api_spex/plug/swagger_ui.ex:196: OpenApiSpex.Plug.SwaggerUI.supplement_config/2
```

It also fixes the following warning which appears when there's no available JSON encoder:

```
warning: nil.encode!/1 is undefined (module nil is not available or is yet to be defined)
  lib/open_api_spex/plug/render_spec.ex:41: OpenApiSpex.Plug.RenderSpec.call/2
```

Resolves https://github.com/open-api-spex/open_api_spex/issues/475