### PR TITLE
Support structs as inputs when casting objects

### DIFF
--- a/lib/open_api_spex/cast/object.ex
+++ b/lib/open_api_spex/cast/object.ex
@@ -33,7 +33,7 @@ defmodule OpenApiSpex.Cast.Object do
           value
         end
 
-      ctx = to_struct(%{ctx | value: value_with_defaults})
+      ctx = to_struct(%{ctx | value: value_with_defaults}, original_value)
       {:ok, ctx}
     end
   end
@@ -188,11 +188,15 @@ defmodule OpenApiSpex.Cast.Object do
 
   defp apply_default(_, object_value), do: object_value
 
-  defp to_struct(%{value: value = %_{}}), do: value
-  defp to_struct(%{value: value, schema: %{"x-struct": nil}}), do: value
+  defp to_struct(%{value: value = %_{}}, _original_value), do: value
 
-  defp to_struct(%{value: value, schema: %{"x-struct": module}}),
-    do: struct(module, value)
+  defp to_struct(%{value: value, schema: %{"x-struct": module}}, _)
+       when not is_nil(module),
+       do: struct(module, value)
+
+  defp to_struct(%{value: value}, %original_module{}), do: struct(original_module, value)
+
+  defp to_struct(%{value: value}, _original_value), do: value
 
   defp ensure_not_struct(val) when is_struct(val), do: Map.from_struct(val)
   defp ensure_not_struct(val), do: val

--- a/lib/open_api_spex/cast/object.ex
+++ b/lib/open_api_spex/cast/object.ex
@@ -147,7 +147,7 @@ defmodule OpenApiSpex.Cast.Object do
       |> Enum.flat_map(&[&1, to_string(&1)])
       |> MapSet.new()
 
-    for {key, _value} = prop <- original_value,
+    for {key, _value} = prop <- ensure_not_struct(original_value),
         not MapSet.member?(recognized_keys, key) do
       prop
     end
@@ -193,4 +193,7 @@ defmodule OpenApiSpex.Cast.Object do
 
   defp to_struct(%{value: value, schema: %{"x-struct": module}}),
     do: struct(module, value)
+
+  defp ensure_not_struct(val) when is_struct(val), do: Map.from_struct(val)
+  defp ensure_not_struct(val), do: val
 end

--- a/test/cast/object_test.exs
+++ b/test/cast/object_test.exs
@@ -360,6 +360,18 @@ defmodule OpenApiSpex.ObjectTest do
       assert user == %User{name: "Name"}
     end
 
+    test "original struct is preserved if no x-struct is specified" do
+      schema = %Schema{
+        type: :object,
+        properties: %{
+          name: %Schema{type: :string}
+        }
+      }
+
+      assert {:ok, user} = cast(value: %User{name: "Name"}, schema: schema)
+      assert user == %User{name: "Name"}
+    end
+
     test "validates maxProperties" do
       schema = %Schema{
         type: :object,

--- a/test/cast/object_test.exs
+++ b/test/cast/object_test.exs
@@ -6,6 +6,10 @@ defmodule OpenApiSpex.ObjectTest do
   defp cast(%Cast{} = ctx), do: Object.cast(ctx)
   defp cast(ctx), do: Object.cast(struct(Cast, ctx))
 
+  defmodule User do
+    defstruct [:name]
+  end
+
   describe "cast/3" do
     test "when input is not an object" do
       schema = %Schema{type: :object}
@@ -19,6 +23,12 @@ defmodule OpenApiSpex.ObjectTest do
       schema = %Schema{type: :object, properties: %{one: %Schema{type: :string}}}
       assert {:ok, map} = cast(value: %{one: "one"}, schema: schema)
       assert map == %{one: "one"}
+    end
+
+    test "input map can be a struct" do
+      schema = %Schema{type: :object, properties: %{name: %Schema{type: :string}}}
+      assert {:ok, map} = cast(value: %User{name: "bob"}, schema: schema)
+      assert map == %{name: "bob"}
     end
 
     test "converting string keys to atom keys when properties are defined" do
@@ -318,10 +328,6 @@ defmodule OpenApiSpex.ObjectTest do
                schema: schema,
                schemas: %{"Age" => age_schema, "NestedSchema" => nested_schema}
              ) == {:ok, %{"nested" => %{age: 20}}}
-    end
-
-    defmodule User do
-      defstruct [:name]
     end
 
     test "optionally casts to struct" do

--- a/test/cast/object_test.exs
+++ b/test/cast/object_test.exs
@@ -6,10 +6,6 @@ defmodule OpenApiSpex.ObjectTest do
   defp cast(%Cast{} = ctx), do: Object.cast(ctx)
   defp cast(ctx), do: Object.cast(struct(Cast, ctx))
 
-  defmodule User do
-    defstruct [:name]
-  end
-
   describe "cast/3" do
     test "when input is not an object" do
       schema = %Schema{type: :object}
@@ -25,10 +21,14 @@ defmodule OpenApiSpex.ObjectTest do
       assert map == %{one: "one"}
     end
 
+    defmodule User2 do
+      defstruct [:name]
+    end
+
     test "input map can be a struct" do
       schema = %Schema{type: :object, properties: %{name: %Schema{type: :string}}}
-      assert {:ok, map} = cast(value: %User{name: "bob"}, schema: schema)
-      assert map == %{name: "bob"}
+      assert {:ok, map} = cast(value: %User2{name: "bob"}, schema: schema)
+      assert map == %User2{name: "bob"}
     end
 
     test "converting string keys to atom keys when properties are defined" do
@@ -330,6 +330,10 @@ defmodule OpenApiSpex.ObjectTest do
              ) == {:ok, %{"nested" => %{age: 20}}}
     end
 
+    defmodule User do
+      defstruct [:name]
+    end
+
     test "optionally casts to struct" do
       schema = %Schema{
         type: :object,
@@ -340,6 +344,19 @@ defmodule OpenApiSpex.ObjectTest do
       }
 
       assert {:ok, user} = cast(value: %{"name" => "Name"}, schema: schema)
+      assert user == %User{name: "Name"}
+    end
+
+    test "casts to struct even if input was a different struct" do
+      schema = %Schema{
+        type: :object,
+        "x-struct": User,
+        properties: %{
+          name: %Schema{type: :string}
+        }
+      }
+
+      assert {:ok, user} = cast(value: %User2{name: "Name"}, schema: schema)
       assert user == %User{name: "Name"}
     end
 


### PR DESCRIPTION
Fixes #528.

Adds support for structs when `Cast` ing values. If casting succeeds the structs are preserved (i.e. not converted to maps).