### PR TITLE
Omit required from schemas when list is empty

### DIFF
--- a/lib/open_api_spex/open_api.ex
+++ b/lib/open_api_spex/open_api.ex
@@ -120,6 +120,7 @@ defmodule OpenApiSpex.OpenApi do
       {k, v} -> {to_string(k), to_map(v, opts)}
     end)
     |> Stream.filter(fn
+      {:required, []} when object == Schema -> false
       {k, _} when k in @vendor_extensions -> opts[:vendor_extensions]
       {_, nil} -> false
       _ -> true


### PR DESCRIPTION
Noticed a validation error when the `required` array is empty.
In the json schema version used by Swagger 3.0, the required property must contain at least one item if it is present.

https://json-schema.org/understanding-json-schema/reference/object.html?highlight=required#required-properties

