### PR TITLE
Infer moduledoc from schema

### DIFF
--- a/lib/open_api_spex.ex
+++ b/lib/open_api_spex.ex
@@ -259,6 +259,12 @@ defmodule OpenApiSpex do
                 Keyword.merge([module: __MODULE__], unquote(opts))
               )
 
+      unless Module.get_attribute(__MODULE__, :moduledoc) do
+        @moduledoc [@schema.title, @schema.description]
+                   |> Enum.reject(&is_nil/1)
+                   |> Enum.join("\n\n")
+      end
+
       def schema, do: @schema
 
       if Map.get(@schema, :"x-struct") == __MODULE__ do

--- a/test/schema_construction_test.exs
+++ b/test/schema_construction_test.exs
@@ -7,6 +7,32 @@ defmodule OpenApiSpex.SchemaConstructionTest do
     OpenApiSpex.schema(%OpenApiSpex.Schema{type: :string})
   end
 
+  defmodule SchemaWithModuledoc do
+    @moduledoc "sample moduledoc"
+
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%OpenApiSpex.Schema{
+      title: "Lines of code",
+      description: "How many lines of code were written today",
+      type: :integer
+    })
+
+    def doc, do: @moduledoc
+  end
+
+  defmodule SchemaWithoutModuledoc do
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%OpenApiSpex.Schema{
+      title: "Lines of code",
+      description: "How many lines of code were written today",
+      type: :integer
+    })
+
+    def doc, do: @moduledoc
+  end
+
   test "calling schema() macro works with a struct" do
     assert %OpenApiSpex.Schema{"x-struct": module, type: schema_type} = SchemaCreate.schema()
     assert schema_type == :string
@@ -38,5 +64,14 @@ defmodule OpenApiSpex.SchemaConstructionTest do
       struct = %SchemaWithoutDerive{}
       Jason.encode!(struct)
     end
+  end
+
+  test "preserves the moduledoc" do
+    assert "sample moduledoc" = SchemaWithModuledoc.doc()
+  end
+
+  test "generates a moduledoc from the schema" do
+    assert "Lines of code\n\nHow many lines of code were written today" =
+             SchemaWithoutModuledoc.doc()
   end
 end


### PR DESCRIPTION
All schema modules generated by `OpenApiSpex.schema/1` appear in the `ex_doc` docs by default since `@moduledoc` is not set to `false`. It's common for schemas to have a `title` and `description` and this PR uses them to populate the `@moduledoc` only when it's not already set.
