### PR TITLE
Accept dates and datetimes in formatted string schemas

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -61,7 +61,7 @@ jobs:
         run: mix do deps.get, test
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Test (OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}})
     strategy:
       matrix:

--- a/lib/open_api_spex/cast/string.ex
+++ b/lib/open_api_spex/cast/string.ex
@@ -6,9 +6,12 @@ defmodule OpenApiSpex.Cast.String do
   schema struct.
 
   """
+
   alias OpenApiSpex.{Cast, Cast.Error}
 
   @schema_fields [:maxLength, :minLength, :pattern]
+
+  def cast(%{value: %Date{} = date, schema: %{format: :date}}), do: {:ok, date}
 
   def cast(%{value: value, schema: %{format: :date}} = ctx) when is_binary(value) do
     case Date.from_iso8601(value) do
@@ -19,6 +22,8 @@ defmodule OpenApiSpex.Cast.String do
         Cast.error(ctx, {:invalid_format, :date})
     end
   end
+
+  def cast(%{value: %DateTime{} = date_time, schema: %{format: :"date-time"}}), do: {:ok, date_time}
 
   def cast(%{value: value, schema: %{format: :"date-time"}} = ctx) when is_binary(value) do
     case DateTime.from_iso8601(value) do

--- a/test/cast/string_test.exs
+++ b/test/cast/string_test.exs
@@ -32,8 +32,11 @@ defmodule OpenApiSpex.CastStringTest do
 
     test "string with format (date time)" do
       schema = %Schema{type: :string, format: :"date-time"}
-      time_string = DateTime.utc_now() |> DateTime.to_string()
+      time = DateTime.utc_now()
+      time_string = to_string(time)
+
       assert {:ok, %DateTime{}} = cast(value: time_string, schema: schema)
+      assert {:ok, ^time} = cast(value: time, schema: schema)
       assert {:error, [error]} = cast(value: "hello", schema: schema)
       assert error.reason == :invalid_format
       assert error.value == "hello"
@@ -42,8 +45,11 @@ defmodule OpenApiSpex.CastStringTest do
 
     test "string with format (date)" do
       schema = %Schema{type: :string, format: :date}
-      date_string = DateTime.utc_now() |> DateTime.to_date() |> Date.to_string()
+      date = Date.utc_today()
+      date_string = to_string(date)
+
       assert {:ok, %Date{}} = cast(value: date_string, schema: schema)
+      assert {:ok, ^date} = cast(value: date, schema: schema)
       assert {:error, [error]} = cast(value: "hello", schema: schema)
       assert error.reason == :invalid_format
       assert error.value == "hello"


### PR DESCRIPTION
Currently trying to cast a `%Date{}` or `%DateTime{}` as a String with `format: :"date-time"` or `format: :"date"` returns a validation error.

With this PR we can improve the consistency of casting and validations by being a little more flexible in the types of inputs accepted `OpenApiSpex.Cast.String` already accepts the following non JSON or OpenAPI primitives:

* Plug.Upload
* `atoms`

### Benefits
 
A schema can be validated, casted, transformed and then validated again.