### PR TITLE
Fix `cast_and_validate/5` to properly handle required `readOnly` fields

### DIFF
--- a/lib/open_api_spex/cast.ex
+++ b/lib/open_api_spex/cast.ex
@@ -100,17 +100,10 @@ defmodule OpenApiSpex.Cast do
 
   """
 
-  @spec cast(schema_or_reference | nil, term(), map(), read_write_scope | nil, [cast_opt()]) ::
+  @spec cast(schema_or_reference | nil, term(), map(), [cast_opt()]) ::
           {:ok, term()} | {:error, [Error.t()]}
-  def cast(schema, value, schemas \\ %{}, read_write_scope \\ nil, opts \\ []) do
-    ctx = %__MODULE__{
-      schema: schema,
-      value: value,
-      schemas: schemas,
-      read_write_scope: read_write_scope,
-      opts: opts
-    }
-
+  def cast(schema, value, schemas \\ %{}, opts \\ []) do
+    ctx = %__MODULE__{schema: schema, value: value, schemas: schemas, opts: opts}
     cast(ctx)
   end
 

--- a/lib/open_api_spex/cast.ex
+++ b/lib/open_api_spex/cast.ex
@@ -100,10 +100,17 @@ defmodule OpenApiSpex.Cast do
 
   """
 
-  @spec cast(schema_or_reference | nil, term(), map(), [cast_opt()]) ::
+  @spec cast(schema_or_reference | nil, term(), map(), read_write_scope | nil, [cast_opt()]) ::
           {:ok, term()} | {:error, [Error.t()]}
-  def cast(schema, value, schemas \\ %{}, opts \\ []) do
-    ctx = %__MODULE__{schema: schema, value: value, schemas: schemas, opts: opts}
+  def cast(schema, value, schemas \\ %{}, read_write_scope \\ nil, opts \\ []) do
+    ctx = %__MODULE__{
+      schema: schema,
+      value: value,
+      schemas: schemas,
+      read_write_scope: read_write_scope,
+      opts: opts
+    }
+
     cast(ctx)
   end
 

--- a/lib/open_api_spex/cast/utils.ex
+++ b/lib/open_api_spex/cast/utils.ex
@@ -22,7 +22,8 @@ defmodule OpenApiSpex.Cast.Utils do
     # Adjust required fields list, based on read_write_scope
     required =
       Enum.filter(required, fn key ->
-        case {ctx.read_write_scope, ctx.schema.properties[key]} do
+        property_schema = OpenApiSpex.resolve_schema(ctx.schema.properties[key], ctx.schemas)
+        case {ctx.read_write_scope, property_schema} do
           {:read, %{writeOnly: true}} -> false
           {:write, %{readOnly: true}} -> false
           _ -> true

--- a/lib/open_api_spex/cast/utils.ex
+++ b/lib/open_api_spex/cast/utils.ex
@@ -22,8 +22,7 @@ defmodule OpenApiSpex.Cast.Utils do
     # Adjust required fields list, based on read_write_scope
     required =
       Enum.filter(required, fn key ->
-        property_schema = OpenApiSpex.resolve_schema(ctx.schema.properties[key], ctx.schemas)
-        case {ctx.read_write_scope, property_schema} do
+        case {ctx.read_write_scope, get_property_schema(ctx, key)} do
           {:read, %{writeOnly: true}} -> false
           {:write, %{readOnly: true}} -> false
           _ -> true
@@ -47,4 +46,11 @@ defmodule OpenApiSpex.Cast.Utils do
   end
 
   def check_required_fields(_ctx, _acc), do: :ok
+
+  defp get_property_schema(ctx, property_name) do
+    case ctx.schema.properties[property_name] do
+      schema = %_{} -> OpenApiSpex.resolve_schema(schema, ctx.schemas)
+      _ -> nil
+    end
+  end
 end

--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -129,8 +129,17 @@ defmodule OpenApiSpex.CastParameters do
     )
     |> pre_parse_parameters(parameters_contexts, parsers)
     |> case do
-      {:error, _} = err -> err
-      params -> Cast.cast(schema, params, components.schemas, :write, opts)
+      {:error, _} = err ->
+        err
+
+      params ->
+        Cast.cast(%Cast{
+          schema: schema,
+          value: params,
+          schemas: components.schemas,
+          opts: opts,
+          read_write_scope: :write
+        })
     end
   end
 

--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -130,7 +130,7 @@ defmodule OpenApiSpex.CastParameters do
     |> pre_parse_parameters(parameters_contexts, parsers)
     |> case do
       {:error, _} = err -> err
-      params -> Cast.cast(schema, params, components.schemas, nil, opts)
+      params -> Cast.cast(schema, params, components.schemas, :write, opts)
     end
   end
 

--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -130,7 +130,7 @@ defmodule OpenApiSpex.CastParameters do
     |> pre_parse_parameters(parameters_contexts, parsers)
     |> case do
       {:error, _} = err -> err
-      params -> Cast.cast(schema, params, components.schemas, opts)
+      params -> Cast.cast(schema, params, components.schemas, nil, opts)
     end
   end
 

--- a/lib/open_api_spex/operation2.ex
+++ b/lib/open_api_spex/operation2.ex
@@ -102,7 +102,7 @@ defmodule OpenApiSpex.Operation2 do
        ) do
     case content do
       %{^content_type => media_type} ->
