### PR TITLE
Allow users to use poison 3.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,7 @@ defmodule OpenApiSpex.Mixfile do
       {:jason, "~> 1.0", optional: true},
       {:phoenix, "~> 1.3", only: [:dev, :test]},
       {:plug, "~> 1.7"},
-      {:poison, "~> 4.0 or ~> 5.0", optional: true},
+      {:poison, "~> 3.0 or ~> 4.0 or ~> 5.0", optional: true},
       {:ymlr, "~> 2.0", optional: true}
     ]
   end


### PR DESCRIPTION
A prior change that was merged broke usage of poison 3.0

https://github.com/open-api-spex/open_api_spex/pull/377/commits/5c0a83a7ab653a06840848cbf96960b976254727#diff-dfa6f4ed74c90e5d4fda283d547d366586e690387289bcfd473e3fa5f9ace308

This forces all users who still have incompatible apps to upgrade even though the dependency is optional.

This PR adds 3.0 back to the list, as it is a breaking change for those with dependencies in umbrellas using 3.0.
