### PR TITLE
`not` schemas not correctly decoded

### DIFF
--- a/lib/open_api_spex/open_api/decode.ex
+++ b/lib/open_api_spex/open_api/decode.ex
@@ -267,7 +267,7 @@ defmodule OpenApiSpex.OpenApi.Decode do
   defp to_struct(%{"not" => _valid_schemas} = map, Schema) do
     Schema
     |> struct_from_map(map)
-    |> prop_to_struct(:not, Schemas)
+    |> prop_to_struct(:not, Schema)
     |> add_extensions(map)
   end
 

--- a/test/open_api/decode_test.exs
+++ b/test/open_api/decode_test.exs
@@ -174,8 +174,11 @@ defmodule OpenApiSpex.OpenApi.DecodeTest do
       assert %{
                "User" => user_schema,
                "Admin" => admin_schema,
-               "DiscriminatorWithType" => disc_with_type
+               "DiscriminatorWithType" => disc_with_type,
+               "Not" => not_schema
              } = schemas
+
+      assert %OpenApiSpex.Schema{not: %OpenApiSpex.Schema{type: :string}} == not_schema
 
       assert %OpenApiSpex.Schema{
                allOf: [

--- a/test/support/encoded_schema.json
+++ b/test/support/encoded_schema.json
@@ -271,6 +271,11 @@
             "type": "object"
           }
         ]
+      },
+      "Not": {
+        "not": {
+          "type": "string"
+        }
       }
     },
     "links": {


### PR DESCRIPTION
Schemas with a `not` keyword were not correctly decoded