### PR TITLE
Fix typespec and add example to Paths.from_routes/1

### DIFF
--- a/lib/open_api_spex/path_item.ex
+++ b/lib/open_api_spex/path_item.ex
@@ -52,8 +52,8 @@ defmodule OpenApiSpex.PathItem do
   Eg from the generated `__routes__` function in a Phoenix.Router module.
   """
   @type route ::
-          %{verb: atom, plug: atom, opts: any}
-          | %{verb: atom, plug: atom, plug_opts: any}
+          %{path: String.t(), verb: atom, plug: atom, opts: any}
+          | %{path: String.t(), verb: atom, plug: atom, plug_opts: any}
 
   @doc """
   Builds a PathItem struct from a list of routes that share a path.

--- a/lib/open_api_spex/paths.ex
+++ b/lib/open_api_spex/paths.ex
@@ -25,8 +25,14 @@ defmodule OpenApiSpex.Paths do
 
   @doc """
   Create a Paths map from a list of routes.
+
+  ## Example
+
+      Paths.from_routes([
+        %{path: "/v1/contacts", verb: :post, plug: MyAppWeb.V1.ContactController, plug_opts: :create}
+      ])
   """
-  @spec from_routes([%{path: String.t(), verb: atom()}]) :: t
+  @spec from_routes([%{path: String.t(), verb: atom(), plug: module(), plug_opts: atom()}]) :: t
   def from_routes(routes) do
     paths =
       routes

--- a/lib/open_api_spex/paths.ex
+++ b/lib/open_api_spex/paths.ex
@@ -32,7 +32,7 @@ defmodule OpenApiSpex.Paths do
         %{path: "/v1/contacts", verb: :post, plug: MyAppWeb.V1.ContactController, plug_opts: :create}
       ])
   """
-  @spec from_routes([%{path: String.t(), verb: atom(), plug: module(), plug_opts: atom()}]) :: t
+  @spec from_routes([PathItem.route()]) :: t
   def from_routes(routes) do
     paths =
       routes


### PR DESCRIPTION
Adds the missing types to `Paths.from_routes/1` `spec`. Also adds an example on how to use this function.

Fixes #527 