### PR TITLE
fixed start-app false when generating openapi file

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ mix openapi.spec.yaml --spec MyAppWeb.ApiSpec
 ```
 
 Invoking this task starts the application by default. This can be
-disabled with the `--start-app=false` option.
+disabled with the `--no-start-app` option.
 
 Please make to replace any calls to [OpenApiSpex.Server.from_endpoint](https://hexdocs.pm/open_api_spex/OpenApiSpex.Server.html#from_endpoint/1) with a `%OpenApiSpex.Server{}` struct like below:
 

--- a/lib/mix/tasks/openapi.spec.json.ex
+++ b/lib/mix/tasks/openapi.spec.json.ex
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.Openapi.Spec.Json do
 
       $ mix openapi.spec.json --spec PhoenixAppWeb.ApiSpec apispec.json
       $ mix openapi.spec.json --spec PhoenixAppWeb.ApiSpec --pretty=true
-      $ mix openapi.spec.json --spec PhoenixAppWeb.ApiSpec --start-app=false
+      $ mix openapi.spec.json --spec PhoenixAppWeb.ApiSpec --no-start-app
       $ mix openapi.spec.json --spec PhoenixAppWeb.ApiSpec --vendor-extensions=false
 
   ## Command line options
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.Openapi.Spec.Json do
 
   * `--pretty` - Whether to prettify the generated JSON (defaults to false)
 
-  * `--start-app` - Whether need to start application before generate schema (defaults to true)
+  * `--no-start-app` - Whether need to avoid to start application before generate schema (by default it starts the application)
 
   * `--vendor-extensions` - Whether to include open_api_spex OpenAPI vendor extensions
     (defaults to true)
@@ -30,7 +30,7 @@ defmodule Mix.Tasks.Openapi.Spec.Json do
 
   @impl true
   def run(argv) do
-    {opts, _, _} = OptionParser.parse(argv, strict: [start_app: :boolean])
+    {opts, _, _} = OptionParser.parse(argv, switches: [start_app: :boolean])
 
     Keyword.get(opts, :start_app, true) |> maybe_start_app()
     OpenApiSpex.ExportSpec.call(argv, &encode/2, @default_filename)

--- a/lib/mix/tasks/openapi.spec.yaml.ex
+++ b/lib/mix/tasks/openapi.spec.yaml.ex
@@ -6,14 +6,14 @@ defmodule Mix.Tasks.Openapi.Spec.Yaml do
   ## Examples
 
       $ mix openapi.spec.yaml --spec PhoenixAppWeb.ApiSpec apispec.yaml
-      $ mix openapi.spec.yaml --spec PhoenixAppWeb.ApiSpec --start-app=false
+      $ mix openapi.spec.yaml --spec PhoenixAppWeb.ApiSpec --no-start-app
       $ mix openapi.spec.yaml --spec PhoenixAppWeb.ApiSpec --vendor-extensions=false
 
   ## Command line options
 
   * `--spec` - The ApiSpec module from which to generate the OpenAPI YAML file
 
-  * `--start-app` - Whether to start the application before generating the schema (defaults to true)
+  * `--no-start-app` - Whether need to avoid to start application before generate schema (by default it starts the application)
 
   * `--vendor-extensions` - Whether to include open_api_spex OpenAPI vendor extensions
     (defaults to true)
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.Openapi.Spec.Yaml do
 
   @impl Mix.Task
   def run(argv) do
-    {opts, _, _} = OptionParser.parse(argv, strict: [start_app: :boolean])
+    {opts, _, _} = OptionParser.parse(argv, switches: [start_app: :boolean])
 
     Keyword.get(opts, :start_app, true) |> maybe_start_app()
     OpenApiSpex.ExportSpec.call(argv, &encode/2, @default_filename)


### PR DESCRIPTION
fixes #489 .
The fix implements a proper usage of `OptionParser`. When it uses `boolean` it is not able to understand assigned values like `true` or `false` but only if the key is present. The alternative is to use `switches` where you can prefix `no` to the existing key to switch the value to false or another approach is to handle it as a string and check for the passed value if it is `=false`. I implemented the one using `swthces`