### PR TITLE
Document OpenApiSpex.Plug.NoneCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,13 @@ scope "/api" do
 end
 ```
 
+In development, to ensure the rendered spec is refreshed, you should disable caching with:
+
+```elixir
+# config/dev.exs
+config :open_api_spex, :cache_adapter, OpenApiSpex.Plug.NoneCache
+```
+
 ## Generating the Spec
 
 You can write the swagger file to disk using the following Mix task and optionally, for your

--- a/lib/open_api_spex/plug/cache.ex
+++ b/lib/open_api_spex/plug/cache.ex
@@ -1,6 +1,6 @@
 defmodule OpenApiSpex.Plug.Cache do
   @moduledoc """
-  Cache for OpenApiSpex
+  Cache for OpenApiSpex API specs.
 
   Settings:
 
@@ -8,13 +8,14 @@ defmodule OpenApiSpex.Plug.Cache do
   config :open_api_spex, :cache_adapter, Module
   ```
 
-  There are already had three cache adapter:
+  There are three cache implementations:
+
   * `OpenApiSpex.Plug.PersistentTermCache` - default
-  * `OpenApiSpex.Plug.AppEnvCache` - if VM not supported `persistent_term`
+  * `OpenApiSpex.Plug.AppEnvCache` - for VMs that don't support `persistent_term`
   * `OpenApiSpex.Plug.NoneCache` - none cache
 
-  If you are constantly modifying specs during development, you can setting
-  like this in `dev.exs`:
+  If you are constantly modifying specs during development, you can configure the cache adapter
+  in `dev.exs` as follows to disable caching:
 
   ```elixir
   config :open_api_spex, :cache_adapter, OpenApiSpex.Plug.NoneCache

--- a/lib/open_api_spex/plug/none_cache.ex
+++ b/lib/open_api_spex/plug/none_cache.ex
@@ -1,5 +1,14 @@
 defmodule OpenApiSpex.Plug.NoneCache do
-  @moduledoc false
+  @moduledoc """
+  A cache adapter to disable caching. Intended to be used in development.
+
+  Configure it with:
+
+  ```elixir
+  # config/dev.exs
+  config :open_api_spex, :cache_adapter, OpenApiSpex.Plug.NoneCache
+  ```
+  """
 
   @behaviour OpenApiSpex.Plug.Cache
 


### PR DESCRIPTION
See: https://github.com/open-api-spex/open_api_spex/issues/476

Some users might miss that there's a way to disable API spec caching and they may be restarting their app after every spec change.