### PR TITLE
Fix typo.

### DIFF
--- a/lib/open_api_spex/open_api/decode.ex
+++ b/lib/open_api_spex/open_api/decode.ex
@@ -292,7 +292,7 @@ defmodule OpenApiSpex.OpenApi.Decode do
     |> prop_to_struct(:parameters, Parameters)
     |> prop_to_struct(:requestBody, RequestBody)
     |> prop_to_struct(:callbacks, Callbacks)
-    |> prop_to_struct(:servers, Server)
+    |> prop_to_struct(:servers, Servers)
     |> add_extensions(map)
   end
 


### PR DESCRIPTION
I found this typo because my code doesn't work with valid OpenApi file.

```
10:56:08.878 pid=<0.3186.0> module=Df.Diagram.Component.Config line=95 [warning] ** (FunctionClauseError) no function clause matching in anonymous fn/1 in OpenApiSpex.OpenApi.Decode.add_extensions/2
    (open_api_spex 3.19.1) lib/open_api_spex/open_api/decode.ex:466: anonymous fn(%{"description" => "production", "url" => "https://trexity.app/storage"}) in OpenApiSpex.OpenApi.Decode.add_extensions/2
    (elixir 1.17.2) lib/enum.ex:4301: Enum.filter_list/2
    (open_api_spex 3.19.1) lib/open_api_spex/open_api/decode.ex:466: OpenApiSpex.OpenApi.Decode.add_extensions/2
    (elixir 1.17.2) lib/map.ex:916: Map.update!/3
    (open_api_spex 3.19.1) lib/open_api_spex/open_api/decode.ex:295: OpenApiSpex.OpenApi.Decode.to_struct/2
    (elixir 1.17.2) lib/map.ex:916: Map.update!/3
    (open_api_spex 3.19.1) lib/open_api_spex/open_api/decode.ex:403: OpenApiSpex.OpenApi.Decode.to_struct/2
    (open_api_spex 3.19.1) lib/open_api_spex/open_api/decode.ex:418: anonymous fn/1 in OpenApiSpex.OpenApi.Decode.to_struct/2
    (elixir 1.17.2) lib/map.ex:257: Map.do_map/2
    (elixir 1.17.2) lib/map.ex:257: Map.do_map/2
    (elixir 1.17.2) lib/map.ex:251: Map.new_from_map/2
    (elixir 1.17.2) lib/map.ex:916: Map.update!/3
    (open_api_spex 3.19.1) lib/open_api_spex/open_api/decode.ex:39: OpenApiSpex.OpenApi.Decode.decode/1

```