### PR TITLE
Add test for casting AllOf with one schema having additionalProperties: false

### DIFF
--- a/test/cast/all_of_test.exs
+++ b/test/cast/all_of_test.exs
@@ -87,6 +87,37 @@ defmodule OpenApiSpex.CastAllOfTest do
       end)
     end
 
+    test "allOf, with additionalProperties: false" do
+      schema = %Schema{
+        allOf: [
+          %Schema{
+            type: :object,
+            properties: %{
+              id: %Schema{
+                type: :string
+              }
+            },
+            additionalProperties: false
+          },
+          %Schema{
+            type: :object,
+            properties: %{
+              bar: %Schema{
+                type: :string
+              }
+            }
+          }
+        ]
+      }
+
+      value = %{id: "e30aee0f-dbda-40bd-9198-6cf609b8b640", bar: "foo"}
+
+      assert {:error, [error | _]} = cast(value: value, schema: schema)
+
+      assert Error.message(error) ==
+               "Failed to cast value as object. Value must be castable using `allOf` schemas listed."
+    end
+
     test "allOf, optional that does not pass validation" do
       schema = %Schema{
         allOf: [


### PR DESCRIPTION
Hello 🌈 !

I had a bit of a hard time tracing back the cause of the cast validation error that I was having:

```
Failed to cast value as object. Value must be castable using `allOf` schemas listed.
```

since the resulting response had the correct shape and the right properties. I only hit the validation error when using the `assert_schema` function in my tests. 

The problem was that one of my schema had `additionalProperties: false` from back when we created the schema some years ago 👵 

I thought that adding a unit test covering this case can help developers finding out what's going on (it would have helped me at least, since I was looking at this test file to understand what was different between my code and the working examples). 

For additional context: the validation error did not pop up for version 3.12.0, and only started to come up on 3.14+.
