### PR TITLE
Fix OTP-28 support

### DIFF
--- a/lib/open_api_spex/cast_parameters.ex
+++ b/lib/open_api_spex/cast_parameters.ex
@@ -4,7 +4,7 @@ defmodule OpenApiSpex.CastParameters do
   alias OpenApiSpex.Cast.Error
   alias Plug.Conn
 
-  @default_parsers %{~r/^application\/.*json.*$/ => OpenApi.json_encoder()}
+  
 
   @spec cast(Plug.Conn.t(), Operation.t(), OpenApi.t(), opts :: [OpenApiSpex.cast_opt()]) ::
           {:error, [Error.t()]} | {:ok, Conn.t()}
@@ -120,7 +120,7 @@ defmodule OpenApiSpex.CastParameters do
          opts
        ) do
     parsers = Map.get(ext || %{}, "x-parameter-content-parsers", %{})
-    parsers = Map.merge(@default_parsers, parsers)
+    parsers = Map.merge(default_parsers(), parsers)
 
     conn
     |> get_params_by_location(
@@ -133,6 +133,9 @@ defmodule OpenApiSpex.CastParameters do
       params -> Cast.cast(schema, params, components.schemas, opts)
     end
   end
+
+  defp default_parsers,
+    do: %{~r/^application\/.*json.*$/ => OpenApi.json_encoder()}
 
   defp pre_parse_parameters(%{} = parameters, %{} = parameters_context, parsers) do
     Enum.reduce_while(parameters, Map.new(), fn {key, value}, acc ->

--- a/test/cast/string_test.exs
+++ b/test/cast/string_test.exs
@@ -27,7 +27,7 @@ defmodule OpenApiSpex.CastStringTest do
       assert {:error, [error]} = cast(value: "hello", schema: schema)
       assert error.reason == :invalid_format
       assert error.value == "hello"
-      assert error.format == ~r/\d-\d/
+      assert error.format.source == "\\d-\\d"
     end
 
     test "string with format (date time)" do

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -186,7 +186,7 @@ defmodule OpenApiSpexTest.Schemas do
       type: :object,
       properties: %{
         id: %Schema{type: :integer, description: "User ID"},
-        name: %Schema{type: :string, description: "User name", pattern: ~r/[a-zA-Z][a-zA-Z0-9_]+/},
+        name: %Schema{type: :string, description: "User name", pattern: "[a-zA-Z][a-zA-Z0-9_]+"},
         email: %Schema{type: :string, description: "Email address", format: :email},
         password: %Schema{type: :string, description: "Login password", writeOnly: true},
         age: %Schema{type: :integer, description: "Age"},


### PR DESCRIPTION
This commit introduces changes to `OpenApiSpex.CastParameters` and `OpenApiSpexTest.Schemas` to support OTP-28

- Moved `@default_parsers` to a private function `default_parsers/0` in `OpenApiSpex.CastParameters` to ensure it's evaluated at runtime, preventing potential compilation issues with `OpenApi.json_encoder()`.
- Updated the `pattern` definition in `OpenApiSpexTest.Schemas` to use a string literal instead of a regex literal for consistency and to avoid potential issues with regex compilation.

Fix: Adjust string pattern test assertion

Following the refactoring, a test in `OpenApiSpex.CastStringTest` failed due to a change in how regex patterns were handled. This fix corrects the assertion for string pattern matching to compare the `source` of the regex instead of the regex struct directly, resolving the test failure.