### PR TITLE
feat: add assert_operation_response, assert_raw_schema

### DIFF
--- a/lib/open_api_spex.ex
+++ b/lib/open_api_spex.ex
@@ -15,7 +15,7 @@ defmodule OpenApiSpex do
     SchemaResolver
   }
 
-  alias OpenApiSpex.Cast.Error
+  alias OpenApiSpex.Cast.{Error, Utils}
 
   @doc """
   Adds schemas to the api spec from the modules specified in the Operations.
@@ -93,20 +93,8 @@ defmodule OpenApiSpex do
         content_type \\ nil,
         opts \\ []
       ) do
-    content_type = content_type || content_type_from_header(conn)
+    content_type = content_type || Utils.content_type_from_header(conn)
     Operation2.cast(spec, operation, conn, content_type, opts)
-  end
-
-  defp content_type_from_header(conn = %Plug.Conn{}) do
-    case Plug.Conn.get_req_header(conn, "content-type") do
-      [header_value | _] ->
-        header_value
-        |> String.split(";")
-        |> List.first()
-
-      _ ->
-        nil
-    end
   end
 
   @doc """
@@ -406,7 +394,7 @@ defmodule OpenApiSpex do
   Resolve a schema or reference to a schema.
   """
   @spec resolve_schema(Schema.t() | Reference.t() | module, Components.schemas_map()) ::
-          Schema.t()
+          Schema.t() | nil
   def resolve_schema(%Schema{} = schema, _), do: schema
   def resolve_schema(%Reference{} = ref, schemas), do: Reference.resolve_schema(ref, schemas)
 

--- a/lib/open_api_spex/cast/utils.ex
+++ b/lib/open_api_spex/cast/utils.ex
@@ -47,6 +47,33 @@ defmodule OpenApiSpex.Cast.Utils do
 
   def check_required_fields(_ctx, _acc), do: :ok
 
+  @doc """
+  Retrieves the content type from the request header of the given connection.
+
+  ## Parameters:
+
+    - `conn`: The connection from which the content type should be retrieved. Must be an instance of `Plug.Conn`.
+
+  ## Returns:
+
+    - If the content type is found: Returns the main content type as a string. For example, for the header "application/json; charset=utf-8", it would return "application/json".
+    - If the content type is not found or is not set: Returns `nil`.
+
+  ## Examples:
+
+      iex> content_type_from_header(%Plug.Conn{req_headers: [{"content-type", "application/json; charset=utf-8"}]})
+      "application/json"
+
+      iex> content_type_from_header(%Plug.Conn{req_headers: []})
+      nil
+
+  ## Notes:
+
+  - The function only retrieves the main content type and does not consider any additional parameters that may be set in the `content-type` header.
+  - If multiple `content-type` headers are found, the function will only return the value of the first one.
+
+  """
+  @spec content_type_from_header(Plug.Conn.t()) :: String.t() | nil
   def content_type_from_header(conn = %Plug.Conn{}) do
     case Plug.Conn.get_req_header(conn, "content-type") do
       [header_value | _] ->

--- a/lib/open_api_spex/cast/utils.ex
+++ b/lib/open_api_spex/cast/utils.ex
@@ -46,4 +46,16 @@ defmodule OpenApiSpex.Cast.Utils do
   end
 
   def check_required_fields(_ctx, _acc), do: :ok
+
+  def content_type_from_header(conn = %Plug.Conn{}) do
+    case Plug.Conn.get_req_header(conn, "content-type") do
+      [header_value | _] ->
+        header_value
+        |> String.split(";")
+        |> List.first()
+
+      _ ->
+        nil
+    end
+  end
 end

--- a/lib/open_api_spex/operation2.ex
+++ b/lib/open_api_spex/operation2.ex
@@ -41,11 +41,25 @@ defmodule OpenApiSpex.Operation2 do
              components,
              opts
            ) do
-      {:ok, conn |> cast_conn(body) |> maybe_replace_body(body, replace_params)}
+      {:ok,
+       conn
+       |> cast_conn(body)
+       |> maybe_replace_body(body, replace_params)
+       |> put_operation_id(operation)}
     end
   end
 
   ## Private functions
+
+  defp put_operation_id(conn, operation) do
+    private_data =
+      conn
+      |> Map.get(:private)
+      |> Map.get(:open_api_spex, %{})
+      |> Map.put(:operation_id, operation.operationId)
+
+    Plug.Conn.put_private(conn, :open_api_spex, private_data)
+  end
 
   defp cast_conn(conn, body) do
     private_data =

--- a/lib/open_api_spex/plug/cast.ex
+++ b/lib/open_api_spex/plug/cast.ex
@@ -44,8 +44,8 @@ defmodule OpenApiSpex.Plug.Cast do
 
   @behaviour Plug
 
+  alias OpenApiSpex.Cast.Utils
   alias OpenApiSpex.Plug.PutApiSpec
-  alias Plug.Conn
 
   @impl Plug
   @deprecated "Use OpenApiSpex.Plug.CastAndValidate instead"
@@ -64,11 +64,7 @@ defmodule OpenApiSpex.Plug.Cast do
     {spec, operation_lookup} = PutApiSpec.get_spec_and_operation_lookup(conn)
     operation = operation_lookup[operation_id]
 
-    content_type =
-      Conn.get_req_header(conn, "content-type")
-      |> Enum.at(0, "")
-      |> String.split(";")
-      |> Enum.at(0)
+    content_type = Utils.content_type_from_header(conn)
 
     # credo:disable-for-next-line
     case apply(OpenApiSpex, :cast, [spec, operation, conn, content_type]) do

--- a/lib/open_api_spex/plug/render_spec.ex
+++ b/lib/open_api_spex/plug/render_spec.ex
@@ -41,7 +41,7 @@ defmodule OpenApiSpex.Plug.RenderSpec do
       |> Plug.Conn.send_resp(200, @json_encoder.encode!(spec))
     end
   else
-    IO.warn("No JSON encoder found. Please add :json or :poison in your mix dependencies.")
+    IO.warn("No JSON encoder found. Please add :jason or :poison in your mix dependencies.")
 
     @impl Plug
     def call(conn, _opts), do: conn

--- a/lib/open_api_spex/test/test_assertions.ex
+++ b/lib/open_api_spex/test/test_assertions.ex
@@ -128,7 +128,12 @@ defmodule OpenApiSpex.TestAssertions do
   """
   @spec assert_operation_response(Plug.Conn.t(), String.t()) ::
           no_return | Plug.Conn.t()
