### PR TITLE
Accept read_write_scope from opts when calling cast functions directly

### DIFF
--- a/lib/open_api_spex.ex
+++ b/lib/open_api_spex.ex
@@ -72,12 +72,17 @@ defmodule OpenApiSpex do
   @doc """
   Cast and validate a value against a given Schema belonging to a given OpenApi spec.
   """
-  def cast_value(value, schema = %schema_mod{}, spec = %OpenApi{})
+  def cast_value(value, schema = %schema_mod{}, spec = %OpenApi{}, opts \\ [])
       when schema_mod in [Schema, Reference] do
-    OpenApiSpex.Cast.cast(schema, value, spec.components.schemas)
+    OpenApiSpex.Cast.cast(schema, value, spec.components.schemas, opts)
   end
 
-  @type cast_opt :: {:replace_params, boolean()} | {:apply_defaults, boolean()}
+  @type read_write_scope :: nil | :read | :write
+
+  @type cast_opt ::
+          {:replace_params, boolean()}
+          | {:apply_defaults, boolean()}
+          | {:read_write_scope, read_write_scope()}
 
   @spec cast_and_validate(
           OpenApi.t(),

--- a/lib/open_api_spex/cast.ex
+++ b/lib/open_api_spex/cast.ex
@@ -22,7 +22,7 @@ defmodule OpenApiSpex.Cast do
 
   @type schema_or_reference :: Schema.t() | Reference.t()
 
-  @type cast_opt :: {:apply_defaults, boolean()}
+  @type cast_opt :: {:apply_defaults, boolean()} | {:read_write_scope, read_write_scope()}
 
   @type t :: %__MODULE__{
           value: term(),
@@ -103,7 +103,16 @@ defmodule OpenApiSpex.Cast do
   @spec cast(schema_or_reference | nil, term(), map(), [cast_opt()]) ::
           {:ok, term()} | {:error, [Error.t()]}
   def cast(schema, value, schemas \\ %{}, opts \\ []) do
-    ctx = %__MODULE__{schema: schema, value: value, schemas: schemas, opts: opts}
+    read_write_scope = Keyword.get(opts, :read_write_scope)
+
+    ctx = %__MODULE__{
+      schema: schema,
+      value: value,
+      schemas: schemas,
+      read_write_scope: read_write_scope,
+      opts: opts
+    }
+
     cast(ctx)
   end
 

--- a/lib/open_api_spex/cast/utils.ex
+++ b/lib/open_api_spex/cast/utils.ex
@@ -17,7 +17,7 @@ defmodule OpenApiSpex.Cast.Utils do
   def check_required_fields(%{value: input_map} = ctx), do: check_required_fields(ctx, input_map)
 
   def check_required_fields(ctx, %{} = input_map) do
-    required = ctx.schema.required || []
+    required = Map.get(ctx.schema, :required) || []
 
     # Adjust required fields list, based on read_write_scope
     required =

--- a/test/cast_test.exs
+++ b/test/cast_test.exs
@@ -253,6 +253,26 @@ defmodule OpenApiSpec.CastTest do
     end
   end
 
+  describe "opts" do
+    test "read_write_scope" do
+      schema = %Schema{
+        type: :object,
+        properties: %{
+          id: %Schema{type: :string, readOnly: true},
+          name: %Reference{"$ref": "#/components/schemas/Name"},
+          age: %Schema{type: :integer}
+        },
+        required: [:id, :name, :age]
+      }
+
+      schemas = %{"Name" => %Schema{type: :string, readOnly: true}}
+
+      value = %{"age" => 30}
+      assert {:error, _} = Cast.cast(schema, value, schemas, [])
+      assert {:ok, %{age: 30}} == Cast.cast(schema, value, schemas, read_write_scope: :write)
+    end
+  end
+
   describe "ok/1" do
     test "basics" do
       assert {:ok, 1} = Cast.ok(%Cast{value: 1})


### PR DESCRIPTION
`read_write_scope` is needed fort correctly handling `readOnly` and `writeOnly` required properties but it is non populated when calling directly cast functions. This adds that option.

There was also a problem when the property marked as `readOnly` or `writeOnly` is inside a reference. Before this change the   [`check_required_fields` function took as input the original `ctx` with properties not yet resolved](https://github.com/open-api-spex/open_api_spex/pull/572/files#diff-aa0035d77c1a9fcfa904c6bc5a3f8110b8e78d360a19bbaf1670767f53ad56dbL25). Now the `ctx` is updated with resolved properties and the required check works as expected. In doing so I also changed a little bit the `Object` module to make all functions modify and accept the same `ctx` making the code much more readable.

Fixes #499 and supersedes #513