### PR TITLE
Optimise property counting for object validations

### DIFF
--- a/lib/open_api_spex/cast/object.ex
+++ b/lib/open_api_spex/cast/object.ex
@@ -72,7 +72,7 @@ defmodule OpenApiSpex.Cast.Object do
 
   defp check_max_properties(%{schema: %{maxProperties: max_properties}} = ctx)
        when is_integer(max_properties) do
-    count = ctx.value |> Map.keys() |> length()
+    count = map_size(ctx.value)
 
     if count > max_properties do
       Cast.error(ctx, {:max_properties, max_properties, count})
@@ -85,7 +85,7 @@ defmodule OpenApiSpex.Cast.Object do
 
   defp check_min_properties(%{schema: %{minProperties: min_properties}} = ctx)
        when is_integer(min_properties) do
-    count = ctx.value |> Map.keys() |> length()
+    count = map_size(ctx.value)
 
     if count < min_properties do
       Cast.error(ctx, {:min_properties, min_properties, count})


### PR DESCRIPTION
[Kernel.map_size/1](https://hexdocs.pm/elixir/Kernel.html#map_size/1) should be preferred to return the number of keys in a map as it runs in constant time.

```
m = for i <- 1..100, into: %{}, do: {:"key_#{i}", i}

Benchee.run(
  %{
    "map_size" => fn -> map_size(m) and map_size(m) end,
    "length" => fn -> length(Map.keys(m)) end
  },
  time: 2,
  memory_time: 2
)
```

Results:

```
length          0.70 M        1.42 μs   ±660.09%        1.31 μs        1.60 μs

Comparison: 
map_size        2.83 M
length          0.70 M - 4.02x slower +1.07 μs

Memory usage statistics:

Name        Memory usage
map_size         0.54 KB
length           2.57 KB - 4.77x memory usage +2.03 KB
```