### PR TITLE
Exclude empty paths from spec

### DIFF
--- a/lib/open_api_spex/path_item.ex
+++ b/lib/open_api_spex/path_item.ex
@@ -69,6 +69,10 @@ defmodule OpenApiSpex.PathItem do
     |> from_valid_routes()
   end
 
+  def empty?(%__MODULE__{} = path_item) do
+    path_item == %__MODULE__{}
+  end
+
   @spec from_valid_routes([route]) :: nil | t
   defp from_valid_routes([]), do: nil
 

--- a/lib/open_api_spex/path_item.ex
+++ b/lib/open_api_spex/path_item.ex
@@ -69,24 +69,21 @@ defmodule OpenApiSpex.PathItem do
     |> from_valid_routes()
   end
 
-  def empty?(%__MODULE__{} = path_item) do
-    path_item == %__MODULE__{}
-  end
-
   @spec from_valid_routes([route]) :: nil | t
   defp from_valid_routes([]), do: nil
 
   defp from_valid_routes(routes) do
-    attrs =
-      routes
-      |> Enum.map(fn route ->
-        case Operation.from_route(route) do
-          nil -> nil
-          op -> {route.verb, op}
-        end
-      end)
-      |> Enum.filter(& &1)
-
-    struct(PathItem, attrs)
+    routes
+    |> Enum.map(fn route ->
+      case Operation.from_route(route) do
+        nil -> nil
+        op -> {route.verb, op}
+      end
+    end)
+    |> Enum.filter(& &1)
+    |> case do
+      [] -> nil
+      attrs -> struct(PathItem, attrs)
+    end
   end
 end

--- a/lib/open_api_spex/paths.ex
+++ b/lib/open_api_spex/paths.ex
@@ -39,6 +39,7 @@ defmodule OpenApiSpex.Paths do
       |> Enum.group_by(fn route -> route.path end)
       |> Enum.map(fn {k, v} -> {open_api_path(k), PathItem.from_routes(v)} end)
       |> Enum.filter(fn {_k, v} -> !is_nil(v) end)
+      |> Enum.reject(fn {_k, v} -> PathItem.empty?(v) end)
       |> Map.new()
 
     paths

--- a/lib/open_api_spex/paths.ex
+++ b/lib/open_api_spex/paths.ex
@@ -39,7 +39,6 @@ defmodule OpenApiSpex.Paths do
       |> Enum.group_by(fn route -> route.path end)
       |> Enum.map(fn {k, v} -> {open_api_path(k), PathItem.from_routes(v)} end)
       |> Enum.filter(fn {_k, v} -> !is_nil(v) end)
-      |> Enum.reject(fn {_k, v} -> PathItem.empty?(v) end)
       |> Map.new()
 
     paths

--- a/test/paths_test.exs
+++ b/test/paths_test.exs
@@ -13,6 +13,7 @@ defmodule OpenApiSpex.PathsTest do
              } = paths
 
       refute Map.has_key?(paths, "/api/noapi")
+      refute Map.has_key?(paths, "/api/noapi_with_struct")
 
       assert pets_path_item.patch.operationId == "OpenApiSpexTest.PetController.update"
       assert pets_path_item.put.operationId == "OpenApiSpexTest.PetController.update (2)"

--- a/test/paths_test.exs
+++ b/test/paths_test.exs
@@ -12,6 +12,8 @@ defmodule OpenApiSpex.PathsTest do
                "/api/pets/{id}" => pets_path_item
              } = paths
 
+      refute Map.has_key?(paths, "/api/noapi")
+
       assert pets_path_item.patch.operationId == "OpenApiSpexTest.PetController.update"
       assert pets_path_item.put.operationId == "OpenApiSpexTest.PetController.update (2)"
     end


### PR DESCRIPTION
We have an issue where the actions that is explicitly marked with `operation false` still show up with empty paths in the spec file. This removes the path from the spec if there are no actions specified.

I'm not sure if comparing with an empty `PathItem` is the best approach here. Please let me know if there is something better that can be used instead.