### PR TITLE
Allow omitting parens for test assertion functions

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -15,7 +15,11 @@
     locals_without_parens: [
       operation: 2,
       tags: 1,
-      security: 1
+      security: 1,
+      assert_schema: 1,
+      assert_schema: 3,
+      assert_request_schema: 3,
+      assert_response_schema: 3
     ]
   ]
 ]


### PR DESCRIPTION
Similar to how ExUnit's [assert](https://hexdocs.pm/ex_unit/ExUnit.Assertions.html#assert/1) does not require parentheses we should follow the same convention for this library's test assertion functions. 