### PR TITLE
Enforce required on object schemas without properties

### DIFF
--- a/lib/open_api_spex/cast/object.ex
+++ b/lib/open_api_spex/cast/object.ex
@@ -1,15 +1,17 @@
 defmodule OpenApiSpex.Cast.Object do
   @moduledoc false
   alias OpenApiSpex.Cast
-  alias OpenApiSpex.Cast.Utils
+  alias OpenApiSpex.Cast.{Error, Utils}
   alias OpenApiSpex.Reference
 
   def cast(%{value: value} = ctx) when not is_map(value) do
     Cast.error(ctx, {:invalid_type, :object})
   end
 
-  def cast(%{value: value, schema: %{properties: nil, additionalProperties: nil}}) do
-    {:ok, value}
+  def cast(%{value: value, schema: %{properties: nil, additionalProperties: nil}} = ctx) do
+    with :ok <- check_required_by_name(ctx, value) do
+      {:ok, value}
+    end
   end
 
   def cast(ctx) do
@@ -50,6 +52,31 @@ defmodule OpenApiSpex.Cast.Object do
   defp resolve_property_if_reference(_not_a_reference, properties, _schemas), do: properties
 
   # When additionalProperties is not false, extra properties are allowed in input
+  # `required` on a schema without `properties` cannot rely on key
+  # atomization, so a required name counts as present when the input carries
+  # the atom key or its string form.
+  defp check_required_by_name(ctx, input_map) do
+    required = Map.get(ctx.schema, :required) || []
+
+    missing =
+      Enum.reject(required, fn key ->
+        Map.has_key?(input_map, key) or Map.has_key?(input_map, to_string(key))
+      end)
+
+    case missing do
+      [] ->
+        :ok
+
+      _ ->
+        errors =
+          Enum.map(missing, fn key ->
+            Error.new(%{ctx | path: [key | ctx.path]}, {:missing_field, key})
+          end)
+
+        {:error, ctx.errors ++ errors}
+    end
+  end
+
   defp check_unrecognized_properties(%{schema: %{additionalProperties: ap}}) when ap != false do
     :ok
   end

--- a/test/cast/object_test.exs
+++ b/test/cast/object_test.exs
@@ -7,6 +7,17 @@ defmodule OpenApiSpex.ObjectTest do
   defp cast(ctx), do: Object.cast(struct(Cast, ctx))
 
   describe "cast/3" do
+    test "required is enforced on a schema without properties" do
+      schema = %Schema{type: :object, required: [:one]}
+
+      assert {:error, [error]} = cast(value: %{}, schema: schema)
+      assert error.reason == :missing_field
+      assert error.name == :one
+
+      assert {:ok, %{"one" => 1}} = cast(value: %{"one" => 1}, schema: schema)
+      assert {:ok, %{one: 1}} = cast(value: %{one: 1}, schema: schema)
+    end
+
     test "when input is not an object" do
       schema = %Schema{type: :object}
       assert {:error, [error]} = cast(value: ["hello"], schema: schema)


### PR DESCRIPTION
Fixes #706.

`Cast.Object`'s short-circuit for schemas with neither `properties` nor `additionalProperties` returned the value without ever running `required`. The clause now checks `required` first. Because no property declarations exist to atomize keys, a required name counts as present when the input carries the atom key or its string form.

This closes the silent either/or failure: `anyOf` arms written as bare `%Schema{type: :object, required: [...]}` accepted every body, and the same arms under `oneOf` rejected every body via the more-than-one-schema-validates rule.

Regression tests: a property-less `required` schema rejects a missing key and accepts both string- and atom-keyed input.

Full test suite: 9 doctests, 390 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)