### PR TITLE
Fix assert_operation_response/2 references

### DIFF
--- a/lib/open_api_spex/test/test_assertions.ex
+++ b/lib/open_api_spex/test/test_assertions.ex
@@ -166,8 +166,17 @@ defmodule OpenApiSpex.TestAssertions do
           Map.get(responses, code_range) ||
           Map.get(responses, :"#{code_range}", %{})
 
+      resolved_response =
+        case response do
+          %OpenApiSpex.Reference{} = ref ->
+            OpenApiSpex.Reference.resolve_response(ref, spec.components.responses)
+
+          _ ->
+            response
+        end
+
       resolved_schema =
-        response
+        resolved_response
         |> Map.get(:content, %{})
         |> Map.get(content_type, %{})
         |> Map.get(:schema)

--- a/test/support/api_spec.ex
+++ b/test/support/api_spec.ex
@@ -76,7 +76,7 @@ defmodule OpenApiSpexTest.ApiSpec do
           }
         },
         responses: %{
-          unprocessable_entity: %Response{
+          "unprocessable_entity" => %Response{
             description: "Unprocessable Entity",
             content: %{"application/json" => %MediaType{schema: %Schema{type: :object}}}
           }

--- a/test/support/pet_controller.ex
+++ b/test/support/pet_controller.ex
@@ -47,7 +47,9 @@ defmodule OpenApiSpexTest.PetController do
        ],
        responses: [
          ok: {"Pet list", "application/json", Schemas.PetsResponse},
-         unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
+         unprocessable_entity: %OpenApiSpex.Reference{
+           "$ref": "#/components/responses/unprocessable_entity"
+         }
        ],
        operation_id: "listPets"
   def index(conn, _params) do


### PR DESCRIPTION
Previously a reference response would lead to the following error.

```
     Failed to resolve a response schema for operation_id: some_operation_id for status code: 404 and content type: application/json
````

This was caused by `assert_operation_response/2` not resolving references.