### PR TITLE
Handle the case where Schema.type is an array

### DIFF
--- a/test/support/encoded_schema.json
+++ b/test/support/encoded_schema.json
@@ -538,7 +538,7 @@
                 "required": [
                   "data"
                 ],
-                "type": "object"
+                "type": ["object", "null"]
               }
             }
           }


### PR DESCRIPTION
Not fully finished since the logic for empty `properties` when type is `object` is wrong, but provided as an example of where I'm at.