### PR TITLE
feat: accept body param as parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v3.19.0 - 2023-09-23
+
+## Added
+
+* Accept expected location body ~> by @yashin5 in https://github.com/open-api-spex/open_api_spex/pull/558
+
 ## v3.18.0 - 2023-08-23
 
 * Relax dependency constraint on ymlr to allow version ~> 4.0 by @arcanemachine in https://github.com/open-api-spex/open_api_spex/pull/544

--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -42,6 +42,10 @@ defmodule OpenApiSpex.CastParameters do
     Plug.Conn.fetch_query_params(conn).query_params
   end
 
+  defp get_params_by_location(conn, :body, _) do
+    conn.body_params
+  end
+
   defp get_params_by_location(conn, :path, _) do
     conn.path_params
   end

--- a/test/plug/cast_test.exs
+++ b/test/plug/cast_test.exs
@@ -40,9 +40,22 @@ defmodule OpenApiSpex.Plug.CastTest do
         |> OpenApiSpexTest.Router.call([])
 
       assert conn.status == 200
-      assert conn.private.open_api_spex.params == conn.params
+    end
 
-      assert OpenApiSpex.params(conn) == %{validParam: true}
+    test "invalid param" do
+      body =
+        Jason.encode!(%{
+          shurato: "123-456-789",
+          goku: "123 Lane St"
+        })
+
+      conn =
+        :post
+        |> Plug.Test.conn("/api/users/123/contact_info", body)
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> OpenApiSpexTest.Router.call([])
+
+      assert conn.status == 422
     end
   end
 

--- a/test/plug/cast_test.exs
+++ b/test/plug/cast_test.exs
@@ -25,6 +25,27 @@ defmodule OpenApiSpex.Plug.CastTest do
     end
   end
 
+  describe "body params - basics" do
+    test "valid param" do
+      body =
+        Jason.encode!(%{
+          phone_number: "123-456-789",
+          postal_address: "123 Lane St"
+        })
+
+      conn =
+        :post
+        |> Plug.Test.conn("/api/users/123/contact_info", body)
+        |> Plug.Conn.put_req_header("content-type", "application/json")
+        |> OpenApiSpexTest.Router.call([])
+
+      assert conn.status == 200
+      assert conn.private.open_api_spex.params == conn.params
+
+      assert OpenApiSpex.params(conn) == %{validParam: true}
+    end
+  end
+
   describe "query params - basics" do
     test "valid param" do
       conn =


### PR DESCRIPTION
I've added :body in :in options, in that way the plug will catch if received body do not match the api schema condition