### PR TITLE
Treat parameters without explicit `style` field as with `style: :form`

### DIFF
--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -160,7 +160,9 @@ defmodule OpenApiSpex.CastParameters do
     end)
   end
 
-  defp pre_parse_parameter(parameter, %{explode: false, style: :form} = _context, _parsers) do
+  defp pre_parse_parameter(parameter, %{explode: false, style: form} = _context, _parsers)
+       # allow nil as `style: :form` should be the default behaviour according to OpenAPI
+       when form in [:form, nil] do
     # e.g. sizes=S,L,M
     # This does not take care of cases where the value may contain a comma itself
     {:ok, String.split(parameter, ",")}


### PR DESCRIPTION
Form style should be the default, according to
https://swagger.io/docs/specification/v3_0/serialization/

Therefore, if the form field was not explicitly set, we should treat as if it was set to form.