-        Cast.cast(media_type.schema, params, components.schemas, opts)
+        Cast.cast(media_type.schema, params, components.schemas, :write, opts)
 
       _ ->
         {:error, [Error.new(%{path: [], value: content_type}, {:invalid_header, "content-type"})]}

--- a/lib/open_api_spex/operation2.ex
+++ b/lib/open_api_spex/operation2.ex
@@ -102,7 +102,13 @@ defmodule OpenApiSpex.Operation2 do
        ) do
     case content do
       %{^content_type => media_type} ->
-        Cast.cast(media_type.schema, params, components.schemas, :write, opts)
+        Cast.cast(%Cast{
+          schema: media_type.schema,
+          value: params,
+          schemas: components.schemas,
+          opts: opts,
+          read_write_scope: :write
+        })
 
       _ ->
         {:error, [Error.new(%{path: [], value: content_type}, {:invalid_header, "content-type"})]}

--- a/test/cast_test.exs
+++ b/test/cast_test.exs
@@ -251,6 +251,37 @@ defmodule OpenApiSpec.CastTest do
 
       assert {:ok, %{data: "default"}} == cast(value: %{}, schema: schema)
     end
+
+    test "required fields respect read_write_scope" do
+      schema = %Schema{
+        type: :object,
+        required: [:data],
+        properties: %{
+          data: %Schema{
+            type: :string,
+            readOnly: true
+          }
+        }
+      }
+
+      assert {:ok, %{}} == cast(value: %{}, schema: schema, read_write_scope: :write)
+      assert {:error, errors} = cast(value: %{}, schema: schema, read_write_scope: :read)
+      assert {:error, ^errors} = cast(value: %{}, schema: schema)
+
+      assert [error] = errors
+      assert %Error{} = error
+      assert error.reason == :missing_field
+      assert error.path == [:data]
+      assert Error.message_with_path(error) == "#/data: Missing field: data"
+
+      assert {:ok, data} =
+               cast(value: %{"data" => "string"}, schema: schema, read_write_scope: :write)
+
+      assert {:ok, ^data} =
+               cast(value: %{"data" => "string"}, schema: schema, read_write_scope: :read)
+
+      assert {:ok, ^data} = cast(value: %{"data" => "string"}, schema: schema)
+    end
   end
 
   describe "ok/1" do


### PR DESCRIPTION
This PR attempts to fix a bug described in #499. The bug leads to `OpenApiSpex.cast_and_validate/5` considering `readOnly` fields to be required in the request body. A fix is achieved by adding an ability to pass `read_write_scope` from `Operation2`/`CastParameters` to object casting code.