### PR TITLE
Add failing test for multipart array parameters

### DIFF
--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -6,7 +6,7 @@ defmodule OpenApiSpexTest.Router do
   pipeline :api do
     plug :accepts, ["json"]
     plug PutApiSpec, module: OpenApiSpexTest.ApiSpec
-    plug Parsers, parsers: [:json], pass: ["text/*"], json_decoder: Jason
+    plug Parsers, parsers: [:json, :multipart], pass: ["text/*"], json_decoder: Jason
   end
 
   scope "/api" do
@@ -25,6 +25,7 @@ defmodule OpenApiSpexTest.Router do
     get "/users/:id/payment_details", OpenApiSpexTest.UserController, :payment_details
     post "/users/:id/contact_info", OpenApiSpexTest.UserController, :contact_info
     post "/users/create_entity", OpenApiSpexTest.UserController, :create_entity
+    post "/upload_multipart", OpenApiSpexTest.UploadMultipartController, :create
     get "/openapi", OpenApiSpex.Plug.RenderSpec, []
 
     resources "/pets", OpenApiSpexTest.PetController, only: [:create, :index, :show, :update]

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -278,6 +278,29 @@ defmodule OpenApiSpexTest.Schemas do
     })
   end
 
+  defmodule UploadRequest do
+    OpenApiSpex.schema(%{
+      title: "UploadRequest",
+      description: "POST body for uploading files",
+      type: :object,
+      properties: %{
+        "files[]": %Schema{type: :array, items: %Schema{type: :string, format: :binary}}
+      },
+      required: [:"files[]"]
+    })
+  end
+
+  defmodule UploadResponse do
+    OpenApiSpex.schema(%{
+      title: "UploadResponse",
+      description: "",
+      type: :object,
+      properties: %{
+        data: %Schema{description: "Filenames", type: :array, items: %Schema{type: :string}}
+      }
+    })
+  end
+
   defmodule UserRequest do
     OpenApiSpex.schema(%{
       title: "UserRequest",

--- a/test/support/upload_multipart_controller.ex
+++ b/test/support/upload_multipart_controller.ex
@@ -1,0 +1,20 @@
+defmodule OpenApiSpexTest.UploadMultipartController do
+  @moduledoc tags: ["uploads"]
+
+  use Phoenix.Controller
+  use OpenApiSpex.Controller
+
+  alias OpenApiSpexTest.Schemas
+
+  plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true, replace_params: false
+
+  @doc request_body: {"Files", "multipart/form-data", Schemas.UploadRequest},
+       responses: [
+         created: {"Files", "application/json", Schemas.UploadResponse}
+       ]
+  def create(conn, %{"files" => files}) do
+    json(conn, %Schemas.UploadResponse{
+      data: Enum.map(files, & &1.filename)
+    })
+  end
+end


### PR DESCRIPTION
Adds a failing spec for the issue described in https://github.com/open-api-spex/open_api_spex/issues/441

```
  1) test query params - basics handles multipart/form-data array parameters (OpenApiSpex.Plug.CastTest)
     test/plug/cast_test.exs:54
     match (=) failed
     code:  assert %{"data" => ["file1.txt", "file2.txt"]} = body
     left:  %{"data" => ["file1.txt", "file2.txt"]}
     right: %{"errors" => [%{"detail" => "Missing field: files[]", "source" => %{"pointer" => "/files[]"}, "title" => "Invalid value"}]}
     stacktrace:
       test/plug/cast_test.exs:79: (test)
```

Array parameters need to be supplied with `[]` on the end of the parameter name, because plug won't parse them into lists without it:

```
iex> Plug.Conn.Query.decode("files=1&files=2")
%{"files" => "2"}
iex> Plug.Conn.Query.decode("files[]=1&files[]=2")
%{"files" => ["1", "2"]}
```

This means the key for the openapi spec needs to have `[]` at the end of array parameters, otherwise clients generated from the openapi.json file will be using the incorrect name in requests (i.e. `files` instead of `files[]`).

Plug's param parsing happens before the CastAndValidate plug, so the plug sees `files` where the user actually provided `files[]` in the request.

How can this be handled?

One option could be to add a `parsed_param_name` option to `Schema`, and use that to cast/validate. Users would then have to provide `parsed_param_name: "files[]"` in this scenario. Maybe there's a way to automatically derive the parsed name from the key name.

Another option is to strip `[]` from the end of key names in the cast/validate plug. This is what the solution provided by @christmoore is doing in https://github.com/open-api-spex/open_api_spex/issues/441#issuecomment-1095288320 (thanks for that @christmoore!). It wouldn't be possible to support `replace_params: true` with this approach though.