### PR TITLE
fix: supports setting a relative path for the API definition URL

### DIFF
--- a/lib/open_api_spex/plug/swagger_ui.ex
+++ b/lib/open_api_spex/plug/swagger_ui.ex
@@ -90,8 +90,7 @@ defmodule OpenApiSpex.Plug.SwaggerUI do
     <% end %>
     window.onload = function() {
       // Begin Swagger UI call region
-      const api_spec_url = new URL(window.location);
-      api_spec_url.pathname = "<%= config.path %>";
+      const api_spec_url = new URL("<%= config.path %>", window.location);
       api_spec_url.hash = "";
       const ui = SwaggerUIBundle({
         url: api_spec_url.href,


### PR DESCRIPTION
By setting a relative path, we can ensure that it works regardless of where the server is hosted.
For example, the server may be served from a subpath.

In the example from the module doc, we can set a relative path `'./openapi` for the Swagger UI,
which is equivalent to the absolute path `/api/openapi` when the server is hosted at the root path.
But if the server is hosted at a subpath like `/myapp`, which is unknown at compile time,
we can use a relative path instead.

```elixir
scope "/" do
  pipe_through :browser # Use the default browser stack

  get "/", MyAppWeb.PageController, :index
  get "/swaggerui", OpenApiSpex.Plug.SwaggerUI,
    path: "/api/openapi",
    default_model_expand_depth: 3,
    display_operation_id: true
end

# Other scopes may use custom stacks.
scope "/api" do
  pipe_through :api
  resources "/users", MyAppWeb.UserController, only: [:index, :create, :show]
  get "/openapi", OpenApiSpex.Plug.RenderSpec, :show
end

# Use a different Swagger UI version
scope "/" do
  pipe_through :browser

  get "/swaggerui", OpenApiSpex.Plug.SwaggerUI,
    path: "./openapi", # changed from `/api/openapi`
    swagger_ui_js_bundle_url: "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.14.0/swagger-ui-bundle.js",
    swagger_ui_js_standalone_preset_url: "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.14.0/swagger-ui-standalone-preset.js",
    swagger_ui_css_url: "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.14.0/swagger-ui.css"
end
```