+
   def assert_operation_response(conn, operation_id \\ nil)
+
+  # No need to check for a schema if the response is empty
+  def assert_operation_response(conn, _operation_id) when conn.status == 204, do: conn
+
   def assert_operation_response(conn, operation_id) do
     {spec, operation_lookup} = PutApiSpec.get_spec_and_operation_lookup(conn)
 

--- a/lib/open_api_spex/test/test_assertions.ex
+++ b/lib/open_api_spex/test/test_assertions.ex
@@ -126,9 +126,9 @@ defmodule OpenApiSpex.TestAssertions do
   @doc """
   Asserts that the response body conforms to the response schema for the operation with id `operation_id`.
   """
-  @spec assert_operation_response(String.t(), Plug.Conn.t()) ::
+  @spec assert_operation_response(Plug.Conn.t(), String.t()) ::
           no_return | term
-  def assert_operation_response(operation_id, conn) do
+  def assert_operation_response(conn, operation_id) do
     {spec, operation_lookup} = PutApiSpec.get_spec_and_operation_lookup(conn)
 
     case operation_lookup[operation_id] do
@@ -140,6 +140,8 @@ defmodule OpenApiSpex.TestAssertions do
       operation ->
         validate_operation_response(conn, operation, spec)
     end
+
+    conn
   end
 
   @spec validate_operation_response(

--- a/lib/open_api_spex/test/test_assertions.ex
+++ b/lib/open_api_spex/test/test_assertions.ex
@@ -122,8 +122,7 @@ defmodule OpenApiSpex.TestAssertions do
   @doc """
   Asserts that the response body conforms to the response schema for the operation with id `operation_id`.
   """
-  @spec assert_operation_response(Plug.Conn.t(), String.t() | nil) ::
-          no_return | Plug.Conn.t()
+  @spec assert_operation_response(Plug.Conn.t(), String.t() | nil) :: Plug.Conn.t()
   def assert_operation_response(conn, operation_id \\ nil)
 
   # No need to check for a schema if the response is empty

--- a/lib/open_api_spex/test/test_assertions.ex
+++ b/lib/open_api_spex/test/test_assertions.ex
@@ -128,8 +128,11 @@ defmodule OpenApiSpex.TestAssertions do
   """
   @spec assert_operation_response(Plug.Conn.t(), String.t()) ::
           no_return | Plug.Conn.t()
+  def assert_operation_response(conn, operation_id \\ nil)
   def assert_operation_response(conn, operation_id) do
     {spec, operation_lookup} = PutApiSpec.get_spec_and_operation_lookup(conn)
+
+    operation_id = operation_id || conn.private.open_api_spex.operation_id
 
     case operation_lookup[operation_id] do
       nil ->

--- a/lib/open_api_spex/test/test_assertions.ex
+++ b/lib/open_api_spex/test/test_assertions.ex
@@ -172,9 +172,10 @@ defmodule OpenApiSpex.TestAssertions do
       end
 
       body =
-        case content_type do
-          "application/json" -> OpenApiSpex.OpenApi.json_encoder().decode!(conn.resp_body)
-          _ -> conn.resp_body
+        if String.match?(content_type, ~r/^application\/.*json.*$/) do
+          OpenApiSpex.OpenApi.json_encoder().decode!(conn.resp_body)
+        else
+          conn.resp_body
         end
 
       assert_raw_schema(

--- a/lib/open_api_spex/test/test_assertions.ex
+++ b/lib/open_api_spex/test/test_assertions.ex
@@ -127,7 +127,7 @@ defmodule OpenApiSpex.TestAssertions do
   Asserts that the response body conforms to the response schema for the operation with id `operation_id`.
   """
   @spec assert_operation_response(Plug.Conn.t(), String.t()) ::
-          no_return | term
+          no_return | Plug.Conn.t()
   def assert_operation_response(conn, operation_id) do
     {spec, operation_lookup} = PutApiSpec.get_spec_and_operation_lookup(conn)
 

--- a/lib/open_api_spex/test/test_assertions.ex
+++ b/lib/open_api_spex/test/test_assertions.ex
@@ -172,7 +172,7 @@ defmodule OpenApiSpex.TestAssertions do
 
     body =
       case content_type do
-        "application/json" -> Jason.decode!(conn.resp_body)
+        "application/json" -> decode_json_or_flunk!(conn.resp_body)
         _ -> conn.resp_body
       end
 
@@ -181,5 +181,12 @@ defmodule OpenApiSpex.TestAssertions do
       resolved_schema,
       spec
     )
