### PR TITLE
Allow casting atoms as strings

### DIFF
--- a/lib/open_api_spex/cast.ex
+++ b/lib/open_api_spex/cast.ex
@@ -65,14 +65,14 @@ defmodule OpenApiSpex.Cast do
       iex> schema = %Schema{type: :string}
       iex> Cast.cast(schema, "a string")
       {:ok, "a string"}
-      iex> Cast.cast(schema, :not_a_string)
+      iex> Cast.cast(schema, 1..100)
       {
         :error,
         [
           %OpenApiSpex.Cast.Error{
             reason: :invalid_type,
             type: :string,
-            value: :not_a_string
+            value: 1..100
           }
         ]
       }

--- a/lib/open_api_spex/cast/string.ex
+++ b/lib/open_api_spex/cast/string.ex
@@ -106,6 +106,13 @@ defmodule OpenApiSpex.Cast.String do
     {:ok, value}
   end
 
+  def cast(%{value: value} = ctx) when is_atom(value) and value not in [true, false, nil] do
+    case cast(%{ctx | value: to_string(value)}) do
+      {:ok, _value} -> {:ok, value}
+      error -> error
+    end
+  end
+
   def cast(%{value: value} = ctx) when is_binary(value) do
     apply_validation(ctx, @schema_fields)
   end

--- a/test/test_assertions_test.exs
+++ b/test/test_assertions_test.exs
@@ -13,7 +13,7 @@ defmodule OpenApiSpex.TestAssertionsTest do
 
     test "failure" do
       schema = %Schema{type: :string}
-      cast_context = %Cast{value: :nope, schema: schema}
+      cast_context = %Cast{value: 1.100, schema: schema}
 
       try do
         TestAssertions.assert_schema(cast_context)


### PR DESCRIPTION
open_api_spex already knows how to treat atoms as string-like types in enums ([example](https://github.com/open-api-spex/open_api_spex/blob/master/test/cast/enum_test.exs#L43)). 
This PR expands this behaviour to strings so that casting an atom value into a :string schema won't fail.