### PR TITLE
Implement casting of "byte" string type

### DIFF
--- a/lib/open_api_spex/cast/string.ex
+++ b/lib/open_api_spex/cast/string.ex
@@ -30,6 +30,16 @@ defmodule OpenApiSpex.Cast.String do
     end
   end
 
+  def cast(%{value: value, schema: %{format: :byte}} = ctx) when is_binary(value) do
+    case Base.decode64(value) do
+      {:ok, _} = result ->
+        result
+
+      _ ->
+        Cast.error(ctx, {:invalid_format, :base64})
+    end
+  end
+
   @uuid_valid_characters [
     ?0,
     ?1,

--- a/test/cast/string_test.exs
+++ b/test/cast/string_test.exs
@@ -50,6 +50,16 @@ defmodule OpenApiSpex.CastStringTest do
       assert error.format == :date
     end
 
+    test "string with format (byte)" do
+      schema = %Schema{type: :string, format: :byte}
+      date_string = Base.encode64("hello")
+      assert {:ok, "hello"} = cast(value: date_string, schema: schema)
+      assert {:error, [error]} = cast(value: "not-a-base64-string", schema: schema)
+      assert error.reason == :invalid_format
+      assert error.value == "not-a-base64-string"
+      assert error.format == :base64
+    end
+
     test "casts a string with valid uuid format" do
       schema = %Schema{type: :string, format: :uuid}
 


### PR DESCRIPTION
According to OpenAPI spec version 3.0, strings of format "byte" contain base64-encoded values.

For context, handling of string format has changed in 3.1, see: https://github.com/OAI/OpenAPI-Specification/pull/2200