+  end
+
+  defp decode_json_or_flunk!(body) do
+    case OpenApiSpex.OpenApi.json_encoder() do
+      nil -> flunk("Unable to use assert_operation_response unless a json encoder is configured")
+      encoder -> encoder.decode!(body)
+    end
   end
 end

--- a/test/support/pet_controller.ex
+++ b/test/support/pet_controller.ex
@@ -23,7 +23,8 @@ defmodule OpenApiSpexTest.PetController do
        ],
        responses: [
          ok: {"Pet", "application/json", Schemas.PetResponse}
-       ]
+       ],
+       operation_id: "showPetById"
   def show(conn, %{id: _id}) do
     json(conn, %Schemas.PetResponse{
       data: %Schemas.Dog{
@@ -36,7 +37,8 @@ defmodule OpenApiSpexTest.PetController do
   @doc """
   Get a list of pets.
   """
-  @doc responses: [ok: {"Pet list", "application/json", Schemas.PetsResponse}]
+  @doc responses: [ok: {"Pet list", "application/json", Schemas.PetsResponse}],
+       operation_id: "listPets"
   def index(conn, _params) do
     json(conn, %Schemas.PetsResponse{
       data: [

--- a/test/test_assertions_test.exs
+++ b/test/test_assertions_test.exs
@@ -95,7 +95,7 @@ defmodule OpenApiSpex.TestAssertionsTest do
     end
   end
 
-  describe "assert_response_operation/2" do
+  describe "assert_operation_response/2" do
     test "success with a manually specified operationId" do
       conn =
         :get

--- a/test/test_assertions_test.exs
+++ b/test/test_assertions_test.exs
@@ -105,7 +105,7 @@ defmodule OpenApiSpex.TestAssertionsTest do
       conn = OpenApiSpexTest.Router.call(conn, [])
 
       assert conn.status == 200
-      TestAssertions.assert_operation_response("listPets", conn)
+      TestAssertions.assert_operation_response(conn, "listPets")
     end
 
     test "missing operation id" do
@@ -118,7 +118,7 @@ defmodule OpenApiSpex.TestAssertionsTest do
       assert conn.status == 200
 
       try do
-        TestAssertions.assert_operation_response("not_a_real_operation_id", conn)
+        TestAssertions.assert_operation_response(conn, "not_a_real_operation_id")
         raise RuntimeError, "Should flunk"
       rescue
         e in ExUnit.AssertionError ->
@@ -138,7 +138,7 @@ defmodule OpenApiSpex.TestAssertionsTest do
       assert conn.status == 200
 
       try do
-        TestAssertions.assert_operation_response("showPetById", conn)
+        TestAssertions.assert_operation_response(conn, "showPetById")
         raise RuntimeError, "Should flunk"
       rescue
         e in ExUnit.AssertionError ->

--- a/test/test_assertions_test.exs
+++ b/test/test_assertions_test.exs
@@ -96,7 +96,7 @@ defmodule OpenApiSpex.TestAssertionsTest do
   end
 
   describe "assert_response_operation/2" do
-    test "success" do
+    test "success with a manually specified operationId" do
       conn =
         :get
         |> Plug.Test.conn("/api/pets")
@@ -106,6 +106,18 @@ defmodule OpenApiSpex.TestAssertionsTest do
 
       assert conn.status == 200
       TestAssertions.assert_operation_response(conn, "listPets")
+    end
+
+    test "success with only conn" do
+      conn =
+        :get
+        |> Plug.Test.conn("/api/pets")
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+
+      conn = OpenApiSpexTest.Router.call(conn, [])
+
+      assert conn.status == 200
+      TestAssertions.assert_operation_response(conn)
     end
 
     test "missing operation id" do


### PR DESCRIPTION
This is a small proposal to add a few things to help with testing based on `operationId`s instead of _(or along side of)_ `schema_name`s. There are a few benefits to this, but the primary one is that it enforces `operationId` usage. Most organizations that deal with any type of code generation are going to most likely want to enforce operationIds.

~~I thought about just looking at the path in `conn` and resolving backwards with a method like `assert_uses_schema`, but that was a bit too 🪄 for what I wanted to achieve.~~ _(i was able to achieve this very simply by assigning the operation_id. it now supports automatic inference or manual specification)_

I'm sure I've missed something here, but very open to feedback if anyone else would benefit from this 🎉 