### PR TITLE
Fix Protocol.UndefinedError when composite casts merge struct results

### DIFF
--- a/lib/open_api_spex/cast/utils.ex
+++ b/lib/open_api_spex/cast/utils.ex
@@ -5,14 +5,20 @@ defmodule OpenApiSpex.Cast.Utils do
 
   # Merge 2 maps considering as equal keys that are atom or string representation
   # of that atom. Atom keys takes precedence over string ones.
+  # Struct arguments are demoted to plain maps first: composite casts
+  # (`allOf`/`anyOf`) can receive struct results from `oneOf`/discriminator
+  # members, and reducing over a struct raises `Protocol.UndefinedError`.
   def merge_maps(map1, map2) do
-    result = Map.merge(map1, map2)
+    result = Map.merge(plain_map(map1), plain_map(map2))
 
     Enum.reduce(result, result, fn
       {k, _v}, result when is_atom(k) -> Map.delete(result, to_string(k))
       _, result -> result
     end)
   end
+
+  defp plain_map(%_{} = struct), do: Map.from_struct(struct)
+  defp plain_map(map), do: map
 
   def check_required_fields(%{value: input_map} = ctx), do: check_required_fields(ctx, input_map)
 

--- a/test/cast/all_of_test.exs
+++ b/test/cast/all_of_test.exs
@@ -34,6 +34,14 @@ defmodule OpenApiSpex.CastAllOfTest do
                "Failed to cast value as Age. Value must be castable using `allOf` schemas listed."
     end
 
+    test "allOf wrapper around a oneOf member whose branch casts to a struct" do
+      union = %Schema{oneOf: [OpenApiSpexTest.Schemas.User.schema()]}
+      schema = %Schema{allOf: [union]}
+      value = %{"name" => "Joe", "email" => "joe@example.com", "password" => "12345678"}
+
+      assert {:ok, %{name: "Joe"}} = cast(value: value, schema: schema)
+    end
+
     test "a more sophisticated example" do
       dog = %{"bark" => "woof", "pet_type" => "Dog"}
       TestAssertions.assert_schema(dog, "Dog", OpenApiSpexTest.ApiSpec.spec())


### PR DESCRIPTION
Fixes #705.

`Cast.Utils.merge_maps/2` now demotes struct arguments to plain maps before merging. `Cast.OneOf` (and the discriminator path) rebuild a matched branch as its schema struct; when that result reaches an `allOf` merge, `Enum.reduce/3` over the struct raised `Protocol.UndefinedError` and killed the whole cast. Demoting at the merge keeps struct building intact everywhere else (v3.18.2 deliberately strengthened it), and also keeps the `anyOf` accumulator safe should its struct short-circuit ever change.

Regression test: an `allOf` wrapper around a `oneOf` member whose branch casts to a struct — the exact wrapper idiom used to attach a description or default to a referenced union. Before the fix it raises `Protocol.UndefinedError`; with it, the cast returns the merged map.

Full test suite: 9 doctests, 390 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)