### PR TITLE
Fix deprecation warning on Elixir 1.15, require Elixir 1.11, adapt CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -66,9 +66,8 @@ jobs:
     strategy:
       matrix:
         otp: ['22', '23', '24', '25']
-        elixir: ['1.10', '1.11', '1.12', '1.13']
+        elixir: ['1.11', '1.12', '1.13']
         exclude:
-          - {otp: '24', elixir: '1.10'}
           - {otp: '25', elixir: '1.10'}
           - {otp: '25', elixir: '1.11'}
           - {otp: '25', elixir: '1.12'}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+* Fix deprecation warning on Elixir 1.15 https://github.com/open-api-spex/open_api_spex/pull/550
+* Now require Elixir 1.11+ https://github.com/open-api-spex/open_api_spex/pull/550
+
 ## v3.17.3 - 2023-05-30
 
 * Raise meaningful error message when `SchemaResolver.resolve_schema_modules_from_schema` failed to pattern match by @yuchunc in https://github.com/open-api-spex/open_api_spex/pull/541

--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -152,7 +152,7 @@ defmodule OpenApiSpex.CastParameters do
   defp pre_parse_parameter(parameter, %{content_type: content_type}, parsers)
        when is_bitstring(content_type) do
     Enum.reduce_while(parsers, {:ok, parameter}, fn {match, parser}, acc ->
-      if Regex.regex?(match) and Regex.match?(match, content_type) do
+      if is_struct(match, Regex) and Regex.match?(match, content_type) do
         {:halt, decode_parameter(parameter, content_type, parser)}
       else
         {:cont, acc}

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule OpenApiSpex.Mixfile do
     [
       app: :open_api_spex,
       version: @version,
-      elixir: "~> 1.10",
+      elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       consolidate_protocols: Mix.env() != :test,


### PR DESCRIPTION
## Warning fix

Before the fix:

```
==> open_api_spex
Compiling 99 files (.ex)
warning: Regex.regex?/1 is deprecated. Use Kernel.is_struct/2 or pattern match on %Regex{} instead
  lib/open_api_spex/cast_parameters.ex:155: OpenApiSpex.CastParameters.pre_parse_parameter/3

Generated open_api_spex app
```

This PR fixes the warning.

## Bump Elixir requirement & adapt CI

Since the CI failed on Elixir 1.10, and it is not maintained anymore, I bumped the requirement to 1.11 & adapted the CI too.