### PR TITLE
fix: merge body params into params as per Plug conventions

### DIFF
--- a/lib/open_api_spex/operation2.ex
+++ b/lib/open_api_spex/operation2.ex
@@ -72,7 +72,8 @@ defmodule OpenApiSpex.Operation2 do
   end
 
   defp maybe_replace_body(conn, _body, false), do: conn
-  defp maybe_replace_body(conn, body, true), do: %{conn | body_params: body}
+  defp maybe_replace_body(conn = %{params: params}, body, true),
+    do: %{conn | body_params: body, params: Map.merge(params, body)}
 
   defp cast_parameters(conn, operation, spec, opts) do
     CastParameters.cast(conn, operation, spec, opts)

--- a/test/operation2_test.exs
+++ b/test/operation2_test.exs
@@ -175,7 +175,9 @@ defmodule OpenApiSpex.Operation2Test do
 
   describe "cast/4" do
     test "cast request body" do
-      conn = create_conn(%{"user" => %{"email" => "foo@bar.com"}})
+      conn =
+        create_conn(%{"user" => %{"email" => "foo@bar.com"}})
+        |> Map.put(:params, %{"id" => 1})
 
       assert {:ok, conn} =
                Operation2.cast(
@@ -185,7 +187,10 @@ defmodule OpenApiSpex.Operation2Test do
                  "application/json"
                )
 
-      assert %Plug.Conn{} = conn
+      assert %Plug.Conn{
+               body_params: %{user: %{email: "foo@bar.com"}},
+               params: %{user: %{email: "foo@bar.com"}}
+             } = conn
     end
 
     test "cast request body with replace_params: false" do


### PR DESCRIPTION
This is a proper fix to make casting conventional with Plug fixes [#123](https://github.com/open-api-spex/open_api_spex/issues/588)