### PR TITLE
Use updated name for HTTP 422 ("Unprocessable Content") in JSON error response schema

### DIFF
--- a/lib/open_api_spex/json_error_response.ex
+++ b/lib/open_api_spex/json_error_response.ex
@@ -6,7 +6,7 @@ defmodule OpenApiSpex.JsonErrorResponse do
 
       @doc responses: %{
              201 => {"User", "application/json", UserResponse}
-             422 => {"Unprocessable Entity", "application/json", OpenApiSpex.JsonErrorResponse}
+             422 => {"Unprocessable Content", "application/json", OpenApiSpex.JsonErrorResponse}
            }
   """
   require OpenApiSpex
@@ -49,7 +49,7 @@ defmodule OpenApiSpex.JsonErrorResponse do
   """
   def response do
     Operation.response(
-      "Unprocessable Entity",
+      "Unprocessable Content",
       "application/json",
       __MODULE__
     )


### PR DESCRIPTION
The newest RFC on HTTP Semantics (RFC 9110) no longer uses the term `Unprocessable Entity` when describing HTTP 422, but now refers to it as `Unprocessable Content`.

This commit updates the default JSON error response schema to reflect this change.

Ref: https://httpwg.org/specs/rfc9110.html#status.422