### PR TITLE
fix: ensure operation_id is always set on conn.private

### DIFF
--- a/lib/open_api_spex/operation2.ex
+++ b/lib/open_api_spex/operation2.ex
@@ -44,22 +44,11 @@ defmodule OpenApiSpex.Operation2 do
       {:ok,
        conn
        |> cast_conn(body)
-       |> maybe_replace_body(body, replace_params)
-       |> put_operation_id(operation)}
+       |> maybe_replace_body(body, replace_params)}
     end
   end
 
   ## Private functions
-
-  defp put_operation_id(conn, operation) do
-    private_data =
-      conn
-      |> Map.get(:private)
-      |> Map.get(:open_api_spex, %{})
-      |> Map.put(:operation_id, operation.operationId)
-
-    Plug.Conn.put_private(conn, :open_api_spex, private_data)
-  end
 
   defp cast_conn(conn, body) do
     private_data =

--- a/lib/open_api_spex/plug/cast_and_validate.ex
+++ b/lib/open_api_spex/plug/cast_and_validate.ex
@@ -78,6 +78,7 @@ defmodule OpenApiSpex.Plug.CastAndValidate do
       ) do
     {spec, operation_lookup} = PutApiSpec.get_spec_and_operation_lookup(conn)
     operation = operation_lookup[operation_id]
+    conn = put_operation_id(conn, operation)
 
     cast_opts = opts |> Map.take([:replace_params]) |> Map.to_list()
 
@@ -149,5 +150,15 @@ defmodule OpenApiSpex.Plug.CastAndValidate do
 
   def call(_conn, _opts) do
     raise ":open_api_spex was not found under :private. Maybe PutApiSpec was not called before?"
+  end
+
+  defp put_operation_id(conn, operation) do
+    private_data =
+      conn
+      |> Map.get(:private)
+      |> Map.get(:open_api_spex, %{})
+      |> Map.put(:operation_id, operation.operationId)
+
+    Plug.Conn.put_private(conn, :open_api_spex, private_data)
   end
 end

--- a/lib/open_api_spex/plug/swagger_ui_oauth2_redirect.ex
+++ b/lib/open_api_spex/plug/swagger_ui_oauth2_redirect.ex
@@ -6,6 +6,8 @@ defmodule OpenApiSpex.Plug.SwaggerUIOAuth2Redirect do
 
   import Plug.Conn
 
+  alias OpenApiSpex.Plug.SwaggerUI
+
   @html """
     <!-- HTML for static distribution bundle build -->
     <!doctype html>
@@ -104,7 +106,7 @@ defmodule OpenApiSpex.Plug.SwaggerUIOAuth2Redirect do
 
   @impl Plug
   def call(conn, config) do
-    html = render(OpenApiSpex.Plug.SwaggerUI.get_nonce(conn, config, :script))
+    html = render(SwaggerUI.get_nonce(conn, config, :script))
 
     conn
     |> put_resp_content_type("text/html")

--- a/test/support/pet_controller.ex
+++ b/test/support/pet_controller.ex
@@ -37,7 +37,18 @@ defmodule OpenApiSpexTest.PetController do
   @doc """
   Get a list of pets.
   """
-  @doc responses: [ok: {"Pet list", "application/json", Schemas.PetsResponse}],
+  @doc parameters: [
+         age: [
+           in: :query,
+           type: %Schema{type: :integer, minimum: 1},
+           description: "Age of the pet",
+           example: 1
+         ]
+       ],
+       responses: [
+         ok: {"Pet list", "application/json", Schemas.PetsResponse},
+         unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
+       ],
        operation_id: "listPets"
   def index(conn, _params) do
     json(conn, %Schemas.PetsResponse{

--- a/test/test_assertions_test.exs
+++ b/test/test_assertions_test.exs
@@ -120,6 +120,16 @@ defmodule OpenApiSpex.TestAssertionsTest do
       TestAssertions.assert_operation_response(conn)
     end
 
+    test "is able to find the operationId via conn when there is an error" do
+      conn =
+        :get
+        |> Plug.Test.conn("/api/pets?age=notanumber")
+        |> OpenApiSpexTest.Router.call([])
+
+      assert conn.status == 422
+      TestAssertions.assert_operation_response(conn)
+    end
+
     test "success with a response code range" do
       conn =
         :get


### PR DESCRIPTION
There was an issue where you had to pass in the `operationId` on error cases to `assert_operation_response` because of the nature of the error handling halting and returning a collection of errors for the given step. Lifting the `put_operation_id` up gets around all of that as even if things `halt`, we'll still have a reference to the operationId in `conn.private`