### PR TITLE
Allow additional schema options on Operation.parameter/5

### DIFF
--- a/lib/open_api_spex/operation.ex
+++ b/lib/open_api_spex/operation.ex
@@ -104,9 +104,11 @@ defmodule OpenApiSpex.Operation do
       [name: name, in: location, description: description, required: location == :path]
       |> Keyword.merge(opts)
 
+    schema = Keyword.get(opts, :schema, type)
+
     Parameter
     |> struct!(params)
-    |> Parameter.put_schema(type)
+    |> Parameter.put_schema(schema)
   end
 
   @doc """

--- a/test/operation_test.exs
+++ b/test/operation_test.exs
@@ -63,5 +63,26 @@ defmodule OpenApiSpex.OperationTest do
                  }
                )
     end
+
+    test "parameter" do
+      assert %OpenApiSpex.Parameter{
+               name: :some_param,
+               in: :query,
+               description: "A string param description",
+               required: false,
+               schema: %OpenApiSpex.Schema{type: :string}
+             } = Operation.parameter(:some_param, :query, :string, "A string param description")
+
+      assert %OpenApiSpex.Parameter{
+               name: :some_param,
+               in: :query,
+               description: "A string param description",
+               required: false,
+               schema: %OpenApiSpex.Schema{enum: ["foo", "bar"], type: :string}
+             } =
+               Operation.parameter(:some_param, :query, :string, "A string param description",
+                 schema: %OpenApiSpex.Schema{type: :string, enum: ["foo", "bar"]}
+               )
+    end
   end
 end


### PR DESCRIPTION
When trying to add additional fields to the `OpenApiSpex.Schema` sent as an option to the `Operation.parameter` function, these options suddenly dissapeared and all that was returned in the resulting JSON was the `:type` key.

This commit adds an additional step to check if the `:schema` key was passed as an option before falling back to building a `schema` solely including the parameter type. This will be useful when displaying for example `enum: ["foo", "bar"]` for a query param taking only some values

Fixes https://github.com/open-api-spex/open_api_spex/issues/563