### PR TITLE
Fix mix config warnings in examples

### DIFF
--- a/examples/plug_app/config/config.exs
+++ b/examples/plug_app/config/config.exs
@@ -1,6 +1,4 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 config :plug_app, ecto_repos: [PlugApp.Repo]
 
@@ -10,6 +8,6 @@ config :plug_app, PlugApp.Repo,
 
 config :logger, level: :debug
 
-if File.exists?(Path.join("config", "#{Mix.env()}.exs")) do
-  import_config "#{Mix.env()}.exs"
+if File.exists?(Path.join("config", "#{config_env()}.exs")) do
+  import_config "#{config_env()}.exs"
 end

--- a/examples/plug_app/config/test.exs
+++ b/examples/plug_app/config/test.exs
@@ -1,3 +1,6 @@
-use Mix.Config
+import Config
+
+# Print only warnings and errors during test
+config :logger, level: :warn
 
 config :plug_app, PlugApp.Repo, pool: Ecto.Adapters.SQL.Sandbox

--- a/examples/plug_app/test/test_helper.exs
+++ b/examples/plug_app/test/test_helper.exs
@@ -1,1 +1,2 @@
+Code.put_compiler_option(:warnings_as_errors, true)
 ExUnit.start()

--- a/examples/plug_app/test/user_handler_test.exs
+++ b/examples/plug_app/test/user_handler_test.exs
@@ -27,7 +27,7 @@ defmodule UserHandlerTest do
 
       json_response = Jason.decode!(body)
 
-      assert %{"data" => [%{"id" => user_id}]} = json_response
+      assert %{"data" => [%{"id" => ^user_id}]} = json_response
 
       assert_schema(json_response, "UsersResponse", api_spec)
     end
@@ -53,7 +53,7 @@ defmodule UserHandlerTest do
 
       json_response = Jason.decode!(body)
 
-      assert %{"data" => %{"id" => user_id}} = json_response
+      assert %{"data" => %{"id" => ^user_id}} = json_response
 
       assert_schema(json_response, "UserResponse", api_spec)
     end
@@ -62,7 +62,9 @@ defmodule UserHandlerTest do
   describe "POST /api/users" do
     @payload example(Schemas.UserRequest)
 
-    test "responds with 201 Created and a JSON body matching the API schema", %{api_spec: api_spec} do
+    test "responds with 201 Created and a JSON body matching the API schema", %{
+      api_spec: api_spec
+    } do
       %{resp_body: body} =
         conn =
         conn(:post, "/api/users", Jason.encode!(@payload))
@@ -84,9 +86,10 @@ defmodule UserHandlerTest do
       }
     }
 
-    test "responds with 422 Unprocessable Entity and a JSON body matching the API schema when ", %{
-      api_spec: api_spec
-    } do
+    test "responds with 422 Unprocessable Entity and a JSON body matching the API schema when ",
+         %{
+           api_spec: api_spec
+         } do
       %{resp_body: body} =
         conn =
         conn(:post, "/api/users", Jason.encode!(@payload))


### PR DESCRIPTION
This PR brings the following changes:

* Ensures there are no compilation warnings in examples/plug_app
* Catches warnings in CI builds
* Adds a `.formatter.exs` in examples/plug_app