### PR TITLE
Cast discriminator when no title present

### DIFF
--- a/test/cast/discriminator_test.exs
+++ b/test/cast/discriminator_test.exs
@@ -143,6 +143,29 @@ defmodule OpenApiSpex.CastDiscriminatorTest do
       assert cast(value: input_value, schema: discriminator_schema) == expected
     end
 
+    test "without title", %{schemas: %{dog: dog, cat: cat}} do
+      dog = Map.put(dog, :title, nil)
+      cat = Map.put(cat, :title, nil)
+
+      schemas = %{"Dog" => dog, "Cat" => cat}
+
+      discriminator_schema = %OpenApiSpex.Schema{
+        anyOf: [
+          %OpenApiSpex.Reference{"$ref": "#/components/schemas/Dog"},
+          %OpenApiSpex.Reference{"$ref": "#/components/schemas/Cat"}
+        ],
+        discriminator: %{
+          mapping: %{"dog" => "#/components/schemas/Dog", "cat" => "#/components/schemas/Cat"},
+          propertyName: "animal_type"
+        },
+        type: :object
+      }
+
+      input_value = %{@discriminator => "dog", "breed" => "Corgi", "age" => 1}
+      expected = {:ok, %{age: 1, breed: "Corgi", animal_type: "dog"}}
+      assert cast(value: input_value, schema: discriminator_schema, schemas: schemas) == expected
+    end
+
     test "valid discriminator mapping but schema does not match", %{
       schemas: %{dog: dog, wolf: wolf, cat: cat}
     } do

--- a/test/mix/tasks/openapi.spec.json_test.exs
+++ b/test/mix/tasks/openapi.spec.json_test.exs
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.Openapi.Spec.JsonTest do
     Mix.Tasks.Openapi.Spec.Json.run(~w(
       --quiet=true
       --spec OpenApiSpexTest.Tasks.SpecModule
-      "tmp/openapi.json"
+      tmp/openapi.json
     ))
 
     refute_received {:mix_shell, :info, ["* creating tmp"]}


### PR DESCRIPTION
When elements of a discriminator does not have a `title` property the cast fails. The `mapping` can indeed contain references so we can fallback to use them to retrieve the discriminator schema from `ctx.schemas`.

A part for variables renaming the main change is [this](https://github.com/open-api-spex/open_api_spex/compare/master...athonet-open:open_api_spex:fix-discriminator?expand=1#diff-7e4bf47947cd534c1229c24ddfad11146800674538e17c7533b1c7f8e18aab6bL96)