### PR TITLE
Raise meaningful error message when SchemaResolver.resolve_schema_modules_from_schema failed to pattern match

### DIFF
--- a/lib/open_api_spex/schema_resolver.ex
+++ b/lib/open_api_spex/schema_resolver.ex
@@ -250,6 +250,19 @@ defmodule OpenApiSpex.SchemaResolver do
 
   defp resolve_schema_modules_from_schema(ref = %Reference{}, schemas), do: {ref, schemas}
 
+  defp resolve_schema_modules_from_schema(_, _) do
+    error_message = """
+    Cannot resolve schema, need to be one of:
+    - boolean
+    - nil
+    - schema module, or schema struct
+    - list of schema module, or schema struct
+    - reference
+    """
+
+    raise error_message
+  end
+
   defp resolve_schema_modules_from_schema_properties(nil, schemas), do: {nil, schemas}
 
   defp resolve_schema_modules_from_schema_properties(properties, schemas)

--- a/test/schema_resolver_test.exs
+++ b/test/schema_resolver_test.exs
@@ -225,6 +225,44 @@ defmodule OpenApiSpex.SchemaResolverTest do
     end
   end
 
+  test "raises error when schema cannot be resolved" do
+    spec = %OpenApi{
+      info: %Info{
+        title: "Test",
+        version: "1.0.0"
+      },
+      paths: %{
+        "/api/users" => %PathItem{
+          get: %Operation{
+            responses: %{
+              200 => %Response{
+                description: "Success",
+                content: %{
+                  "application/json" => %MediaType{
+                    schema: %{}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    error_message = """
+    Cannot resolve schema, need to be one of:
+    - boolean
+    - nil
+    - schema module, or schema struct
+    - list of schema module, or schema struct
+    - reference
+    """
+
+    assert_raise RuntimeError, error_message, fn ->
+      OpenApiSpex.resolve_schema_modules(spec)
+    end
+  end
+
   describe "add_schemas/2" do
     @empty_spec %OpenApi{
       info: %Info{


### PR DESCRIPTION
I ran in to an unreadable error while working, and it took me a long time to realized I was doing: 

```elixir
%Schema{
  type: :object, 
  properties: %{
    data: %{}
  }
}
```

instead of: 

```elixir
%Schema{
  type: :object, 
  properties: %{
    data: %Schema{}
  }
}
```

This PR will raise with some (I think) helpful error message. 