### PR TITLE
Add `--quiet` option for spec generation

### DIFF
--- a/lib/mix/tasks/openapi.spec.json.ex
+++ b/lib/mix/tasks/openapi.spec.json.ex
@@ -20,6 +20,7 @@ defmodule Mix.Tasks.Openapi.Spec.Json do
   * `--vendor-extensions` - Whether to include open_api_spex OpenAPI vendor extensions
     (defaults to true)
 
+  * `--quiet` - Whether to disable output printing (defaults to false)
   """
   use Mix.Task
   require Mix.Generator

--- a/lib/mix/tasks/openapi.spec.yaml.ex
+++ b/lib/mix/tasks/openapi.spec.yaml.ex
@@ -17,6 +17,7 @@ defmodule Mix.Tasks.Openapi.Spec.Yaml do
   * `--vendor-extensions` - Whether to include open_api_spex OpenAPI vendor extensions
     (defaults to true)
 
+  * `--quiet` - Whether to disable output printing (defaults to false)
   """
   use Mix.Task
   require Mix.Generator

--- a/test/mix/tasks/openapi.spec.json_test.exs
+++ b/test/mix/tasks/openapi.spec.json_test.exs
@@ -18,4 +18,15 @@ defmodule Mix.Tasks.Openapi.Spec.JsonTest do
 
     assert File.read!(actual_schema_path) == File.read!(expected_schema_path)
   end
+
+  test "generates openapi.json quietly" do
+    Mix.Tasks.Openapi.Spec.Json.run(~w(
+      --quiet=true
+      --spec OpenApiSpexTest.Tasks.SpecModule
+      "tmp/openapi.json"
+    ))
+
+    refute_received {:mix_shell, :info, ["* creating tmp"]}
+    refute_received {:mix_shell, :info, ["* creating tmp/openapi.json"]}
+  end
 end


### PR DESCRIPTION
This PR adds a `--quiet` option on the spec generation task.
It allows to disable the mix shell printing when creating folders and files.

Useful to avoid pollution if you run the task in tests, for example:

![screen](https://github.com/open-api-spex/open_api_spex/assets/1422403/3e116599-c7ff-48a5-afa9-fd7e53229245)