### PR TITLE
improvement: use struct spec to avoid double `%` in struct inspect

### DIFF
--- a/lib/open_api_spex/inspect/for_schema.ex
+++ b/lib/open_api_spex/inspect/for_schema.ex
@@ -16,6 +16,6 @@ defimpl Inspect, for: OpenApiSpex.Schema do
           Map.has_key?(map, field),
           do: info
 
-     Inspect.Map.inspect(map, Macro.inspect_atom(:literal, OpenApiSpex.Schema), infos, opts)
+    Inspect.Map.inspect(map, to_doc(OpenApiSpex.Schema, opts), infos, opts)
   end
 end

--- a/lib/open_api_spex/inspect/for_schema.ex
+++ b/lib/open_api_spex/inspect/for_schema.ex
@@ -14,7 +14,6 @@ defimpl Inspect, for: OpenApiSpex.Schema do
     infos =
       for %{field: field} = info <- OpenApiSpex.Schema.__info__(:struct),
           Map.has_key?(map, field),
-          field not in [:__struct__, :__exception__],
           do: info
 
      Inspect.Map.inspect(map, Macro.inspect_atom(:literal, OpenApiSpex.Schema), infos, opts)

--- a/lib/open_api_spex/inspect/for_schema.ex
+++ b/lib/open_api_spex/inspect/for_schema.ex
@@ -11,6 +11,12 @@ defimpl Inspect, for: OpenApiSpex.Schema do
       end)
       |> Map.new()
 
-    concat(["%OpenApiSpex.Schema", to_doc(map, opts)])
+    infos =
+      for %{field: field} = info <- OpenApiSpex.Schema.__info__(:struct),
+          Map.has_key?(map, field),
+          field not in [:__struct__, :__exception__],
+          do: info
+
+     Inspect.Map.inspect(map, Macro.inspect_atom(:literal, OpenApiSpex.Schema), infos, opts)
   end
 end

--- a/test/inspect/for_schema_test.exs
+++ b/test/inspect/for_schema_test.exs
@@ -5,6 +5,6 @@ defmodule OpenApiSpex.Inspect.ForSchemaTest do
   test "inspect schema" do
     schema = %Schema{title: "Hello"}
     output = inspect(schema)
-    assert output == "%OpenApiSpex.Schema%{title: \"Hello\"}"
+    assert output == "%OpenApiSpex.Schema{title: \"Hello\"}"
   end
 end


### PR DESCRIPTION
currently, inspecting an `OpenApiSpex.Schema` looks like this:

`%OpenApiSpex.Schema%{type: :object}`

with the new change, it looks like this:

`%OpenApiSpex.Schema{type: :object}`

which allows copy/pasting the struct