### PR TITLE
Feat: add `--check` option in Mix tasks to compare the generated spec with a previously generated file

### DIFF
--- a/lib/mix/tasks/openapi.spec.json.ex
+++ b/lib/mix/tasks/openapi.spec.json.ex
@@ -7,6 +7,7 @@ defmodule Mix.Tasks.Openapi.Spec.Json do
 
       $ mix openapi.spec.json --spec PhoenixAppWeb.ApiSpec apispec.json
       $ mix openapi.spec.json --spec PhoenixAppWeb.ApiSpec --pretty=true
+      $ mix openapi.spec.json --spec PhoenixAppWeb.ApiSpec --check=true
       $ mix openapi.spec.json --spec PhoenixAppWeb.ApiSpec --start-app=false
       $ mix openapi.spec.json --spec PhoenixAppWeb.ApiSpec --vendor-extensions=false
 
@@ -15,6 +16,8 @@ defmodule Mix.Tasks.Openapi.Spec.Json do
   * `--spec` - The ApiSpec module from which to generate the OpenAPI JSON file
 
   * `--pretty` - Whether to prettify the generated JSON (defaults to false)
+
+  * `--check` - Whether to only compare the generated JSON with the spec file (defaults to false)
 
   * `--start-app` - Whether need to start application before generate schema (defaults to true)
 

--- a/lib/mix/tasks/openapi.spec.yaml.ex
+++ b/lib/mix/tasks/openapi.spec.yaml.ex
@@ -6,12 +6,15 @@ defmodule Mix.Tasks.Openapi.Spec.Yaml do
   ## Examples
 
       $ mix openapi.spec.yaml --spec PhoenixAppWeb.ApiSpec apispec.yaml
+      $ mix openapi.spec.yaml --spec PhoenixAppWeb.ApiSpec --check=true
       $ mix openapi.spec.yaml --spec PhoenixAppWeb.ApiSpec --start-app=false
       $ mix openapi.spec.yaml --spec PhoenixAppWeb.ApiSpec --vendor-extensions=false
 
   ## Command line options
 
   * `--spec` - The ApiSpec module from which to generate the OpenAPI YAML file
+
+  * `--check` - Whether to only compare the generated YAML with the spec file (defaults to false)
 
   * `--start-app` - Whether to start the application before generating the schema (defaults to true)
 


### PR DESCRIPTION
Add a `--check` option to run Mix tasks and compare the generated spec with a previously generated file.

This is useful for scenarios where a CI check is desirable to catch unwanted drifts from a validated OpenAPI spec: e.g. the OpenAPI spec is committed and reviewed, and should not change without additional review.

Fixes #617