### PR TITLE
Remove blank space on rewrited operationId

### DIFF
--- a/lib/open_api_spex/paths.ex
+++ b/lib/open_api_spex/paths.ex
@@ -84,7 +84,7 @@ defmodule OpenApiSpex.Paths do
       rest
       |> Enum.with_index(2)
       |> Enum.map(fn {{path, verb, operation}, occurrence} ->
-        {path, verb, %{operation | operationId: "#{operation_id} (#{occurrence})"}}
+        {path, verb, %{operation | operationId: "#{operation_id}_#{occurrence}"}}
       end)
     end)
   end

--- a/test/paths_test.exs
+++ b/test/paths_test.exs
@@ -18,7 +18,7 @@ defmodule OpenApiSpex.PathsTest do
       operation_ids = [pets_path_item.put.operationId, pets_path_item.patch.operationId]
 
       assert "OpenApiSpexTest.PetController.update" in operation_ids
-      assert "OpenApiSpexTest.PetController.update (2)" in operation_ids
+      assert "OpenApiSpexTest.PetController.update_2" in operation_ids
     end
   end
 end


### PR DESCRIPTION
The operationId is usually used in the URL (e.g: Swagger UI), so URLs should contain only _safe_ chars.

The inspiration for this PR is the spectral linter validation: https://github.com/stoplightio/spectral/blob/develop/packages/rulesets/src/oas/index.ts#L296