### PR TITLE
Generalise SwaggerUI plug config supplementing for Phoenix app

### DIFF
--- a/lib/open_api_spex/plug/swagger_ui.ex
+++ b/lib/open_api_spex/plug/swagger_ui.ex
@@ -193,14 +193,24 @@ defmodule OpenApiSpex.Plug.SwaggerUI do
   end
 
   if Code.ensure_loaded?(Phoenix.Controller) do
-    defp supplement_config(%{oauth2_redirect_url: {:endpoint_url, path}} = config, conn) do
+    defp supplement_config(config, conn) do
       endpoint_module = Phoenix.Controller.endpoint_module(conn)
-      url = Path.join(endpoint_module.url(), path)
-      Map.put(config, :oauth2_redirect_url, url)
-    end
-  end
 
-  defp supplement_config(config, _conn) do
-    config
+      Enum.map(config, fn
+        {k, {:endpoint_url, path}} ->
+          {k, Path.join(endpoint_module.url(), endpoint_module.path(path))}
+
+        {k, {:endpoint_path, path}} ->
+          {k, endpoint_module.path(path)}
+
+        k_v ->
+          k_v
+      end)
+      |> Map.new()
+    end
+  else
+    defp supplement_config(config, _conn) do
+      config
+    end
   end
 end

--- a/test/plug/swagger_ui_test.exs
+++ b/test/plug/swagger_ui_test.exs
@@ -3,14 +3,48 @@ defmodule OpenApiSpec.Plug.SwaggerUITest do
 
   alias OpenApiSpex.Plug.SwaggerUI
 
-  @opts SwaggerUI.init(path: "/ui")
+  setup_all do
+    start_supervised!(OpenApiSpexTest.Endpoint)
+    :ok
+  end
 
   test "renders csrf token" do
+    config = SwaggerUI.init(path: "/ui")
+
     token = Plug.CSRFProtection.get_csrf_token()
 
-    conn = Plug.Test.conn(:get, "/ui")
-    conn = SwaggerUI.call(conn, @opts)
-    assert conn.resp_body =~ ~r[pathname.+?/ui]
+    conn =
+      Plug.Test.conn(:get, "/ui")
+      |> Plug.Conn.put_private(:phoenix_endpoint, OpenApiSpexTest.Endpoint)
+
+    conn = SwaggerUI.call(conn, config)
+    assert conn.resp_body =~ ~r[pathname.+?"/ui"]
     assert String.contains?(conn.resp_body, token)
+  end
+
+  Application.put_env(:open_api_spex_test, OpenApiSpexTest.Endpoint,
+    url: [scheme: "https", host: "some-host.com", port: 1234, path: "/some-prefix"]
+  )
+
+  test "generate actual path dependent to endpoint" do
+    config = SwaggerUI.init(path: {:endpoint_path, "/ui"})
+
+    conn =
+      Plug.Test.conn(:get, "/ui")
+      |> Plug.Conn.put_private(:phoenix_endpoint, OpenApiSpexTest.Endpoint)
+
+    conn = SwaggerUI.call(conn, config)
+    assert conn.resp_body =~ ~r[pathname.+?"/some-prefix/ui"]
+  end
+
+  test "generate actual url dependent to endpoint" do
+    config = SwaggerUI.init(path: {:endpoint_url, "/ui"})
+
+    conn =
+      Plug.Test.conn(:get, "/ui")
+      |> Plug.Conn.put_private(:phoenix_endpoint, OpenApiSpexTest.Endpoint)
+
+    conn = SwaggerUI.call(conn, config)
+    assert conn.resp_body =~ ~r[pathname.+?"https://some-host.com:1234/some-prefix/ui"]
   end
 end


### PR DESCRIPTION
Resolve #546.

The previous implementation of the SwaggerUI plug's configuration supplementing function for the Phoenix app was limited. It only applied to `oauth2_redirect_url` and joined the `path` only with the [Endpoint URL](https://hexdocs.pm/phoenix/1.7.6/Phoenix.Endpoint.html#c:url/0). This approach was inaccurate if a `path` was already present in the Endpoint URL configuration.

This PR enhances the configuration supplementing functionality. It introduces the ability to join desired paths with `:endpoint_url` and `:endpoint_path`. This flexibility is provided for all configuration values that adhere to the respective structure.