### PR TITLE
Add support for email format for field type string

### DIFF
--- a/lib/open_api_spex/cast/string.ex
+++ b/lib/open_api_spex/cast/string.ex
@@ -5,6 +5,8 @@ defmodule OpenApiSpex.Cast.String do
   validate a binary based on maxLength, minLength, or a Regex pattern passed through the
   schema struct.
 
+  Supported formats: `:date`, `:"date-time"`, `:byte`, `:uuid`, `:binary`, `:email`.
+
   """
 
   alias OpenApiSpex.{Cast, Cast.Error}
@@ -119,6 +121,15 @@ defmodule OpenApiSpex.Cast.String do
 
   def cast(%{value: value = %Plug.Upload{}, schema: %{format: :binary}}) do
     {:ok, value}
+  end
+
+  @email_regex ~r/^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  def cast(%{value: value, schema: %{format: :email}} = ctx) when is_binary(value) do
+    if Regex.match?(@email_regex, value) do
+      {:ok, value}
+    else
+      Cast.error(ctx, {:invalid_format, :email})
+    end
   end
 
   def cast(%{value: value} = ctx) when is_atom(value) and value not in [true, false, nil] do

--- a/test/cast/string_test.exs
+++ b/test/cast/string_test.exs
@@ -99,6 +99,46 @@ defmodule OpenApiSpex.CastStringTest do
       # There is no error case when a regular string is passed
     end
 
+    test "string with format (email) - valid emails" do
+      schema = %Schema{type: :string, format: :email}
+
+      for email <- [
+            "user@example.com",
+            "user+tag@example.com",
+            "user+tag@sub.example.co.uk",
+            "firstname.lastname@example.com",
+            "user123@domain.org",
+            "USER@EXAMPLE.COM",
+            "user@xn--nxasmq6b.com"
+          ] do
+        assert {:ok, ^email} = cast(value: email, schema: schema), "expected #{inspect(email)} to be valid"
+      end
+    end
+
+    test "string with format (email) - invalid emails" do
+      schema = %Schema{type: :string, format: :email}
+
+      for email <- [
+            "not-an-email",
+            "random string with spaces",
+            "",
+            "@nodomain",
+            "noatsign",
+            "missing@tld",
+            "space in@local.com",
+            "double@@at.com",
+            "@.com",
+            "user@",
+            "user@ example.com",
+            "user @example.com"
+          ] do
+        assert {:error, [error]} = cast(value: email, schema: schema),
+               "expected #{inspect(email)} to be invalid"
+
+        assert %Error{reason: :invalid_format, format: :email} = error
+      end
+    end
+
     # Note: we measure length of string after trimming leading and trailing whitespace
     test "minLength" do
       schema = %Schema{type: :string, minLength: 1}


### PR DESCRIPTION
The `:email` format is listed in the official OpenAPI spec as a common open format value, and was already used in the library's own documentation examples, but was silently ignored during validation — any string would pass regardless of content.

This adds a `cast/1` clause in `OpenApiSpex.Cast.String` that validates the value against a practical email regex when `format: :email` is set on a string schema. Invalid values now return a `{:invalid_format, :email}` cast error, consistent with how other formats such as `:uuid` and `:date` behave. The original string value is returned unchanged on success.

Tests cover a range of valid addresses (plus-addressing, subdomains, punycode domains, uppercase) and invalid ones (missing `@`, empty local part or domain, spaces, double `@`, missing TLD).

Fixes #694 