### PR TITLE
Resolve schema modules in discriminator mapping

### DIFF
--- a/test/schema_resolver_test.exs
+++ b/test/schema_resolver_test.exs
@@ -134,6 +134,25 @@ defmodule OpenApiSpex.SchemaResolverTest do
               }
             }
           }
+        },
+        "/api/appointsments" => %PathItem{
+          post: %Operation{
+            description: "Create a new pet appointment",
+            operationId: "PetAppointmentController.create",
+            requestBody: %RequestBody{
+              required: true,
+              content: %{
+                "application/json" => %MediaType{
+                  schema: OpenApiSpexTest.Schemas.PetAppointmentRequest
+                }
+              }
+            },
+            responses: %{
+              201 => %Response{
+                description: "Appointment created"
+              }
+            }
+          }
         }
       }
     }
@@ -149,6 +168,12 @@ defmodule OpenApiSpex.SchemaResolverTest do
     assert %Reference{"$ref": "#/components/schemas/UserRequest"} =
              resolved.paths["/api/users"].post.requestBody.content["application/json"].schema
 
+    assert "#/components/schemas/TrainingAppointment" =
+             resolved.components.schemas["PetAppointmentRequest"].discriminator.mapping["training"]
+
+    assert "#/components/schemas/GroomingAppointment" =
+             resolved.components.schemas["PetAppointmentRequest"].discriminator.mapping["grooming"]
+
     assert %{
              "UserRequest" => %Schema{},
              "UserResponse" => %Schema{},
@@ -156,7 +181,10 @@ defmodule OpenApiSpex.SchemaResolverTest do
              "UserSubscribeRequest" => %Schema{},
              "PaymentDetails" => %Schema{},
              "CreditCardPaymentDetails" => %Schema{},
-             "DirectDebitPaymentDetails" => %Schema{}
+             "DirectDebitPaymentDetails" => %Schema{},
+             "PetAppointmentRequest" => %Schema{},
+             "TrainingAppointment" => %Schema{},
+             "GroomingAppointment" => %Schema{}
            } = resolved.components.schemas
 
     get_friends = resolved.paths["/api/users/{id}/friends"].get

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -645,8 +645,8 @@ defmodule OpenApiSpexTest.Schemas do
       discriminator: %OpenApiSpex.Discriminator{
         propertyName: "appointment_type",
         mapping: %{
-          "training" => "TrainingAppointment",
-          "grooming" => "GroomingAppointment"
+          "training" => TrainingAppointment,
+          "grooming" => GroomingAppointment
         }
       }
     })


### PR DESCRIPTION
fixes #387

Given a schemas such as `PetAppointmentRequest` from the test suite:

```elixir
defmodule PetAppointmentRequest do
    OpenApiSpex.schema(%{
      title: "PetAppointmentRequest",
      description: "POST body for making a pet appointment",
      type: :object,
      oneOf: [
        TrainingAppointment,
        GroomingAppointment
      ],
      discriminator: %OpenApiSpex.Discriminator{
        propertyName: "appointment_type",
        mapping: %{
          "training" => TrainingAppointment,
          "grooming" => GroomingAppointment
        }
      }
    })
  end
```

The `resolve_schema_modules` function will now replace modules appearing in the `discriminator.property.mapping` map, with the appropriate path to the schema, eg "#/components/schemas/TrainingAppointment".


Rendered to JSON gives:

```json
      "PetAppointmentRequest": {
        "description": "POST body for making a pet appointment",
        "discriminator": {
          "mapping": {
            "grooming": "#/components/schemas/GroomingAppointment",
            "training": "#/components/schemas/TrainingAppointment"
          },
          "propertyName": "appointment_type"
        },
        "oneOf": [
          {
            "$ref": "#/components/schemas/TrainingAppointment"
          },
          {
            "$ref": "#/components/schemas/GroomingAppointment"
          }
        ],
        "title": "PetAppointmentRequest",
        "type": "object"
      },
```