### PR TITLE
Set read_write_scope in CastAndValidate plug

### DIFF
--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -25,6 +25,10 @@ defmodule OpenApiSpexTest.Router do
     get "/users/:id/payment_details", OpenApiSpexTest.UserController, :payment_details
     post "/users/:id/contact_info", OpenApiSpexTest.UserController, :contact_info
     post "/users/create_entity", OpenApiSpexTest.UserController, :create_entity
+
+    post "/users/search", OpenApiSpexTest.UserController, :search,
+      assigns: %{read_write_scope: :read}
+
     get "/openapi", OpenApiSpex.Plug.RenderSpec, []
 
     resources "/pets", OpenApiSpexTest.PetController, only: [:create, :index, :show, :update]

--- a/test/support/user_controller.ex
+++ b/test/support/user_controller.ex
@@ -100,6 +100,44 @@ defmodule OpenApiSpexTest.UserController do
   end
 
   @doc """
+  Search user.
+
+  Find a user by name and email.
+  """
+  @doc request_body: {"The user attributes", "application/json", Schemas.UserRequest},
+       responses: [
+         ok: {"User", "application/json", Schemas.UserResponse},
+         not_found: Schemas.NotFound.response(),
+         unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
+       ]
+  def search(conn = %{body_params: %Schemas.UserRequest{user: user = %Schemas.User{}}}, _) do
+    case user do
+      %Schemas.User{name: "joe user", email: "joe@gmail.com"} ->
+        conn
+        |> put_status(200)
+        |> json(%Schemas.UserResponse{
+          data: %Schemas.User{
+            id: 123,
+            name: "joe user",
+            email: "joe@gmail.com"
+          }
+        })
+
+      _ ->
+        conn
+        |> put_status(404)
+        |> json(%{
+          errors: [
+            %{
+              title: "Not Found",
+              detail: "The requested resource cannot be found."
+            }
+          ]
+        })
+    end
+  end
+
+  @doc """
   Show user payment details.
 
   Shows a users payment details.


### PR DESCRIPTION
This is the last missing piece to make `readOnly` and `writeOnly` work with the plug.

With this PR merged `read_write_scope` is set either based on the HTTP method or manual configuration set in the routes.

Fixes #499.