### PR TITLE
Relax dependency constraint on ymlr to allow version ~> 5.0

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -65,12 +65,17 @@ jobs:
     name: Test (OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}})
     strategy:
       matrix:
-        otp: ['22', '23', '24', '25']
-        elixir: ['1.11', '1.12', '1.13']
+        otp: ['22', '23', '24', '25', '26']
+        elixir: ['1.11', '1.12', '1.13', '1.14', '1.15', '1.16']
         exclude:
           - {otp: '25', elixir: '1.10'}
           - {otp: '25', elixir: '1.11'}
           - {otp: '25', elixir: '1.12'}
+          - {otp: '26', elixir: '1.10'}
+          - {otp: '26', elixir: '1.11'}
+          - {otp: '26', elixir: '1.12'}
+          - {otp: '26', elixir: '1.13'}
+          - {otp: '26', elixir: '1.14'}
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/mix.exs
+++ b/mix.exs
@@ -70,7 +70,7 @@ defmodule OpenApiSpex.Mixfile do
       {:phoenix, "~> 1.3", only: [:dev, :test]},
       {:plug, "~> 1.7"},
       {:poison, "~> 3.0 or ~> 4.0 or ~> 5.0", optional: true},
-      {:ymlr, "~> 2.0 or ~> 3.0 or ~> 4.0", optional: true}
+      {:ymlr, "~> 2.0 or ~> 3.0 or ~> 4.0 or ~> 5.0", optional: true}
     ]
   end
 

--- a/test/cast/object_test.exs
+++ b/test/cast/object_test.exs
@@ -415,7 +415,11 @@ defmodule OpenApiSpex.ObjectTest do
         }
       }
 
-      assert {:error, [error1, error2]} = cast(value: %{"age" => 0, "name" => "N"}, schema: schema)
+      assert {:error, [_error1, _error2] = errors} =
+               cast(value: %{"age" => 0, "name" => "N"}, schema: schema)
+
+      error1 = Enum.find(errors, &(&1.path == [:age]))
+      error2 = Enum.find(errors, &(&1.path == [:name]))
 
       assert %Error{} = error1
       assert error1.reason == :minimum

--- a/test/paths_test.exs
+++ b/test/paths_test.exs
@@ -15,8 +15,8 @@ defmodule OpenApiSpex.PathsTest do
       refute Map.has_key?(paths, "/api/noapi")
       refute Map.has_key?(paths, "/api/noapi_with_struct")
 
-      assert pets_path_item.patch.operationId == "OpenApiSpexTest.PetController.update"
-      assert pets_path_item.put.operationId == "OpenApiSpexTest.PetController.update (2)"
+      assert pets_path_item.put.operationId == "OpenApiSpexTest.PetController.update"
+      assert pets_path_item.patch.operationId == "OpenApiSpexTest.PetController.update (2)"
     end
   end
 end


### PR DESCRIPTION
Seems to also work with ymlr 5.0.0

Also:
- I noticed that 2 tests were failing. Maybe it's because I'm running Elixir 1.16. I tried to fix them.
- I also added more Elixir versions to the CI pipeline.