### PR TITLE
Document schema resolver duplicate titles behaviour

### DIFF
--- a/lib/open_api_spex.ex
+++ b/lib/open_api_spex.ex
@@ -29,7 +29,17 @@ defmodule OpenApiSpex do
   Then the `UserResponse.schema()` function will be called to load the schema, and
   a `Reference` to the loaded schema will be used in the operation response.
 
-  See `OpenApiSpex.schema` macro for a convenient syntax for defining schema modules.
+  See `OpenApiSpex.schema/2` macro for a convenient syntax for defining schema modules.
+
+  > #### Known Issues {: .info}
+  >
+  > Resolving schemas expects the schema title to be unique for the generated references to be unique.
+  >
+  > For schemas defined with the `OpenApiSpex.schema/2` macro, the title is automatically set
+  > to the last part of module name. For example `MyAppWeb.Schemas.User` will have the title `"User"`,
+  > and `MyAppWeb.OtherSchemas.User` **will also** have the title `"User"` which can lead to conflicts.
+  >
+  > The recommendation is to set the title explicitly in the schema definition.
   """
   @spec resolve_schema_modules(OpenApi.t()) :: OpenApi.t()
   def resolve_schema_modules(spec = %OpenApi{}) do

--- a/test/schema_resolver_test.exs
+++ b/test/schema_resolver_test.exs
@@ -14,206 +14,237 @@ defmodule OpenApiSpex.SchemaResolverTest do
     SchemaResolver
   }
 
-  test "Resolves schemas in OpenApi spec" do
-    spec = %OpenApi{
-      info: %Info{
-        title: "Test",
-        version: "1.0.0"
-      },
-      paths: %{
-        "/api/users" => %PathItem{
-          get: %Operation{
-            responses: %{
-              200 => %Response{
-                description: "Success",
+  describe "resolve_schema_modules/1" do
+    test "resolves schemas in OpenApi spec" do
+      spec = %OpenApi{
+        info: %Info{
+          title: "Test",
+          version: "1.0.0"
+        },
+        paths: %{
+          "/api/users" => %PathItem{
+            get: %Operation{
+              responses: %{
+                200 => %Response{
+                  description: "Success",
+                  content: %{
+                    "application/json" => %MediaType{
+                      schema: OpenApiSpexTest.Schemas.UsersResponse
+                    }
+                  }
+                }
+              }
+            },
+            post: %Operation{
+              description: "Create a user",
+              operationId: "UserController.create",
+              requestBody: %RequestBody{
                 content: %{
                   "application/json" => %MediaType{
-                    schema: OpenApiSpexTest.Schemas.UsersResponse
+                    schema: OpenApiSpexTest.Schemas.UserRequest
+                  }
+                }
+              },
+              responses: %{
+                201 => %Response{
+                  description: "Created",
+                  content: %{
+                    "application/json" => %MediaType{
+                      schema: OpenApiSpexTest.Schemas.UserResponse
+                    }
                   }
                 }
               }
             }
           },
-          post: %Operation{
-            description: "Create a user",
-            operationId: "UserController.create",
-            requestBody: %RequestBody{
-              content: %{
-                "application/json" => %MediaType{
-                  schema: OpenApiSpexTest.Schemas.UserRequest
-                }
-              }
-            },
-            responses: %{
-              201 => %Response{
-                description: "Created",
-                content: %{
-                  "application/json" => %MediaType{
-                    schema: OpenApiSpexTest.Schemas.UserResponse
-                  }
-                }
-              }
-            }
-          }
-        },
-        "/api/users/{id}/payment_details" => %PathItem{
-          get: %Operation{
-            responses: %{
-              200 => %Response{
-                description: "Success",
-                content: %{
-                  "application/json" => %MediaType{
-                    schema: OpenApiSpexTest.Schemas.PaymentDetails
-                  }
-                }
-              }
-            }
-          }
-        },
-        "/api/users/{id}/friends" => %PathItem{
-          get: %Operation{
-            parameters: [
-              %OpenApiSpex.Parameter{
-                name: :id,
-                in: :path,
-                schema: %Schema{type: :integer}
-              }
-            ],
-            responses: %{
-              200 => %Response{
-                description: "Success",
-                content: %{
-                  "application/json" => %MediaType{
-                    schema: %Schema{
-                      type: :array,
-                      items: OpenApiSpexTest.Schemas.User
+          "/api/users/{id}/payment_details" => %PathItem{
+            get: %Operation{
+              responses: %{
+                200 => %Response{
+                  description: "Success",
+                  content: %{
+                    "application/json" => %MediaType{
+                      schema: OpenApiSpexTest.Schemas.PaymentDetails
                     }
                   }
                 }
               }
             }
-          }
-        },
-        "/api/users/subscribe" => %PathItem{
-          post: %Operation{
-            description: "Subscribe to user updates",
-            operationId: "UserController.subscribe",
-            requestBody: %RequestBody{
-              required: true,
-              content: %{
-                "application/json" => %MediaType{
-                  schema: OpenApiSpexTest.Schemas.UserSubscribeRequest
+          },
+          "/api/users/{id}/friends" => %PathItem{
+            get: %Operation{
+              parameters: [
+                %OpenApiSpex.Parameter{
+                  name: :id,
+                  in: :path,
+                  schema: %Schema{type: :integer}
+                }
+              ],
+              responses: %{
+                200 => %Response{
+                  description: "Success",
+                  content: %{
+                    "application/json" => %MediaType{
+                      schema: %Schema{
+                        type: :array,
+                        items: OpenApiSpexTest.Schemas.User
+                      }
+                    }
+                  }
                 }
               }
-            },
-            callbacks: %{
-              "user_updated" => %{
-                "{$request.body#/callback_url}" => %PathItem{
-                  post: %Operation{
-                    description: "Provided endpoint for sending updates",
-                    requestBody: %RequestBody{
-                      required: true,
-                      content: %{
-                        "application/json" => %MediaType{
-                          schema: OpenApiSpexTest.Schemas.UserResponse
+            }
+          },
+          "/api/users/subscribe" => %PathItem{
+            post: %Operation{
+              description: "Subscribe to user updates",
+              operationId: "UserController.subscribe",
+              requestBody: %RequestBody{
+                required: true,
+                content: %{
+                  "application/json" => %MediaType{
+                    schema: OpenApiSpexTest.Schemas.UserSubscribeRequest
+                  }
+                }
+              },
+              callbacks: %{
+                "user_updated" => %{
+                  "{$request.body#/callback_url}" => %PathItem{
+                    post: %Operation{
+                      description: "Provided endpoint for sending updates",
+                      requestBody: %RequestBody{
+                        required: true,
+                        content: %{
+                          "application/json" => %MediaType{
+                            schema: OpenApiSpexTest.Schemas.UserResponse
+                          }
+                        }
+                      },
+                      responses: %{
+                        200 => %Response{
+                          description: "Your server returns this code if it accepts the callback"
                         }
                       }
-                    },
-                    responses: %{
-                      200 => %Response{
-                        description: "Your server returns this code if it accepts the callback"
+                    }
+                  }
+                }
+              },
+              responses: %{
+                201 => %Response{
+                  description: "Webhook created"
+                }
+              }
+            }
+          },
+          "/api/appointsments" => %PathItem{
+            post: %Operation{
+              description: "Create a new pet appointment",
+              operationId: "PetAppointmentController.create",
+              requestBody: %RequestBody{
+                required: true,
+                content: %{
+                  "application/json" => %MediaType{
+                    schema: OpenApiSpexTest.Schemas.PetAppointmentRequest
+                  }
+                }
+              },
+              responses: %{
+                201 => %Response{
+                  description: "Appointment created"
+                }
+              }
+            }
+          }
+        }
+      }
+
+      resolved = OpenApiSpex.resolve_schema_modules(spec)
+
+      assert %Reference{"$ref": "#/components/schemas/UsersResponse"} =
+               resolved.paths["/api/users"].get.responses[200].content["application/json"].schema
+
+      assert %Reference{"$ref": "#/components/schemas/UserResponse"} =
+               resolved.paths["/api/users"].post.responses[201].content["application/json"].schema
+
+      assert %Reference{"$ref": "#/components/schemas/UserRequest"} =
+               resolved.paths["/api/users"].post.requestBody.content["application/json"].schema
+
+      assert "#/components/schemas/TrainingAppointment" =
+               resolved.components.schemas["PetAppointmentRequest"].discriminator.mapping[
+                 "training"
+               ]
+
+      assert "#/components/schemas/GroomingAppointment" =
+               resolved.components.schemas["PetAppointmentRequest"].discriminator.mapping[
+                 "grooming"
+               ]
+
+      assert %{
+               "UserRequest" => %Schema{},
+               "UserResponse" => %Schema{},
+               "User" => %Schema{},
+               "UserSubscribeRequest" => %Schema{},
+               "PaymentDetails" => %Schema{},
+               "CreditCardPaymentDetails" => %Schema{},
+               "DirectDebitPaymentDetails" => %Schema{},
+               "PetAppointmentRequest" => %Schema{},
+               "TrainingAppointment" => %Schema{},
+               "GroomingAppointment" => %Schema{}
+             } = resolved.components.schemas
+
+      get_friends = resolved.paths["/api/users/{id}/friends"].get
+
+      assert %Reference{"$ref": "#/components/schemas/User"} =
+               get_friends.responses[200].content["application/json"].schema.items
+    end
+
+    test "raises informative error when schema :properties is not a map" do
+      spec = %OpenApi{
+        info: %Info{
+          title: "Test",
+          version: "1.0.0"
+        },
+        paths: %{
+          "/api/users" => %PathItem{
+            get: %Operation{
+              responses: %{
+                200 => %Response{
+                  description: "Success",
+                  content: %{
+                    "application/json" => %MediaType{
+                      schema: %Schema{
+                        type: :object,
+                        properties: Invalid
                       }
                     }
                   }
                 }
               }
-            },
-            responses: %{
-              201 => %Response{
-                description: "Webhook created"
-              }
-            }
-          }
-        },
-        "/api/appointsments" => %PathItem{
-          post: %Operation{
-            description: "Create a new pet appointment",
-            operationId: "PetAppointmentController.create",
-            requestBody: %RequestBody{
-              required: true,
-              content: %{
-                "application/json" => %MediaType{
-                  schema: OpenApiSpexTest.Schemas.PetAppointmentRequest
-                }
-              }
-            },
-            responses: %{
-              201 => %Response{
-                description: "Appointment created"
-              }
             }
           }
         }
       }
-    }
 
-    resolved = OpenApiSpex.resolve_schema_modules(spec)
+      assert_raise RuntimeError, "Expected :properties to be a map. Got: Invalid", fn ->
+        OpenApiSpex.resolve_schema_modules(spec)
+      end
+    end
 
-    assert %Reference{"$ref": "#/components/schemas/UsersResponse"} =
-             resolved.paths["/api/users"].get.responses[200].content["application/json"].schema
-
-    assert %Reference{"$ref": "#/components/schemas/UserResponse"} =
-             resolved.paths["/api/users"].post.responses[201].content["application/json"].schema
-
-    assert %Reference{"$ref": "#/components/schemas/UserRequest"} =
-             resolved.paths["/api/users"].post.requestBody.content["application/json"].schema
-
-    assert "#/components/schemas/TrainingAppointment" =
-             resolved.components.schemas["PetAppointmentRequest"].discriminator.mapping[
-               "training"
-             ]
-
-    assert "#/components/schemas/GroomingAppointment" =
-             resolved.components.schemas["PetAppointmentRequest"].discriminator.mapping[
-               "grooming"
-             ]
-
-    assert %{
-             "UserRequest" => %Schema{},
-             "UserResponse" => %Schema{},
-             "User" => %Schema{},
-             "UserSubscribeRequest" => %Schema{},
-             "PaymentDetails" => %Schema{},
-             "CreditCardPaymentDetails" => %Schema{},
-             "DirectDebitPaymentDetails" => %Schema{},
-             "PetAppointmentRequest" => %Schema{},
-             "TrainingAppointment" => %Schema{},
-             "GroomingAppointment" => %Schema{}
-           } = resolved.components.schemas
-
-    get_friends = resolved.paths["/api/users/{id}/friends"].get
-
-    assert %Reference{"$ref": "#/components/schemas/User"} =
-             get_friends.responses[200].content["application/json"].schema.items
-  end
-
-  test "raises informative error when schema :properties is not a map" do
-    spec = %OpenApi{
-      info: %Info{
-        title: "Test",
-        version: "1.0.0"
-      },
-      paths: %{
-        "/api/users" => %PathItem{
-          get: %Operation{
-            responses: %{
-              200 => %Response{
-                description: "Success",
-                content: %{
-                  "application/json" => %MediaType{
-                    schema: %Schema{
-                      type: :object,
-                      properties: Invalid
+    test "raises error when schema cannot be resolved" do
+      spec = %OpenApi{
+        info: %Info{
+          title: "Test",
+          version: "1.0.0"
+        },
+        paths: %{
+          "/api/users" => %PathItem{
+            get: %Operation{
+              responses: %{
+                200 => %Response{
+                  description: "Success",
+                  content: %{
+                    "application/json" => %MediaType{
+                      schema: %{}
                     }
                   }
                 }
@@ -222,28 +253,66 @@ defmodule OpenApiSpex.SchemaResolverTest do
           }
         }
       }
-    }
 
-    assert_raise RuntimeError, "Expected :properties to be a map. Got: Invalid", fn ->
-      OpenApiSpex.resolve_schema_modules(spec)
+      error_message = """
+      Cannot resolve schema %{}.
+
+      Must be one of:
+
+      - schema module, or schema struct
+      - list of schema modules, or schema structs
+      - boolean
+      - nil
+      - reference
+      """
+
+      assert_raise RuntimeError, error_message, fn ->
+        OpenApiSpex.resolve_schema_modules(spec)
+      end
     end
-  end
 
-  test "raises error when schema cannot be resolved" do
-    spec = %OpenApi{
-      info: %Info{
-        title: "Test",
-        version: "1.0.0"
-      },
-      paths: %{
-        "/api/users" => %PathItem{
-          get: %Operation{
-            responses: %{
-              200 => %Response{
-                description: "Success",
-                content: %{
-                  "application/json" => %MediaType{
-                    schema: %{}
+    defmodule Duplicates.UsersResponse do
+      require OpenApiSpex
+
+      OpenApiSpex.schema(%{
+        description: "A duplicate",
+        type: :object,
+        properties: %{
+          unexpected: %Schema{type: :string}
+        }
+      })
+    end
+
+    test "resolution ignores schemas with duplicate title" do
+      spec = %OpenApi{
+        info: %Info{
+          title: "Test",
+          version: "1.0.0"
+        },
+        paths: %{
+          "/api/users" => %PathItem{
+            get: %Operation{
+              responses: %{
+                200 => %Response{
+                  description: "Success",
+                  content: %{
+                    "application/json" => %MediaType{
+                      schema: OpenApiSpexTest.Schemas.UsersResponse
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "/api/clones" => %PathItem{
+            get: %Operation{
+              responses: %{
+                200 => %Response{
+                  description: "Success",
+                  content: %{
+                    "application/json" => %MediaType{
+                      schema: Duplicates.UsersResponse
+                    }
                   }
                 }
               }
@@ -251,22 +320,19 @@ defmodule OpenApiSpex.SchemaResolverTest do
           }
         }
       }
-    }
 
-    error_message = """
-    Cannot resolve schema %{}.
+      assert %{
+               components: %{
+                 schemas: %{
+                   "UsersResponse" => %OpenApiSpex.Schema{
+                     description: "A duplicate",
+                     "x-struct": OpenApiSpex.SchemaResolverTest.Duplicates.UsersResponse
+                   }
+                 }
+               }
+             } = resolved = OpenApiSpex.resolve_schema_modules(spec)
 
-    Must be one of:
-
-    - schema module, or schema struct
-    - list of schema modules, or schema structs
-    - boolean
-    - nil
-    - reference
-    """
-
-    assert_raise RuntimeError, error_message, fn ->
-      OpenApiSpex.resolve_schema_modules(spec)
+      assert Map.keys(resolved.components.schemas) == ["UsersResponse"]
     end
   end
 


### PR DESCRIPTION
This PR clarifies and tests the behaviour of SchemaResolved when it encounters schema modules with the same title.
See: https://github.com/open-api-spex/open_api_spex/issues/587, https://github.com/open-api-spex/open_api_spex/issues/566

It adds the following admonition block:

![Screenshot 2025-03-07 at 13 33 12](https://github.com/user-attachments/assets/62c09f32-0883-4f94-8c62-fe4eb5d6ba8b)


## Alternatives Considered / Future Work

When a schema module we're resolving already exists in `components.schemas` and its `x-struct` is different from the module being resolved we can log a warning. This can turn out to be very noisy this library currently logs very little.