### PR TITLE
chore: Drop build matrix support for elixir 1.11, 1.12, 1.13 and OTP 22

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ['25']
-        elixir: ['1.13']
+        otp: ["26"]
+        elixir: ["1.16"]
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
@@ -45,8 +45,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 24
-          elixir-version: 1.13
+          otp-version: 26
+          elixir-version: 1.16
       - uses: actions/cache@v2
         with:
           key: |
@@ -65,27 +65,17 @@ jobs:
     name: Test (OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}})
     strategy:
       matrix:
-        otp: ['22', '23', '24', '25', '26']
-        elixir: ['1.11', '1.12', '1.13', '1.14', '1.15', '1.16']
+        otp: ["23", "24", "25", "26"]
+        elixir: ["1.14", "1.15", "1.16"]
+        # Test each elixir version with lowest and highest compatible OTP version, exclude others
+        # See https://hexdocs.pm/elixir/compatibility-and-deprecations.html#between-elixir-and-erlang-otp
         exclude:
-          - {otp: '22', elixir: '1.14'}
-          - {otp: '22', elixir: '1.15'}
-          - {otp: '22', elixir: '1.16'}
-          - {otp: '23', elixir: '1.14'}
-          - {otp: '23', elixir: '1.15'}
-          - {otp: '23', elixir: '1.16'}
-          - {otp: '24', elixir: '1.11'}
-          - {otp: '24', elixir: '1.12'}
-          - {otp: '24', elixir: '1.13'}
-          - {otp: '24', elixir: '1.14'}
-          - {otp: '24', elixir: '1.15'}
-          - {otp: '25', elixir: '1.11'}
-          - {otp: '25', elixir: '1.12'}
-          - {otp: '25', elixir: '1.14'}
-          - {otp: '26', elixir: '1.11'}
-          - {otp: '26', elixir: '1.12'}
-          - {otp: '26', elixir: '1.13'}
-          - {otp: '26', elixir: '1.14'}
+          - { otp: "24", elixir: "1.14" }
+          - { otp: "25", elixir: "1.14" }
+          - { otp: "23", elixir: "1.15" }
+          - { otp: "25", elixir: "1.15" }
+          - { otp: "23", elixir: "1.16" }
+          - { otp: "25", elixir: "1.16" }
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule OpenApiSpex.Mixfile do
     [
       app: :open_api_spex,
       version: @version,
-      elixir: "~> 1.11",
+      elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       consolidate_protocols: Mix.env() != :test,


### PR DESCRIPTION
See CI failure in #613 for build failure in older elixir verisons.