### PR TITLE
Make layout configurable in Swagger UI

### DIFF
--- a/lib/open_api_spex/plug/swagger_ui.ex
+++ b/lib/open_api_spex/plug/swagger_ui.ex
@@ -115,7 +115,7 @@ defmodule OpenApiSpex.Plug.SwaggerUI do
         plugins: [
           SwaggerUIBundle.plugins.DownloadUrl
         ],
-        layout: "StandaloneLayout",
+        layout: "<%= config[:layout] || "StandaloneLayout" %>",
         requestInterceptor: function(request){
           server_base = window.location.protocol + "//" + window.location.host;
           if(request.url.startsWith(server_base)) {


### PR DESCRIPTION
This allows users to configure the Swagger UI layout with:

```
get("/swaggerui", OpenApiSpex.Plug.SwaggerUI, path: "/api/openapi", layout: "BaseLayout")
```